### PR TITLE
Lock dependencies #trivial

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.0.0"
 
   spec.add_runtime_dependency 'claide'
-  spec.add_runtime_dependency 'grit'
-  spec.add_runtime_dependency 'colored'
+  spec.add_runtime_dependency 'grit', '2.5.0'
+  spec.add_runtime_dependency 'colored', '~> 1.2'
   spec.add_runtime_dependency 'faraday'
-  spec.add_runtime_dependency 'octokit'
-  spec.add_runtime_dependency 'redcarpet'
-  spec.add_runtime_dependency 'terminal-table'
+  spec.add_runtime_dependency 'octokit', '~> 4.2'
+  spec.add_runtime_dependency 'redcarpet', '~> 3.3'
+  spec.add_runtime_dependency 'terminal-table', '~> 1'
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/danger/version.rb
+++ b/lib/danger/version.rb
@@ -1,4 +1,4 @@
 module Danger
-  VERSION = "0.3.0"
+  VERSION = "0.5.0"
   DESCRIPTION = "Automate your PR etiquette."
 end


### PR DESCRIPTION
By using an older ( like by 2 weeks or something :P ) version of Fastlane, my Gemfile resolved our grit version to be a version many versions ago, and so https://github.com/artsy/eigen/pull/1188 failed. I've locked grit to the latest build and made everything else pretty flex