### PR TITLE
[WIP] - add gitlab support + SPLIT out APISources

### DIFF
--- a/GITLAB.md
+++ b/GITLAB.md
@@ -1,0 +1,7 @@
+ * clone as a mirror:
+ * git clone --mirror git@gitlab.krone.at:hjanuschka/dangertest.git .git
+ * adapt KEYS
+
+
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in danger.gemspec
+gem 'gitlab', :git => "https://github.com/hjanuschka/gitlab.git", :branch => "hj"
 gemspec

--- a/lib/danger/api_source/api_source.rb
+++ b/lib/danger/api_source/api_source.rb
@@ -2,7 +2,7 @@ module Danger
   module APISource
     # "abstract" API class
     class API
-      attr_accessor :ci_source, :environment
+      attr_accessor :ci_source, :pr_json, :issue_json, :environment, :base_commit, :head_commit
       def initialize(ci_source, environment = nil)
           self.ci_source = ci_source
           self.environment = environment

--- a/lib/danger/api_source/api_source.rb
+++ b/lib/danger/api_source/api_source.rb
@@ -1,0 +1,56 @@
+module Danger
+  module APISource
+    # "abstract" API class
+    class API
+      attr_accessor :ci_source, :environment
+      def initialize(ci_source, environment = nil)
+          self.ci_source = ci_source
+          self.environment = environment
+      end
+       
+      def self.validates?(_env)
+        false
+      end
+    def client
+      puts "INITIALIZE client"
+    end
+
+    def fetch_details
+      puts "fetch details"
+    end
+
+    def fetch_issue_details(pr_json)
+      puts "fetch issue details"
+    end
+
+    def base_commit
+      puts "base commit"
+    end
+
+    def head_commit
+      puts "head_commit"
+    end
+
+    def pr_title
+      puts "pr_title"
+    end
+
+    def pr_body
+      puts "pr_body"
+    end
+
+    def pr_author
+      puts "pr_author"
+    end
+
+    def pr_labels
+      puts "pr_labels"
+    end
+
+    # Sending data to GitHub
+    def update_pull_request!(warnings: nil, errors: nil, messages: nil)
+      puts "update pull request"
+    end
+end
+  end
+end

--- a/lib/danger/api_source/gitlab.rb
+++ b/lib/danger/api_source/gitlab.rb
@@ -1,0 +1,18 @@
+# https://circleci.com/docs/environment-variables
+require 'uri'
+
+module Danger
+  module APISource
+    class GitlabCI < API
+      def self.validates?(env)
+        return !env["GITLAB_CI"].nil? && !env["GITLAB_CI_PULL"].nil?
+      end
+
+      def self.initialize(cisource, env = nil) 
+          # The first one is an extra slash, ignore it
+          #self.repo_slug = "FXF/FXF-IOS"
+          #self.pull_request_id = env["GITLAB_CI_PULL"];
+      end
+    end
+  end
+end

--- a/lib/danger/api_source/gitlab.rb
+++ b/lib/danger/api_source/gitlab.rb
@@ -33,12 +33,30 @@ module Danger
         self.pr_json.title
       end
 
+      def generate_comment(warnings: [], errors: [], messages: [])
+      require 'erb'
+
+      md_template = File.join(Danger.gem_path, "lib/danger/comment_generators/github.md.erb")
+
+      # erb: http://www.rrn.dk/rubys-erb-templating-system
+      # for the extra args: http://stackoverflow.com/questions/4632879/erb-template-removing-the-trailing-line
+      @tables = [
+        { name: "Error", emoji: "no_entry_sign", content: errors },
+        { name: "Warning", emoji: "warning", content: warnings },
+        { name: "Message", emoji: "book", content: messages }
+      ]
+      return ERB.new(File.read(md_template), 0, "-").result(binding)
+    end
       def update_pull_request!(warnings: nil, errors: nil, messages: nil)
         puts "update pull request"
         puts "##################"
         puts warnings.inspect
         puts errors.inspect
         puts messages.inspect
+
+        body = generate_comment(warnings: warnings, errors: errors, messages: messages)
+        client.create_merge_request_comment(107,226, body);
+
       end
       def self.initialize(cisource, env = nil) 
           # The first one is an extra slash, ignore it

--- a/lib/danger/api_source/gitlab.rb
+++ b/lib/danger/api_source/gitlab.rb
@@ -1,5 +1,6 @@
 # https://circleci.com/docs/environment-variables
 require 'uri'
+require 'gitlab'
 
 module Danger
   module APISource
@@ -7,7 +8,38 @@ module Danger
       def self.validates?(env)
         return !env["GITLAB_CI"].nil? && !env["GITLAB_CI_PULL"].nil?
       end
+      def fetch_details
+        # FIXME project ID + PR ID (use repo_slug and pr_id)
+        self.pr_json = client.merge_request(107, 226)
+        #fetch_issue_details(self.pr_json)
+      end
+      def client 
+        # FIXME dynamic tokens via ENV
+        @client ||= Gitlab.client(endpoint: 'http://gitlab.krone.at/api/v3', private_token: 'Wypos9xJ3LdHXpzQQskq')
+      end
+      def base_commit
+        self.pr_json.target_branch
+      end
+      def head_commit
+        self.pr_json.source_branch
+      end
+      def pr_author
+        self.pr_json.author.username
+      end
+      def pr_body
+        self.pr_json.description
+      end
+      def pr_title
+        self.pr_json.title
+      end
 
+      def update_pull_request!(warnings: nil, errors: nil, messages: nil)
+        puts "update pull request"
+        puts "##################"
+        puts warnings.inspect
+        puts errors.inspect
+        puts messages.inspect
+      end
       def self.initialize(cisource, env = nil) 
           # The first one is an extra slash, ignore it
           #self.repo_slug = "FXF/FXF-IOS"

--- a/lib/danger/api_source/gitlab.rb
+++ b/lib/danger/api_source/gitlab.rb
@@ -4,18 +4,20 @@ require 'gitlab'
 
 module Danger
   module APISource
-    class GitlabCI < API
+    class GitlabAPI < API
       def self.validates?(env)
-        return !env["GITLAB_CI"].nil? && !env["GITLAB_CI_PULL"].nil?
+        return !env["GITLAB_PROJECT_ID"].nil? && !env["GITLAB_MR_ID"].nil?
       end
       def fetch_details
-        # FIXME project ID + PR ID (use repo_slug and pr_id)
-        self.pr_json = client.merge_request(107, 226)
-        #fetch_issue_details(self.pr_json)
+        puts client.inspect
+       self.pr_json = client.merge_request(self.ci_source.repo_slug, self.ci_source.pull_request_id)
+       #self.pr_json = client.merge_request(107, 226)
       end
       def client 
-        # FIXME dynamic tokens via ENV
-        @client ||= Gitlab.client(endpoint: 'http://gitlab.krone.at/api/v3', private_token: 'Wypos9xJ3LdHXpzQQskq')
+        token = @environment["DANGER_GITLAB_PRIVATE_TOKEN"]
+        endpoint = @environment["DANGER_GITLAB_ENDPOINT"]
+        raise "No API given, please provide one using `DANGER_GITLAB_PRIVATE_TOKEN` and `DANGER_GITLAB_ENDPOINT`" unless (token && endpoint)
+        @client ||= Gitlab.client(endpoint: endpoint, private_token: token)
       end
       def base_commit
         self.pr_json.target_branch
@@ -67,6 +69,7 @@ module Danger
           # The first one is an extra slash, ignore it
           #self.repo_slug = "FXF/FXF-IOS"
           #self.pull_request_id = env["GITLAB_CI_PULL"];
+         
       end
     end
   end

--- a/lib/danger/api_source/gitlab.rb
+++ b/lib/danger/api_source/gitlab.rb
@@ -54,8 +54,13 @@ module Danger
         puts errors.inspect
         puts messages.inspect
 
-        body = generate_comment(warnings: warnings, errors: errors, messages: messages)
-        client.create_merge_request_comment(107,226, body);
+        if (warnings + errors + messages).empty?
+          #FIXME delete old comment
+        else
+          #FIXME update comment
+          body = generate_comment(warnings: warnings, errors: errors, messages: messages)
+          client.create_merge_request_comment(107,226, body);
+        end
 
       end
       def self.initialize(cisource, env = nil) 

--- a/lib/danger/ci_source/gitlab.rb
+++ b/lib/danger/ci_source/gitlab.rb
@@ -5,13 +5,13 @@ module Danger
   module CISource
     class GitlabCI < CI
       def self.validates?(env)
-        return !env["GITLAB_CI"].nil? && !env["GITLAB_CI_PULL"].nil?
+        return !env["GITLAB_PROJECT_ID"].nil? && !env["GITLAB_MR_ID"].nil?
       end
 
       def initialize(env)
           # The first one is an extra slash, ignore it
-          self.repo_slug = "FXF/FXF-IOS"
-          self.pull_request_id = env["GITLAB_CI_PULL"];
+          self.repo_slug = env["GITLAB_PROJECT_ID"];
+          self.pull_request_id = env["GITLAB_MR_ID"];
       end
     end
   end

--- a/lib/danger/ci_source/gitlab.rb
+++ b/lib/danger/ci_source/gitlab.rb
@@ -1,0 +1,18 @@
+# https://circleci.com/docs/environment-variables
+require 'uri'
+
+module Danger
+  module CISource
+    class GitlabCI < CI
+      def self.validates?(env)
+        return !env["GITLAB_CI"].nil? && !env["GITLAB_CI_PULL"].nil?
+      end
+
+      def initialize(env)
+          # The first one is an extra slash, ignore it
+          self.repo_slug = "FXF/FXF-IOS"
+          self.pull_request_id = env["GITLAB_CI_PULL"];
+      end
+    end
+  end
+end


### PR DESCRIPTION
hello

i like the idea of danger - and i want to have it - but since we are using gitlab.
this is an unfinished WIP PR - that try's to split out the API source logic
and implement a `gitlab.rb` doing the stuff using 'gitlab' gem.



let me know what you think about it, right now its broken, since i am still fighting with the gitlab api.



at the end there needs to be a little webapp, that receives the `merge_request` hook from gitlab.
wich then does the danger thing, as of now the CI in gitlab is not able to detect if it is inside a merge-request.




lg
