### PR TITLE
fix danger --version doesn't print out version [#151] #trivial

### DIFF
--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -6,6 +6,7 @@ module Danger
 
     self.summary = 'Run the Dangerfile.'
     self.command = 'danger'
+    self.version = Danger::VERSION
 
     self.plugin_prefixes = %w(claide danger)
 

--- a/spec/commands/runner_command_spec.rb
+++ b/spec/commands/runner_command_spec.rb
@@ -50,5 +50,9 @@ module Command
         end
       end
     end
+
+    it 'has the correct version' do
+      expect(Danger::Runner.version).to eq(Danger::VERSION)
+    end
   end
 end


### PR DESCRIPTION
Fixes the issue where `danger --version` prints out an empty line.