### PR TITLE
fix a crash where ci_source.dsl is not available with danger local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Considerable under-the-hood changes around the DSL, shouldn't affect end-user Dangerfiles though - orta
+* Fix for `danger local` crash due to ^ - dbgrandi
 * Add support for Drone CI = gabro
 
 ## 0.7.4

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -56,7 +56,7 @@ module Danger
       dm.env.scm = GitRepo.new
 
       dm.env.ensure_danger_branches_are_setup
-      dm.env.scm.diff_for_folder(".", from: dm.env.ci_source.dsl.base_commit, to: dm.env.ci_source.dsl.head_commit)
+      dm.env.scm.diff_for_folder(".", from: dm.env.ci_source.base_commit, to: dm.env.ci_source.head_commit)
       dm.parse(Pathname.new(@dangerfile_path))
       dm.print_results
     end


### PR DESCRIPTION
Had a crash when running `danger local` due to the DSL changes.

```
Users/dbgrandi/watched/danger/danger/lib/danger/commands/local.rb:59:in `run': undefined method `dsl' for #<Danger::CISource::LocalGitRepo:0x007f7fbd110848> (NoMethodError)
	from /Users/dbgrandi/.rvm/gems/ruby-2.2.4/gems/claide-1.0.0/lib/claide/command.rb:334:in `run'
	from bin/danger:5:in `<main>'
```

#nottested