### PR TITLE
Support file renaming

### DIFF
--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -43,7 +43,7 @@ module Danger
     private
 
     def extract_new_file(git_file)
-      git_file.gsub(/(.*) => (.*)/, "\\2")
+      git_file.gsub(/{?(.*) => (.*)}?/, "\\2")
     end
   end
 end

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -24,7 +24,8 @@ module Danger
     end
 
     def modified_files
-      Danger::FileList.new(@diff.stats[:files].keys)
+      files = @diff.stats[:files].keys.map(&method(:extract_new_file))
+      Danger::FileList.new(files)
     end
 
     def lines_of_code
@@ -37,6 +38,12 @@ module Danger
 
     def insertions
       @diff.insertions
+    end
+
+    private
+
+    def extract_new_file(git_file)
+      git_file.gsub(/(.*) => (.*)/, "\\2")
     end
   end
 end

--- a/spec/sources/git_spec.rb
+++ b/spec/sources/git_spec.rb
@@ -76,6 +76,27 @@ describe Danger::GitRepo do
       end
     end
 
+    it 'handles moved as expected' do
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          `git init`
+          `touch oldFile`
+          `git add .`
+          `git commit -m "ok"`
+
+          `git checkout -b new`
+          `mv oldFile newFile`
+          `git add .`
+          `git commit -m "another"`
+        end
+
+        g = Danger::GitRepo.new
+        g.diff_for_folder(dir, from: "master", to: "new")
+
+        expect(g.modified_files).to eql(["newFile"])
+      end
+    end
+
     it 'handles modified as expected' do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do


### PR DESCRIPTION
Hey all,

First of all, thanks for a great open source contribution. We at SoundCloud just implemented this project into our iOS pipeline and we love it.

Here's what we've found however:

When a file is moved or renamed in the pull request, `modified_files` will not return the new file's name, but rather something in this format
`/path/to/OldFile.h => NewFile.h`

This comes from upstream call to `@diff.stats[:files].keys`.

Obviously it is impossible to read the file in this format, so if developer is relying on `modified_fiels` to return valid file paths, this may be considered as a bug.

Unit test should be pretty much self-explanatory. 