### PR TITLE
Fix comparison issue with Ruby 2.3.0

### DIFF
--- a/spec/dangerfile_spec.rb
+++ b/spec/dangerfile_spec.rb
@@ -14,7 +14,7 @@ describe Danger::Dangerfile do
     file = make_temp_file ""
     dm = Danger::Dangerfile.new
     dm.parse file.path
-    expect(dm.defined_in_file).to be file.path
+    expect(dm.defined_in_file).to eq file.path
   end
 
   it 'runs the ruby code inside the Dangerfile' do


### PR DESCRIPTION
As highlighted in https://github.com/danger/danger/pull/124, in ruby 2.3.0, `expect(actual).to be(expected)` works differently, since it's a different instance of the object it asserts it's different, while it's value is still exactly the same.

Error as shown in 2.3.0:
```
  1) Danger::Dangerfile keeps track of the original Dangerfile
     Failure/Error: expect(dm.defined_in_file).to be file.path

       expected #<String:70180931302200> => "/var/folders/8f/wnyyflm90jqdw6nygmv5z4yr0000gn/T/dangefile_tests20160309-28419-1gv8xnp"
            got #<String:70180931302880> => "/var/folders/8f/wnyyflm90jqdw6nygmv5z4yr0000gn/T/dangefile_tests20160309-28419-1gv8xnp"

       Compared using equal?, which compares object identity,
       but expected and actual are not the same object. Use
       `expect(actual).to eq(expected)` if you don't care about
       object identity in this example.
     # ./spec/dangerfile_spec.rb:17:in `block (2 levels) in <top (required)>'
```