### PR TITLE
Use 100% width tables for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
 
+* Use 100% width tables for messages - marcelofabri
 
 ## 0.3.0
 

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'colored'
   spec.add_runtime_dependency 'nap'
   spec.add_runtime_dependency 'octokit'
+  spec.add_runtime_dependency 'redcarpet'
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -1,11 +1,21 @@
 <% @tables.each do |table| %>
   <% if table[:content].any? %>
-    &nbsp; | <%= table[:content].count %> <%= table[:name] %><%= "s" unless table[:content].count == 1 %>
-    ------------- | ------------
-    <% table[:content].each do |message| -%>
-    :<%= table[:emoji] %>: | <%= message %>
-    <% end %>
-
+    <table>
+      <thead>
+        <tr>
+          <th width="50"></th>
+          <th width="100%"><%= table[:content].count %> <%= table[:name] %><%= "s" unless table[:content].count == 1 %></th>
+         </tr>
+      </thead>
+      <tbody>
+        <% table[:content].each do |message| -%>
+        <tr>
+          <td>:<%= table[:emoji] %>:</td>
+          <td><%= message %></td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
   <% end %>
 <% end %>
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -132,15 +132,17 @@ module Danger
 
     def generate_comment(warnings: [], errors: [], messages: [])
       require 'erb'
+      require 'redcarpet'
 
       md_template = File.join(Danger.gem_path, "lib/danger/comment_generators/github.md.erb")
+      markdown_parser = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
 
       # erb: http://www.rrn.dk/rubys-erb-templating-system
       # for the extra args: http://stackoverflow.com/questions/4632879/erb-template-removing-the-trailing-line
       @tables = [
-        { name: "Error", emoji: "no_entry_sign", content: errors },
-        { name: "Warning", emoji: "warning", content: warnings },
-        { name: "Message", emoji: "book", content: messages }
+        { name: "Error", emoji: "no_entry_sign", content: errors.map { |s| markdown_parser.render(s) } },
+        { name: "Warning", emoji: "warning", content: warnings.map { |s| markdown_parser.render(s) } },
+        { name: "Message", emoji: "book", content: messages.map { |s| markdown_parser.render(s) } }
       ]
       return ERB.new(File.read(md_template), 0, "-").result(binding)
     end

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -79,16 +79,30 @@ describe Danger::GitHub do
 
       it "some warnings, no errors" do
         result = @g.generate_comment(warnings: ["my warning", "second warning"], errors: [], messages: [])
+        # rubocop:disable Metrics/LineLength
         expect(result.gsub(/\s+/, "")).to eq(
-          "&nbsp;|2Warnings-------------|------------:warning:|mywarning:warning:|secondwarning<palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/KrauseFx/danger/\">danger</a></p>"
+          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><td><p>mywarning</p></td></tr><tr><td>:warning:</td><td><p>secondwarning</p></td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/KrauseFx/danger/\">danger</a></p>"
         )
+        # rubocop:enable Metrics/LineLength
+      end
+
+      it "some warnings with markdown, no errors" do
+        warnings = ["a markdown [link to danger](https://github.com/danger/danger)", "second **warning**"]
+        result = @g.generate_comment(warnings: warnings, errors: [], messages: [])
+        # rubocop:disable Metrics/LineLength
+        expect(result.gsub(/\s+/, "")).to eq(
+          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><td><p>amarkdown<ahref=\"https://github.com/danger/danger\">linktodanger</a></p></td></tr><tr><td>:warning:</td><td><p>second<strong>warning</strong></p></td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/KrauseFx/danger/\">danger</a></p>"
+        )
+        # rubocop:enable Metrics/LineLength
       end
 
       it "some warnings, some errors" do
         result = @g.generate_comment(warnings: ["my warning"], errors: ["some error"], messages: [])
+        # rubocop:disable Metrics/LineLength
         expect(result.gsub(/\s+/, "")).to eq(
-          "&nbsp;|1Error-------------|------------:no_entry_sign:|someerror&nbsp;|1Warning-------------|------------:warning:|mywarning<palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/KrauseFx/danger/\">danger</a></p>"
+          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><td><p>someerror</p></td></tr></tbody></table><table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><td><p>mywarning</p></td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/KrauseFx/danger/\">danger</a></p>"
         )
+        # rubocop:enable Metrics/LineLength
       end
 
       it "needs to include generated_by_danger" do


### PR DESCRIPTION
Fixes #37, keeping the ability to use markdown in message (the markdown is parsed to HTML with redcarpet)