### PR TITLE
Crossing out issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Added new `modified_files.include?("rakelib/*_stats.rake") file globbing support - KrauseFx
+* Resolved issues are now crossed out by Danger - marcelofabri
 
 ## 0.6.5
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ The `Dangerfile` is a ruby file, so really, you can do anything. However, at thi
 declared_trivial = pr_title.include? "#trivial"
 
 # Just to let people know
-warn("PR is classed as Work in Progress") if pr_title.include? "[WIP]"
+warn("PR is classed as Work in Progress", sticky: false) if pr_title.include? "[WIP]"
 ```
 
 #### Being cautious around specific files
 
 ``` ruby
 # Devs shouldn't ship changes to this file
-fail("Developer Specific file shouldn't be changed") if modified_files.include?("Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.m")
+fail("Developer Specific file shouldn't be changed", sticky: false) if modified_files.include?("Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.m")
 
 # Did you make analytics changes? Well you should also include a change to our analytics spec
 made_analytics_changes = modified_files.include?("/Artsy/App/ARAppDelegate+Analytics.m")
@@ -130,6 +130,15 @@ You can tell Danger to ignore a specific warning or error by commenting on the P
 
 ```
 > Danger: Ignore "Developer Specific file shouldn't be changed"
+```
+
+## Sticky
+
+Danger can keep its history if a warning/error/message is marked as *sticky*. When the violation is resolved,
+Danger will update the comment to cross it out. If you don't want this behavior, just use `sticky: false`.
+
+```ruby
+fail("PR needs labels", sticky: false) if pr_labels.empty?
 ```
 
 ## Useful bits of knowledge

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -14,6 +14,12 @@
       <td data-sticky="<%= violation.sticky %>"><%= violation.message %></td>
     </tr>
     <% end %>
+    <% table[:resolved].each do |violation| -%>
+      <tr>
+        <td>:white_check_mark:</td>
+        <td data-sticky="<%= violation.sticky %>"><strike><%= violation.message %></strike></td>
+      </tr>
+    <% end %>
   </tbody>
 </table>
   <% end %>

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -8,10 +8,10 @@
      </tr>
   </thead>
   <tbody>
-    <% table[:content].each do |message| -%>
+    <% table[:content].each do |violation| -%>
     <tr>
       <td>:<%= table[:emoji] %>:</td>
-      <td><%= message %></td>
+      <td data-sticky="<%= violation.sticky %>"><%= violation.message %></td>
     </tr>
     <% end %>
   </tbody>

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -14,10 +14,10 @@
       <td data-sticky="<%= violation.sticky %>"><%= violation.message %></td>
     </tr>
     <% end %>
-    <% table[:resolved].each do |violation| -%>
+    <% table[:resolved].each do |message| -%>
       <tr>
         <td>:white_check_mark:</td>
-        <td data-sticky="<%= violation.sticky %>"><strike><%= violation.message %></strike></td>
+        <td data-sticky="true"><strike><%= message %></strike></td>
       </tr>
     <% end %>
   </tbody>

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -4,7 +4,13 @@
   <thead>
     <tr>
       <th width="50"></th>
-      <th width="100%"><%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %></th>
+      <th width="100%" data-kind="<%= table[:name] %>">
+        <% if table[:count] > 0 %>
+            <%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %>
+        <% else %>
+            :white_check_mark: <%= random_compliment %>
+        <% end %>
+      </th>
      </tr>
   </thead>
   <tbody>

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -4,7 +4,13 @@
   <thead>
     <tr>
       <th width="50"></th>
-      <th width="100%"><%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %></th>
+      <th width="100%">
+        <% if table[:count] > 0 %>
+          <%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %>
+        <% else %>
+          :white_check_mark: <%= random_compliment %>
+        <% end %>
+      </th>
      </tr>
   </thead>
   <tbody>

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -1,10 +1,10 @@
 <% @tables.each do |table| %>
-  <% if table[:content].any? %>
+  <% if table[:content].any? || table[:resolved].any? %>
 <table>
   <thead>
     <tr>
       <th width="50"></th>
-      <th width="100%"><%= table[:content].count %> <%= table[:name] %><%= "s" unless table[:content].count == 1 %></th>
+      <th width="100%"><%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %></th>
      </tr>
   </thead>
   <tbody>

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -17,7 +17,7 @@
     <% table[:resolved].each do |message| -%>
       <tr>
         <td>:white_check_mark:</td>
-        <td data-sticky="true"><strike><%= message %></strike></td>
+        <td data-sticky="true"><del><%= message %></del></td>
       </tr>
     <% end %>
   </tbody>

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -4,13 +4,7 @@
   <thead>
     <tr>
       <th width="50"></th>
-      <th width="100%">
-        <% if table[:count] > 0 %>
-          <%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %>
-        <% else %>
-          :white_check_mark: <%= random_compliment %>
-        <% end %>
-      </th>
+      <th width="100%"><%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %></th>
      </tr>
   </thead>
   <tbody>

--- a/lib/danger/dangerfile_dsl.rb
+++ b/lib/danger/dangerfile_dsl.rb
@@ -1,3 +1,5 @@
+require 'danger/violation'
+
 module Danger
   class Dangerfile
     module DSL
@@ -30,9 +32,9 @@ module Danger
       #
       # @param    [String] message
       #           The message to present to the user
-      def fail(message)
+      def fail(message, sticky = true)
         return if should_ignore_violation(message)
-        self.errors << message
+        self.errors << Violation.new(message, sticky)
         puts "Raising error '#{message}'"
       end
 
@@ -40,9 +42,9 @@ module Danger
       #
       # @param    [String] message
       #           The message to present to the user
-      def warn(message)
+      def warn(message, sticky = true)
         return if should_ignore_violation(message)
-        self.warnings << message
+        self.warnings << Violation.new(message, sticky)
         puts "Printing warning '#{message}'"
       end
 
@@ -50,8 +52,8 @@ module Danger
       #
       # @param    [String] message
       #           The message to present to the user
-      def message(message)
-        self.messages << message
+      def message(message, sticky = true)
+        self.messages << Violation.new(message, sticky)
         puts "Printing message '#{message}'"
       end
 

--- a/lib/danger/dangerfile_dsl.rb
+++ b/lib/danger/dangerfile_dsl.rb
@@ -32,7 +32,9 @@ module Danger
       #
       # @param    [String] message
       #           The message to present to the user
-      def fail(message, sticky = true)
+      # @param    [Boolean] sticky
+      #           Whether the message should be kept after it was fixed
+      def fail(message, sticky: true)
         return if should_ignore_violation(message)
         self.errors << Violation.new(message, sticky)
         puts "Raising error '#{message}'"
@@ -42,7 +44,9 @@ module Danger
       #
       # @param    [String] message
       #           The message to present to the user
-      def warn(message, sticky = true)
+      # @param    [Boolean] sticky
+      #           Whether the message should be kept after it was fixed
+      def warn(message, sticky: true)
         return if should_ignore_violation(message)
         self.warnings << Violation.new(message, sticky)
         puts "Printing warning '#{message}'"
@@ -52,7 +56,9 @@ module Danger
       #
       # @param    [String] message
       #           The message to present to the user
-      def message(message, sticky = true)
+      # @param    [Boolean] sticky
+      #           Whether the message should be kept after it was fixed
+      def message(message, sticky: true)
         self.messages << Violation.new(message, sticky)
         puts "Printing message '#{message}'"
       end

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -141,11 +141,17 @@ module Danger
       end
     end
 
+    def random_compliment
+      compliment = ["Well done.", "Congrats.", "Woo!",
+                    "Yay.", "Jolly good show.", "Good on 'ya.", "Nice work."]
+      compliment.sample
+    end
+
     def generate_github_description(warnings: nil, errors: nil)
       if errors.empty? && warnings.empty?
         compliment = ["Well done.", "Congrats.", "Woo!",
                       "Yay.", "Jolly good show.", "Good on 'ya.", "Nice work."]
-        return "All green. #{compliment.sample}"
+        return "All green. #{random_compliment}"
       else
         message = "⚠ "
         message += "#{errors.count} Error#{errors.count == 1 ? '' : 's'}. " unless errors.empty?
@@ -176,7 +182,7 @@ module Danger
       previous_violations = all_previous_violations[kind] || []
       messages = content.map(&:message)
       resolved_violations = previous_violations.reject { |s| messages.include? s }
-      count = content.count + resolved_violations.count
+      count = content.count
       { name: name, emoji: emoji, content: content, resolved: resolved_violations, count: count }
     end
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -176,7 +176,7 @@ module Danger
       previous_violations = all_previous_violations[kind] || []
       messages = content.map(&:message)
       resolved_violations = previous_violations.reject { |s| messages.include? s }
-      count = content.count + content.count
+      count = content.count + resolved_violations.count
       { name: name, emoji: emoji, content: content, resolved: resolved_violations, count: count }
     end
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -192,12 +192,12 @@ module Danger
         violations[kind] = violations_from_table(table)
       end
 
-      violations.reject { |k, v| v.empty? }
+      violations.reject { |_, v| v.empty? }
     end
 
     def violations_from_table(table)
-      regex = %r{<td data-sticky="true">(<del>)?(.*?)(</del>)?\s*</td>}im
-      table.scan(regex).map { |a| a[1] }.map(&:strip)
+      regex = %r{<td data-sticky="true">(?:<del>)?(.*?)(?:</del>)?\s*</td>}im
+      table.scan(regex).flatten.map(&:strip)
     end
 
     def table_kind_from_title(title)

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -196,7 +196,7 @@ module Danger
     end
 
     def violations_from_table(table)
-      regex = %r{<td data-sticky="true">(<strike>)?(.*?)(</strike>)?\s*</td>}im
+      regex = %r{<td data-sticky="true">(<del>)?(.*?)(</del>)?\s*</td>}im
       table.scan(regex).map { |a| a[1] }.map(&:strip)
     end
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -141,17 +141,11 @@ module Danger
       end
     end
 
-    def random_compliment
-      compliment = ["Well done.", "Congrats.", "Woo!",
-                    "Yay.", "Jolly good show.", "Good on 'ya.", "Nice work."]
-      compliment.sample
-    end
-
     def generate_github_description(warnings: nil, errors: nil)
       if errors.empty? && warnings.empty?
         compliment = ["Well done.", "Congrats.", "Woo!",
                       "Yay.", "Jolly good show.", "Good on 'ya.", "Nice work."]
-        return "All green. #{random_compliment}"
+        return "All green. #{compliment.sample}"
       else
         message = "⚠ "
         message += "#{errors.count} Error#{errors.count == 1 ? '' : 's'}. " unless errors.empty?
@@ -182,7 +176,7 @@ module Danger
       previous_violations = all_previous_violations[kind] || []
       messages = content.map(&:message)
       resolved_violations = previous_violations.reject { |s| messages.include? s }
-      count = content.count
+      count = content.count + resolved_violations.count
       { name: name, emoji: emoji, content: content, resolved: resolved_violations, count: count }
     end
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -108,7 +108,7 @@ module Danger
       message = generate_github_description(warnings: warnings, errors: errors)
       client.create_status(ci_source.repo_slug, latest_pr_commit_ref, status, {
         description: message,
-        context: "KrauseFx/danger",
+        context: "danger/danger",
         target_url: details_url
       })
     rescue
@@ -155,18 +155,18 @@ module Danger
       # erb: http://www.rrn.dk/rubys-erb-templating-system
       # for the extra args: http://stackoverflow.com/questions/4632879/erb-template-removing-the-trailing-line
       @tables = [
-        { name: "Error", emoji: "no_entry_sign", content: errors.map { |s| process_markdown(s) } },
-        { name: "Warning", emoji: "warning", content: warnings.map { |s| process_markdown(s) } },
-        { name: "Message", emoji: "book", content: messages.map { |s| process_markdown(s) } }
+        { name: "Error", emoji: "no_entry_sign", content: errors.map { |v| process_markdown(v) } },
+        { name: "Warning", emoji: "warning", content: warnings.map { |v| process_markdown(v) } },
+        { name: "Message", emoji: "book", content: messages.map { |v| process_markdown(v) } }
       ]
       return ERB.new(File.read(md_template), 0, "-").result(binding)
     end
 
-    def process_markdown(string)
-      html = markdown_parser.render(string)
+    def process_markdown(violation)
+      html = markdown_parser.render(violation.message)
       match = html.match(%r{^<p>(.*)</p>$})
-      return match.captures.first unless match.nil?
-      html
+      message = match.nil? ? html : match.captures.first
+      Violation.new(message, violation.sticky)
     end
   end
 end

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -141,11 +141,15 @@ module Danger
       end
     end
 
+    def random_compliment
+      compliment = ["Well done.", "Congrats.", "Woo!",
+                    "Yay.", "Jolly good show.", "Good on 'ya.", "Nice work."]
+      compliment.sample
+    end
+
     def generate_github_description(warnings: nil, errors: nil)
       if errors.empty? && warnings.empty?
-        compliment = ["Well done.", "Congrats.", "Woo!",
-                      "Yay.", "Jolly good show.", "Good on 'ya.", "Nice work."]
-        return "All green. #{compliment.sample}"
+        return "All green. #{random_compliment}"
       else
         message = "⚠ "
         message += "#{errors.count} Error#{errors.count == 1 ? '' : 's'}. " unless errors.empty?
@@ -176,7 +180,7 @@ module Danger
       previous_violations = all_previous_violations[kind] || []
       messages = content.map(&:message)
       resolved_violations = previous_violations.reject { |s| messages.include? s }
-      count = content.count + resolved_violations.count
+      count = content.count
       { name: name, emoji: emoji, content: content, resolved: resolved_violations, count: count }
     end
 
@@ -184,7 +188,7 @@ module Danger
       tables = parse_tables_from_comment(comment)
       violations = {}
       tables.each do |table|
-        next unless table =~ %r{<th width="100%">(.*?)</th>}im
+        next unless table =~ %r{<th width="100%"(.*?)</th>}im
         title = Regexp.last_match(1)
         kind = table_kind_from_title(title)
         next unless kind

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -176,7 +176,8 @@ module Danger
       previous_violations = all_previous_violations[kind] || []
       messages = content.map(&:message)
       resolved_violations = previous_violations.reject { |s| messages.include? s }
-      { name: name, emoji: emoji, content: content, resolved: resolved_violations }
+      count = content.count + content.count
+      { name: name, emoji: emoji, content: content, resolved: resolved_violations, count: count }
     end
 
     def parse_comment(comment)

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -166,20 +166,19 @@ module Danger
       tables = parse_tables_from_comment(comment)
       violations = {}
       tables.each do |table|
-        if table =~ /<th width="100%">(.*?)<\/th>/im
-          title = $1
-          kind = table_kind_from_title(title)
-          next unless kind
+        next unless table =~ %r{<th width="100%">(.*?)</th>}im
+        title = Regexp.last_match(1)
+        kind = table_kind_from_title(title)
+        next unless kind
 
-          violations[kind] = violations_from_table(table)
-        end
+        violations[kind] = violations_from_table(table)
       end
 
       violations
     end
 
     def violations_from_table(table)
-      regex = /<td data-sticky="true">(<strike>)?(.*?)(<\/strike>)?<\/td>/im
+      regex = %r{<td data-sticky="true">(<strike>)?(.*?)(</strike>)?</td>}im
       table.scan(regex).flatten.compact.map(&:strip)
     end
 
@@ -190,8 +189,6 @@ module Danger
         :warning
       elsif title =~ /message/i
         :message
-      else
-        nil
       end
     end
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -174,7 +174,8 @@ module Danger
       content = violations.map { |v| process_markdown(v) }
       kind = table_kind_from_title(name)
       previous_violations = all_previous_violations[kind] || []
-      resolved_violations = previous_violations.reject { |s| content.include? s }
+      messages = content.map(&:message)
+      resolved_violations = previous_violations.reject { |s| messages.include? s }
       { name: name, emoji: emoji, content: content, resolved: resolved_violations }
     end
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -178,8 +178,8 @@ module Danger
     end
 
     def violations_from_table(table)
-      regex = %r{<td data-sticky="true">(<strike>)?(.*?)(</strike>)?</td>}im
-      table.scan(regex).flatten.compact.map(&:strip)
+      regex = %r{<td data-sticky="true">(<strike>)?(.*?)(</strike>)?\s*</td>}im
+      table.scan(regex).map { |a| a[1] }.map(&:strip)
     end
 
     def table_kind_from_title(title)

--- a/lib/danger/violation.rb
+++ b/lib/danger/violation.rb
@@ -1,0 +1,10 @@
+module Danger
+  class Violation
+    attr_accessor :message, :sticky
+
+    def initialize(message, sticky)
+      self.message = message
+      self.sticky = sticky
+    end
+  end
+end

--- a/spec/dangerfile_spec.rb
+++ b/spec/dangerfile_spec.rb
@@ -53,9 +53,9 @@ describe Danger::Dangerfile do
 
     dm.parse Pathname.new(""), code
 
-    expect(dm.messages).to eql(['A message'])
-    expect(dm.warnings).to eql(['A warning'])
-    expect(dm.errors).to eql(['An error'])
+    expect(dm.messages.map(&:message)).to eql(['A message'])
+    expect(dm.warnings.map(&:message)).to eql(['A warning'])
+    expect(dm.errors.map(&:message)).to eql(['An error'])
   end
 
   describe "verbose" do

--- a/spec/fixtures/comment_with_error.html
+++ b/spec/fixtures/comment_with_error.html
@@ -1,0 +1,16 @@
+<table>
+    <thead>
+    <tr>
+        <th width="50"></th>
+        <th width="100%">1 Error</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>:no_entry_sign:</td>
+        <td data-sticky="true">Some error
+        </td>
+    </tr>
+
+    </tbody>
+</table>

--- a/spec/fixtures/comment_with_error_and_warnings.html
+++ b/spec/fixtures/comment_with_error_and_warnings.html
@@ -1,0 +1,34 @@
+<table>
+    <thead>
+    <tr>
+        <th width="50"></th>
+        <th width="100%">1 Error</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>:no_entry_sign:</td>
+        <td data-sticky="true">Some error
+        </td>
+    </tr>
+
+    </tbody>
+</table>
+
+<table>
+    <thead>
+    <tr>
+        <th width="50"></th>
+        <th width="100%">2 Warnings</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>:warning:</td>
+        <td data-sticky="true">First warning
+        </td>
+        <td data-sticky="true">Second warning</td>
+    </tr>
+
+    </tbody>
+</table>

--- a/spec/fixtures/comment_with_non_sticky.html
+++ b/spec/fixtures/comment_with_non_sticky.html
@@ -1,0 +1,34 @@
+<table>
+    <thead>
+    <tr>
+        <th width="50"></th>
+        <th width="100%">1 Error</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>:no_entry_sign:</td>
+        <td data-sticky="false">Some error
+        </td>
+    </tr>
+
+    </tbody>
+</table>
+
+<table>
+    <thead>
+    <tr>
+        <th width="50"></th>
+        <th width="100%">2 Warnings</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>:warning:</td>
+        <td data-sticky="true">First warning
+        </td>
+        <td>Second warning</td>
+    </tr>
+
+    </tbody>
+</table>

--- a/spec/fixtures/comment_with_resolved_violation.html
+++ b/spec/fixtures/comment_with_resolved_violation.html
@@ -2,12 +2,12 @@
     <thead>
     <tr>
         <th width="50"></th>
-        <th width="100%">1 Error</th>
+        <th width="100%" data-kind="Error">:white_check_mark: Woo!</th>
     </tr>
     </thead>
     <tbody>
     <tr>
-        <td>:no_entry_sign:</td>
+        <td>:white_check_mark:</td>
         <td data-sticky="true"><del>Some error</del>
         </td>
     </tr>
@@ -19,7 +19,7 @@
     <thead>
     <tr>
         <th width="50"></th>
-        <th width="100%">2 Warnings</th>
+        <th width="100%">1 Warning</th>
     </tr>
     </thead>
     <tbody>

--- a/spec/fixtures/comment_with_resolved_violation.html
+++ b/spec/fixtures/comment_with_resolved_violation.html
@@ -8,7 +8,7 @@
     <tbody>
     <tr>
         <td>:no_entry_sign:</td>
-        <td data-sticky="true"><strike>Some error</strike>
+        <td data-sticky="true"><del>Some error</del>
         </td>
     </tr>
 

--- a/spec/fixtures/comment_with_resolved_violation.html
+++ b/spec/fixtures/comment_with_resolved_violation.html
@@ -1,0 +1,34 @@
+<table>
+    <thead>
+    <tr>
+        <th width="50"></th>
+        <th width="100%">1 Error</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>:no_entry_sign:</td>
+        <td data-sticky="true"><strike>Some error</strike>
+        </td>
+    </tr>
+
+    </tbody>
+</table>
+
+<table>
+    <thead>
+    <tr>
+        <th width="50"></th>
+        <th width="100%">2 Warnings</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>:warning:</td>
+        <td data-sticky="true">First warning
+        </td>
+        <td data-sticky="true">Second warning</td>
+    </tr>
+
+    </tbody>
+</table>

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -144,6 +144,18 @@ describe Danger::GitHub do
         result = @g.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]), messages: [])
         expect(result.gsub(/\s+/, "")).to include("generated_by_danger")
       end
+
+      it "sets data-sticky to true when a violation is sticky" do
+        sticky_warning = Danger::Violation.new("my warning", true)
+        result = @g.generate_comment(warnings: [sticky_warning], errors: [], messages: [])
+        expect(result.gsub(/\s+/, "")).to include("tddata-sticky=\"true\"")
+      end
+
+      it "sets data-sticky to false when a violation is not sticky" do
+        non_sticky_warning = Danger::Violation.new("my warning", false)
+        result = @g.generate_comment(warnings: [non_sticky_warning], errors: [], messages: [])
+        expect(result.gsub(/\s+/, "")).to include("tddata-sticky=\"false\"")
+      end
     end
 
     describe "status message" do

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -215,10 +215,43 @@ describe Danger::GitHub do
     end
 
     describe "comment parsing" do
-      it "parses a comment with errors" do
+      it "detects the warning kind" do
+        expect(@g.table_kind_from_title('1 Warning')).to eq(:warning)
+        expect(@g.table_kind_from_title('2 Warnings')).to eq(:warning)
+      end
+
+      it "detects the error kind" do
+        expect(@g.table_kind_from_title('1 Error')).to eq(:error)
+        expect(@g.table_kind_from_title('2 Errors')).to eq(:error)
+      end
+
+      it "detects the warning kind" do
+        expect(@g.table_kind_from_title('1 Message')).to eq(:message)
+        expect(@g.table_kind_from_title('2 Messages')).to eq(:message)
+      end
+
+      it "parses a comment with error" do
         comment = comment_fixture('comment_with_error')
         violations = @g.parse_comment(comment)
         expect(violations).to eq({ error: ['Some error'] })
+      end
+
+      it "parses a comment with error and warnings" do
+        comment = comment_fixture('comment_with_error_and_warnings')
+        violations = @g.parse_comment(comment)
+        expect(violations).to eq({ error: ['Some error'], warning: ['First warning', 'Second warning'] })
+      end
+
+      it "ignores non-sticky violations when parsing a comment" do
+        comment = comment_fixture('comment_with_non_sticky')
+        violations = @g.parse_comment(comment)
+        expect(violations).to eq({ error: [], warning: ['First warning'] })
+      end
+
+      it "parses a comment with error and warnings removing strike tag" do
+        comment = comment_fixture('comment_with_resolved_violation')
+        violations = @g.parse_comment(comment)
+        expect(violations).to eq({ error: ['Some error'], warning: ['First warning', 'Second warning'] })
       end
     end
   end

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -245,7 +245,7 @@ describe Danger::GitHub do
       it "ignores non-sticky violations when parsing a comment" do
         comment = comment_fixture('comment_with_non_sticky')
         violations = @g.parse_comment(comment)
-        expect(violations).to eq({ error: [], warning: ['First warning'] })
+        expect(violations).to eq({ warning: ['First warning'] })
       end
 
       it "parses a comment with error and warnings removing strike tag" do

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -120,7 +120,7 @@ describe Danger::GitHub do
         result = @g.generate_comment(warnings: violations(["my warning", "second warning"]), errors: [], messages: [])
         # rubocop:disable Metrics/LineLength
         expect(result.gsub(/\s+/, "")).to eq(
-          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky=\"false\">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky=\"false\">secondwarning</td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
+          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\"data-kind=\"Warning\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky=\"false\">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky=\"false\">secondwarning</td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
         )
         # rubocop:enable Metrics/LineLength
       end
@@ -130,7 +130,7 @@ describe Danger::GitHub do
         result = @g.generate_comment(warnings: warnings, errors: [], messages: [])
         # rubocop:disable Metrics/LineLength
         expect(result.gsub(/\s+/, "")).to eq(
-          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky=\"false\">amarkdown<ahref=\"https://github.com/danger/danger\">linktodanger</a></td></tr><tr><td>:warning:</td><tddata-sticky=\"false\">second<strong>warning</strong></td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
+          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\"data-kind=\"Warning\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky=\"false\">amarkdown<ahref=\"https://github.com/danger/danger\">linktodanger</a></td></tr><tr><td>:warning:</td><tddata-sticky=\"false\">second<strong>warning</strong></td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
         )
         # rubocop:enable Metrics/LineLength
       end
@@ -139,7 +139,7 @@ describe Danger::GitHub do
         result = @g.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]), messages: [])
         # rubocop:disable Metrics/LineLength
         expect(result.gsub(/\s+/, "")).to eq(
-          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky=\"false\">someerror</td></tr></tbody></table><table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky=\"false\">mywarning</td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
+          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\"data-kind=\"Error\">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky=\"false\">someerror</td></tr></tbody></table><table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\"data-kind=\"Warning\">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky=\"false\">mywarning</td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
         )
         # rubocop:enable Metrics/LineLength
       end

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -116,7 +116,7 @@ describe Danger::GitHub do
         result = @g.generate_comment(warnings: violations(["my warning", "second warning"]), errors: [], messages: [])
         # rubocop:disable Metrics/LineLength
         expect(result.gsub(/\s+/, "")).to eq(
-          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><td>mywarning</td></tr><tr><td>:warning:</td><td>secondwarning</td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
+          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky=\"false\">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky=\"false\">secondwarning</td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
         )
         # rubocop:enable Metrics/LineLength
       end
@@ -126,7 +126,7 @@ describe Danger::GitHub do
         result = @g.generate_comment(warnings: warnings, errors: [], messages: [])
         # rubocop:disable Metrics/LineLength
         expect(result.gsub(/\s+/, "")).to eq(
-          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><td>amarkdown<ahref=\"https://github.com/danger/danger\">linktodanger</a></td></tr><tr><td>:warning:</td><td>second<strong>warning</strong></td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
+          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky=\"false\">amarkdown<ahref=\"https://github.com/danger/danger\">linktodanger</a></td></tr><tr><td>:warning:</td><tddata-sticky=\"false\">second<strong>warning</strong></td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
         )
         # rubocop:enable Metrics/LineLength
       end
@@ -135,7 +135,7 @@ describe Danger::GitHub do
         result = @g.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]), messages: [])
         # rubocop:disable Metrics/LineLength
         expect(result.gsub(/\s+/, "")).to eq(
-          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><td>someerror</td></tr></tbody></table><table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><td>mywarning</td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
+          "<table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky=\"false\">someerror</td></tr></tbody></table><table><thead><tr><thwidth=\"50\"></th><thwidth=\"100%\">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky=\"false\">mywarning</td></tr></tbody></table><palign=\"right\"data-meta=\"generated_by_danger\"data-base-commit=\"\"data-head-commit=\"\">Generatedby:no_entry_sign:<ahref=\"https://github.com/danger/danger/\">danger</a></p>"
         )
         # rubocop:enable Metrics/LineLength
       end

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -13,6 +13,11 @@ def fixture(file)
   File.read("spec/fixtures/#{file}.json")
 end
 
+def comment_fixture(file)
+  File.read("spec/fixtures/#{file}.html")
+end
+
+
 def violation(message)
   Danger::Violation.new(message, false)
 end
@@ -207,6 +212,14 @@ describe Danger::GitHub do
 
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", "12").and_return({})
         @g.update_pull_request!(warnings: [], errors: [], messages: [])
+      end
+    end
+
+    describe "comment parsing" do
+      it "parses a comment with errors" do
+        comment = comment_fixture('comment_with_error')
+        violations = @g.parse_comment(comment)
+        expect(violations).to eq({:error => ['Some error']})
       end
     end
   end

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -17,7 +17,6 @@ def comment_fixture(file)
   File.read("spec/fixtures/#{file}.html")
 end
 
-
 def violation(message)
   Danger::Violation.new(message, false)
 end
@@ -219,7 +218,7 @@ describe Danger::GitHub do
       it "parses a comment with errors" do
         comment = comment_fixture('comment_with_error')
         violations = @g.parse_comment(comment)
-        expect(violations).to eq({:error => ['Some error']})
+        expect(violations).to eq({ error: ['Some error'] })
       end
     end
   end


### PR DESCRIPTION
Will fix #153. 

- [x] Add (optional) `sticky` parameter to DSL methods
- [x] Refactor warnings/messages/errors to be arrays of `Violation`
- [x] Add `data-sticky` to the table HTML
- [x] Make HTML tests green again
- [x] Read all violations from a HTML comment
- [x] Find out which ones should be crossed
- [x] Update comment with the crossed violations
- [x] Changelog
- [x] Tests 
- [x] Update README