### PR TITLE
Removing nap dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Set CHANGELOG merge strategy to union - marcelofabri
+* Remove `nap` dependency - marcelofabri
 * Show command summary in help - marcelofabri
 * Use 100% width tables for messages - marcelofabri
 

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'claide'
   spec.add_runtime_dependency 'git', "~> 1.2.9"
   spec.add_runtime_dependency 'colored'
-  spec.add_runtime_dependency 'nap'
+  spec.add_runtime_dependency 'faraday'
   spec.add_runtime_dependency 'octokit'
   spec.add_runtime_dependency 'redcarpet'
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -1,7 +1,4 @@
 # coding: utf-8
-require 'rest'
-require 'json'
-require 'base64'
 require 'octokit'
 
 module Danger

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -1,5 +1,4 @@
 # coding: utf-8
-require 'rest'
 require 'spec_helper'
 require 'danger/request_sources/github'
 require 'danger/ci_source/circle'


### PR DESCRIPTION
Fixes #63.

It seems that `nap` wasn't really used (just imported) or I missed something here :grin: 

I also imported `faraday` in the Gemfile, as we're now using it directly.