### PR TITLE
Adds a command-line argument to support choosing a specific merged PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
-* Remove me - jeroenvisser101
+* Adds the ability to specify a PR number in `danger local` - orta
+* Ensures local branches are set up with  `danger local` - orta
 
 ## 0.7.3
 

--- a/README.md
+++ b/README.md
@@ -169,8 +169,11 @@ open to turning useful bits into the official API.
 
 ## Test locally with `danger local`
 
-Using `danger local` will look for the last merged pull request in your git history, and apply your current
-`Dangerfile` against that Pull Request. Useful when editing.
+You can yse `danger local` to run Danger in an environment similar to how it will be ran on CI. By default Danger will look
+at the most recently merged PR, then run you `Dangerfile` against that Pull Request. This is really useful when making changes.
+
+If you have a specific PR in mind that you'd like to work against, make sure you have it merged in your current git
+history, then append `--use-merged-pr=[id]` to the command.
 
 ## Suppress Violations
 

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -34,10 +34,19 @@ module Danger
           end
         end
 
+        specific_pr = env["LOCAL_GIT_PR_ID"]
+        pr_ref = specific_pr ? "##{specific_pr}" : ''
+        pr_command = "log --merges --oneline | grep \"Merge pull request #{pr_ref}\" | head -n 1"
+
         # get the most recent PR merge
-        pr_merge = run_git "log --since='2 weeks ago' --merges --oneline | grep \"Merge pull request\" | head -n 1".strip
+        pr_merge = run_git pr_command.strip
+
         if pr_merge.to_s.empty?
-          raise "No recent pull requests found for this repo, danger requires at least one PR for the local mode"
+          if has_specific_pr
+            raise "Could not find the pull request (#{specific_pr}) inside the git history for this repo."
+          else
+            raise "No recent pull requests found for this repo, danger requires at least one PR for the local mode."
+          end
         end
 
         self.pull_request_id = pr_merge.match("#([0-9]+)")[1]

--- a/lib/danger/commands/new_plugin.rb
+++ b/lib/danger/commands/new_plugin.rb
@@ -3,14 +3,6 @@ module Danger
     self.summary = 'Generate a new danger plugin.'
     self.command = 'new_plugin'
 
-    def initialize(argv)
-      super
-    end
-
-    def validate!
-      super
-    end
-
     def run
       require 'fileutils'
 


### PR DESCRIPTION
I'm on the side of  we shouldn't support arbitrary repos e.g. `danger local --pr=artsy/eigen#11` as the file system isn't going to match the expectations of danger, a merged PR at least will have an approximation of the current file system ( though, obviously it may have changed since then, but that should be pretty obvious to the user. ) 

So this just adds a way to pass a single id along via `danger local --use-merged-pr=11`

Fixes https://github.com/danger/danger/issues/134 