### PR TITLE
fixes danger local to work with Grit (or really, just unix directly)

### DIFF
--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -13,9 +13,11 @@ module Danger
       end
 
       def initialize(*)
-        git = Grit::Repository.new "."
-        if git.remote("origin")
-          url = git.remote("origin").url
+        git = Grit::Git.new(".")
+        # get the remote URL
+        remote = git.sh "/usr/local/bin/git remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-"
+        if remote
+          url = remote[0].strip
           # deal with https://
           if url.start_with? "https://github.com/"
             self.repo_slug = url.gsub("https://github.com/", "").gsub(".git", '')
@@ -23,19 +25,30 @@ module Danger
           # deal with SSH origin
           elsif url.start_with? "git@github.com:"
             self.repo_slug = url.gsub("git@github.com:", "").gsub(".git", '')
+          else
+            puts "Danger local requires a repository hosted on github."
           end
         end
 
-        logs = git.log.since('2 weeks ago')
-        # Look for something like
-        # "Merge pull request #38 from KrauseFx/funky_circles\n\nAdd support for GitHub compare URLs that don't conform
-        pr_merge = logs.detect { |log| (/Merge pull request #[0-9]* from/ =~ log.message) == 0 }
+        # get the most recent PR merge
+        logs = git.sh "/usr/local/bin/git log --since='2 weeks ago' --merges --oneline | grep \"Merge pull request\" | head -n 1"
+        pr_merge = logs[0].strip
         if pr_merge
-          # then pull out the 38, to_i
-          self.pull_request_id = pr_merge.message.gsub("Merge pull request #", "").to_i
-          self.base_commit = pr_merge.parents[0].sha
-          self.head_commit = pr_merge.parents[1].sha
+          self.pull_request_id = pr_merge.match("#[0-9]*")[0].gsub("#","")
+          sha = pr_merge.split(" ")[0]
+          parents = git.sh "/usr/local/bin/git rev-list --parents -n 1 #{sha}"
+          self.base_commit = parents[0].strip.split(" ")[0]
+          self.head_commit = parents[0].strip.split(" ")[1]
         end
+        # # Look for something like
+        # # "Merge pull request #38 from KrauseFx/funky_circles\n\nAdd support for GitHub compare URLs that don't conform
+        # pr_merge = logs.detect { |log| (/Merge pull request #[0-9]* from/ =~ log.message) == 0 }
+        # if pr_merge
+        #   # then pull out the 38, to_i
+        #   self.pull_request_id = pr_merge.message.gsub("Merge pull request #", "").to_i
+        #   self.base_commit = pr_merge.parents[0].sha
+        #   self.head_commit = pr_merge.parents[1].sha
+        # end
       end
     end
   end

--- a/spec/sources/local_git_repo_spec.rb
+++ b/spec/sources/local_git_repo_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'danger/ci_source/local_git_repo'
+
+def run_in_repo
+  Dir.mktmpdir do |dir|
+    Dir.chdir dir do
+      `git init`
+      `touch file1`
+      `git add .`
+      `git commit -m "adding file1"`
+      `git checkout -b new-branch`
+      `touch file2`
+      `git add .`
+      `git commit -m "adding file2"`
+      `git checkout master`
+      `git merge new-branch --no-ff -m "Merge pull request #1234 from new-branch"`
+      
+      yield
+    end
+  end
+end
+
+describe Danger::CISource::LocalGitRepo do
+  it 'validates when run by danger local' do
+    env = { "DANGER_USE_LOCAL_GIT" => "true" }
+    expect(Danger::CISource::LocalGitRepo.validates?(env)).to be true
+  end
+
+  it 'doesnt validate when the local git flag is missing' do
+    env = { "HAS_ANDREW_W_K_SEAL_OF_APPROVAL" => "true" }
+    expect(Danger::CISource::LocalGitRepo.validates?(env)).to be false
+  end
+  
+  it 'gets the pull request ID' do
+    run_in_repo do
+      env = { "DANGER_USE_LOCAL_GIT" => "true" }
+      t = Danger::CISource::LocalGitRepo.new(env)
+      expect(t.pull_request_id).to eql("1234")
+    end
+  end
+
+  describe 'github repos' do
+    it 'gets the repo address when it uses https' do
+      run_in_repo do
+        `git remote add origin https://github.com/orta/danger.git`
+        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        t = Danger::CISource::LocalGitRepo.new(env)
+        expect(t.repo_slug).to eql("orta/danger")
+      end
+    end
+
+    it 'gets the repo address when it uses git@' do
+      run_in_repo do
+        `git remote add origin git@github.com:orta/danger.git`
+        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        t = Danger::CISource::LocalGitRepo.new(env)
+        expect(t.repo_slug).to eql("orta/danger")
+      end
+    end    
+  end
+  
+  describe 'non-github repos' do
+
+    it 'does not set a repo_slug' do
+      run_in_repo do
+        `git remote add origin git@git.evilcorp.com:tyrell/danger.git`
+        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        t = Danger::CISource::LocalGitRepo.new(env)
+        expect(t.repo_slug).to be_nil
+      end
+    end
+    
+  end
+
+  # it 'gets out a repo slug and pull request number' do
+  #   env = {
+  #     "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
+  #     "TRAVIS_PULL_REQUEST" => "800",
+  #     "TRAVIS_REPO_SLUG" => "artsy/eigen",
+  #     "TRAVIS_COMMIT_RANGE" => "759adcbd0d8f...13c4dc8bb61d"
+  #   }
+  #   t = Danger::CISource::Travis.new(env)
+  #   expect(t.repo_slug).to eql("artsy/eigen")
+  #   expect(t.pull_request_id).to eql("800")
+  # end
+end


### PR DESCRIPTION
Couch coding in between MarioKart runs.

- `Grit::Git` was not calling git properly as a wrapper, so I was using the `sh` method directly. If this could be fixed, it would simplify all of the unix commands (assuming the logic for those is brought into Ruby)
- alternatively, you could just use the git CLI for a brittle, but dependency free, impl
- added some basic specs for `LocalGitRepo`