### PR TITLE
Update CHANGELOG + Dangerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Master
+
+* Added internal plugin system - KrauseFx
+* Refactored unit tests - KrauseFx
+
 ## 0.5.2
 
 * Typo fixes for `danger init` - lumaxis 
@@ -17,8 +22,6 @@
 * Remove `nap` dependency - marcelofabri
 * Show command summary in help - marcelofabri
 * Use 100% width tables for messages - marcelofabri
-* Added plugin system - KrauseFx
-* Refactored unit tests - KrauseFx
 
 ## 0.3.0
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -20,7 +20,7 @@ if pr_body.length < 5
   fail "Please provide a summary in the Pull Request description"
 end
 
-declared_trivial = pr_title.include? "#trivial" || !has_app_changes
+declared_trivial = pr_title.include?("#trivial") || !has_app_changes
 if !files_modified.include?("CHANGELOG.md") && !declared_trivial
   fail "Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/danger/danger/blob/master/CHANGELOG.md)."
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,25 +1,26 @@
 # Sometimes its a README fix, or something like that - which isn't relevant for
 # including in a CHANGELOG for example
-declared_trivial = pr_title.include? "#trivial"
+
+has_app_changes = !files_modified.grep(/lib/).empty?
+has_test_changes = !files_modified.grep(/spec/).empty?
 
 if ["KrauseFx", "orta"].include?(pr_author) == false
-  warn("Author @#{pr_author} is not a contributor")
+  warn "Author @#{pr_author} is not a contributor"
 end
 
 if (pr_body + pr_title).include?("WIP")
-  warn("Pull Request is Work in Progress")
+  warn "Pull Request is Work in Progress"
 end
 
-if files_modified.any? { |a| a.include?("spec/") }
-  message("Tests were updated / added")
-else
-  warn("Tests were not updated")
+if has_app_changes && !has_test_changes
+  warn "Tests were not updated"
 end
 
 if pr_body.length < 5
   fail "Please provide a summary in the Pull Request description"
 end
 
+declared_trivial = pr_title.include? "#trivial" || !has_app_changes
 if !files_modified.include?("CHANGELOG.md") && !declared_trivial
-  fail "Please include a CHANGELOG entry"
+  fail "Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/danger/danger/blob/master/CHANGELOG.md)."
 end


### PR DESCRIPTION
I've moved your CHANGELOG notes to master, and started improving the Dangerfile. Now PRs to non-app parts don't have to be declared trivial, and we only warn when there are no tests and app code has been changed.