### PR TITLE
Ensure the messages have no preceding tabs #trivial

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,7 @@
+# Sometimes its a README fix, or something like that - which isn't relevant for
+# including in a CHANGELOG for example
+declared_trivial = pr_title.include? "#trivial"
+
 if ["KrauseFx", "orta"].include?(pr_author) == false
   warn("Author @#{pr_author} is not a contributor")
 end
@@ -16,6 +20,6 @@ if pr_body.length < 5
   fail "Please provide a summary in the Pull Request description"
 end
 
-unless files_modified.any? { |a| a.include?("CHANGELOG.md") }
+if !files_modified.include?("CHANGELOG.md") && !declared_trivial
   fail "Please include a CHANGELOG entry"
 end

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -1,21 +1,21 @@
 <% @tables.each do |table| %>
   <% if table[:content].any? %>
-    <table>
-      <thead>
-        <tr>
-          <th width="50"></th>
-          <th width="100%"><%= table[:content].count %> <%= table[:name] %><%= "s" unless table[:content].count == 1 %></th>
-         </tr>
-      </thead>
-      <tbody>
-        <% table[:content].each do |message| -%>
-        <tr>
-          <td>:<%= table[:emoji] %>:</td>
-          <td><%= message %></td>
-        </tr>
-        <% end %>
-      </tbody>
-    </table>
+<table>
+  <thead>
+    <tr>
+      <th width="50"></th>
+      <th width="100%"><%= table[:content].count %> <%= table[:name] %><%= "s" unless table[:content].count == 1 %></th>
+     </tr>
+  </thead>
+  <tbody>
+    <% table[:content].each do |message| -%>
+    <tr>
+      <td>:<%= table[:emoji] %>:</td>
+      <td><%= message %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
   <% end %>
 <% end %>
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'danger'
 require 'webmock'
-
+require 'json'
 WebMock.disable_net_connect!(allow: 'coveralls.io')


### PR DESCRIPTION
fixes #69

I needed to `require 'JSON'` in my local specs to get them to run. I wonder if circle/travis are on a different ruby to me.