### PR TITLE
Fix typo #trivial

### DIFF
--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -20,7 +20,7 @@ module Danger
     end
 
     def client
-      raise "No API given, please provide one using `DANGER_GITHUB_API_TOKEN`" if !@token && !support_tokenless_auth
+      raise "No API token given, please provide one using `DANGER_GITHUB_API_TOKEN`" if !@token && !support_tokenless_auth
 
       @client ||= Octokit::Client.new(
         access_token: @token


### PR DESCRIPTION
The word `token` was omitted from the error message.