### PR TITLE
Adding Jenkins provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Master
 
+
 ## 0.3.0
 
+* Adding Jenkins provider - marcelofabri
 * Add a `danger local` command to test your current Dangerfile against the last PR merged on the repo - orta
 * Calling CircleCI API when `CI_PULL_REQUEST` is not set - marcelofabri
 * Look inside PR JSON for the commit range (instead of getting from CI providers) - marcelofabri

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -1,0 +1,25 @@
+# https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables
+# https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin
+
+module Danger
+  module CISource
+    class Jenkins < CI
+      def self.validates?(env)
+        return !env["ghprbPullId"].nil? && !env["GIT_URL"].nil?
+      end
+
+      def initialize(env)
+        repo = env["GIT_URL"]
+        unless repo.nil?
+          repo_matches = repo.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
+          self.repo_slug = repo_matches[2] unless repo_matches.nil?
+        end
+
+        # from https://docs.travis-ci.com/user/pull-requests, as otherwise it's "false"
+        if env["ghprbPullId"].to_i > 0
+          self.pull_request_id = env["ghprbPullId"]
+        end
+      end
+    end
+  end
+end

--- a/spec/sources/buildkite_spec.rb
+++ b/spec/sources/buildkite_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'danger/ci_source/circle'
+require 'danger/ci_source/buildkite'
 
 describe Danger::CISource::Buildkite do
   it "validates when buildkite env var is found" do

--- a/spec/sources/jenkins_spec.rb
+++ b/spec/sources/jenkins_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'danger/ci_source/circle'
+
+describe Danger::CISource::Jenkins do
+  it "validates when jenkins env var is found" do
+    env = {
+      "GIT_URL" => "https://github.com/danger/danger.git",
+      "ghprbPullId" => "1234"
+    }
+    expect(Danger::CISource::Jenkins.validates?(env)).to be true
+  end
+
+  it "doesnt validate when jenkins is not found" do
+    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true" }
+    expect(Danger::CISource::Jenkins.validates?(env)).to be false
+  end
+
+  it "gets out a repo slug from a git+ssh repo and pull request number" do
+    env = {
+      "GIT_URL" => "git@github.com:danger/danger.git",
+      "ghprbPullId" => "12"
+    }
+    t = Danger::CISource::Jenkins.new(env)
+    expect(t.repo_slug).to eql("danger/danger")
+    expect(t.pull_request_id).to eql("12")
+  end
+
+  it "gets out a repo slug from a https repo and pull request number" do
+    env = {
+      "GIT_URL" => "https://github.com/danger/danger.git",
+      "ghprbPullId" => "14"
+    }
+    t = Danger::CISource::Jenkins.new(env)
+    expect(t.repo_slug).to eql("danger/danger")
+    expect(t.pull_request_id).to eql("14")
+  end
+end


### PR DESCRIPTION
This will only work if using [this plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin) to build PR on Jenkins, but that seems to be the most used one.