### PR TITLE
Fix commands help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
 
+* Show command summary in help - marcelofabri
 * Use 100% width tables for messages - marcelofabri
 
 ## 0.3.0

--- a/lib/danger/commands/init.rb
+++ b/lib/danger/commands/init.rb
@@ -1,6 +1,6 @@
 module Danger
   class Init < Runner
-    self.description = 'Creates a Dangerfile.'
+    self.summary = 'Creates a Dangerfile.'
     self.command = 'init'
 
     def initialize(argv)

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -1,6 +1,6 @@
 module Danger
   class Local < Runner
-    self.description = 'Run the Dangerfile locally.'
+    self.summary = 'Run the Dangerfile locally.'
     self.command = 'local'
 
     def initialize(argv)

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -3,7 +3,7 @@ module Danger
     require 'danger/commands/init'
     require 'danger/commands/local'
 
-    self.description = 'Run the Dangerfile.'
+    self.summary = 'Run the Dangerfile.'
     self.command = 'danger'
 
     def initialize(argv)


### PR DESCRIPTION
```
✗ danger --help     
Usage:

    $ danger COMMAND

      Run the Dangerfile.

Commands:

    + init                       Creates a Dangerfile.
    + local                      Run the Dangerfile locally.

Options:

    --base=[master|dev|stable]   A branch/tag/commit to use as the base of the diff
    --head=[master|dev|stable]   A branch/tag/commit to use as the head
    --version                    Show the version of the tool
    --verbose                    Show more debugging information
    --no-ansi                    Show output without ANSI codes
    --help                       Show help banner of specified command
```