### PR TITLE
Fixed crash on `danger init`

### DIFF
--- a/lib/danger/commands/init.rb
+++ b/lib/danger/commands/init.rb
@@ -231,7 +231,7 @@ module Danger
       end
 
       ui.say "In order to expose an environment variable, go to:"
-      ui.link "https://circleci.com/gh/#{repo_slug}/edit#env-vars"
+      ui.link "https://circleci.com/gh/#{current_repo_slug}/edit#env-vars"
       ui.say "The name is " + "DANGER_GITHUB_API_TOKEN".yellow + " and the value is the GitHub Personal Acess Token."
     end
 


### PR DESCRIPTION
Fixes
```
In order to expose an environment variable, go to:
/Users/felixkrause/Developer/danger/lib/danger/commands/init.rb:234:in `circle_token': undefined local variable or method `repo_slug' for #<Danger::Init:0x007f9cfcdfc208> (NameError)
	from /Users/felixkrause/Developer/danger/lib/danger/commands/init.rb:159:in `setup_danger_ci'
```