### PR TITLE
Support circle forks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,8 @@ machine:
   ruby:
     version:
       2.1.3
+  environment:
+    DANGER_GITHUB_API_TOKEN: d64147730d40cb6501ed65aae5190a97e46f73f5
 
 dependencies:
   pre:


### PR DESCRIPTION
- fixes CI for circle in #52 

Not optimal, but this is the equivalent of giving someone free reign to an empty account ( it has no special access to danger's repos )