### PR TITLE
Add support for git:// remote urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added internal plugin system - KrauseFx
 * Refactored unit tests - KrauseFx
 * Fixed issue when PR Title or PR body is nil - KrauseFx
+* Added support for `git://`-prefixed url as remote - jeroenvisser101
 
 ## 0.5.2
 

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -25,14 +25,9 @@ module Danger
         # get the remote URL
         remote = run_git "remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-"
         if remote
-          url = remote[0].strip
-          # deal with https://
-          if url.start_with? "https://github.com/"
-            self.repo_slug = url.gsub("https://github.com/", "").gsub(/.git$/, '')
-
-          # deal with SSH origin
-          elsif url =~ %r{^(git://)?(git@)?github\.com(:|/)}
-            self.repo_slug = url.gsub(%r{(git://)?(git@)?github\.com(:|/)}, "").gsub(/.git$/, '')
+          remote_url_matches = remote.first.chomp.match(%r{github\.com(:|/)(?<repo_slug>.+/.+?)(?:\.git)?$})
+          if !remote_url_matches.nil? and remote_url_matches["repo_slug"]
+            self.repo_slug = remote_url_matches["repo_slug"]
           else
             puts "Danger local requires a repository hosted on github."
           end

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -31,8 +31,8 @@ module Danger
             self.repo_slug = url.gsub("https://github.com/", "").gsub(/.git$/, '')
 
           # deal with SSH origin
-          elsif url.start_with? "git@github.com:"
-            self.repo_slug = url.gsub("git@github.com:", "").gsub(/.git$/, '')
+          elsif url =~ %r{^(git://)?(git@)?github\.com(:|/)}
+            self.repo_slug = url.gsub(%r{(git://)?(git@)?github\.com(:|/)}, "").gsub(/.git$/, '')
           else
             puts "Danger local requires a repository hosted on github."
           end

--- a/spec/sources/local_git_repo_spec.rb
+++ b/spec/sources/local_git_repo_spec.rb
@@ -66,6 +66,24 @@ describe Danger::CISource::LocalGitRepo do
         expect(t.repo_slug).to eql("artsy/artsy.github.com")
       end
     end
+
+    it 'gets the repo address when it starts with git://' do
+      run_in_repo do
+        `git remote add origin git://github.com:orta/danger.git`
+        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        t = Danger::CISource::LocalGitRepo.new(env)
+        expect(t.repo_slug).to eql("orta/danger")
+      end
+    end
+
+    it 'gets the repo address when it starts with git://git@' do
+      run_in_repo do
+        `git remote add origin git://git@github.com:orta/danger.git`
+        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        t = Danger::CISource::LocalGitRepo.new(env)
+        expect(t.repo_slug).to eql("orta/danger")
+      end
+    end
   end
 
   describe 'non-github repos' do


### PR DESCRIPTION
As highlighted in the hub documentation (https://hub.github.com/), hub
adds remotes with `git://` prefix, instead of what github.com uses
(`git@` as prefix).

Danger should now support both.

Along with that, the logic has been simplified with a regular expression for all types of urls.