### PR TITLE
Moves the commits reference to be public in the DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## Master
 
 * Remove me - jeroenvisser101
+* Add `commits` for the Git SCM source - segiddins
 
 ## 0.7.3
 
 * Minor `danger init` typo fixes - orta + danger
 * Added support for CLAide-based plugins - segiddins
-* Add `commits` for the Git SCM source - segiddins
 
 ## 0.7.2
 

--- a/lib/danger/available_values.rb
+++ b/lib/danger/available_values.rb
@@ -12,7 +12,8 @@ module Danger
         :deleted_files,
         :added_files,
         :deletions,
-        :insertions
+        :insertions,
+        :commits
       ]
     end
 


### PR DESCRIPTION
I'll handle updating all the CHANGELOGs once #195  and this is merged, and make a `0.7.4` release - should un-block https://github.com/CocoaPods/CocoaPods/pull/5227
 
