### PR TITLE
Use `rubygems-bundler` to fix Circle CI builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 
 dependencies:
   pre:
+    - gem install rubygems-bundler
     - gem install bundler
 
 test:


### PR DESCRIPTION
I ran `bundle -v` before and after the `gem install bundler` on Circle CI. Both reported `1.9.5` despite having just installed bundler 1.11.2. This meant to me that the RVM Ruby environment on Circle wasn't aware of the new bundler binary which had just been installed.

I looked around for RVM answers a bit and wound up on this page: https://rvm.io/integration/bundler

Versions of RVM later than 1.11.0 should include this functionality already, but despite Circle having a much later one (1.26?) I found that doing the `gem install rubygems-bundler` mentioned there made the difference in the system picking up on the new version of bundler.