### PR TITLE
initial work on migrating to new plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Considerable under-the-hood changes around the DSL, shouldn't affect end-user Dangerfiles though - orta
 * Add support for Drone CI = gabro
+* [BREAKING] Add initial support for more expressive and documented plugins. Breaks all existing plugins. - dbgrandi/orta
 
 ## 0.7.4
 

--- a/danger_plugins/protect_files.rb
+++ b/danger_plugins/protect_files.rb
@@ -1,34 +1,34 @@
-module Danger
-  class Dangerfile
-    module DSL
-      class ProtectFiles < Plugin
-        def run(path: nil, message: nil, fail_build: true)
-          raise "You have to provide a message" if message.to_s.length == 0
-          raise "You have to provide a path" if path.to_s.length == 0
-          
-          broken_rule = false
-          
-          Dir.glob(path) do |current|
-            broken_rule = true if self.env.scm.dsl.modified_files.include?(current)
-          end
+# module Danger
+#   class Dangerfile
+#     module DSL
+#       class ProtectFiles < Plugin
+#         def run(path: nil, message: nil, fail_build: true)
+#           raise "You have to provide a message" if message.to_s.length == 0
+#           raise "You have to provide a path" if path.to_s.length == 0
 
-          return unless broken_rule
-          violation = Danger::Violation.new(message, true)
-          if fail_build
-            @dsl.errors << violation
-          else
-            @dsl.warnings << violation
-          end
-        end
+#           broken_rule = false
 
-        def self.description
-          [
-            "Protect a file from being changed. This can",
-            "be used in combination with some kind of",
-            "permission check if a user is inside the org"
-          ].join(" ")
-        end
-      end
-    end
-  end
-end
+#           Dir.glob(path) do |current|
+#             broken_rule = true if self.env.scm.dsl.modified_files.include?(current)
+#           end
+
+#           return unless broken_rule
+#           violation = Danger::Violation.new(message, true)
+#           if fail_build
+#             @dsl.errors << violation
+#           else
+#             @dsl.warnings << violation
+#           end
+#         end
+
+#         def self.description
+#           [
+#             "Protect a file from being changed. This can",
+#             "be used in combination with some kind of",
+#             "permission check if a user is inside the org"
+#           ].join(" ")
+#         end
+#       end
+#     end
+#   end
+# end

--- a/danger_plugins/work_in_progress_warning.rb
+++ b/danger_plugins/work_in_progress_warning.rb
@@ -1,17 +1,17 @@
-module Danger
-  class Dangerfile
-    module DSL
-      class WorkInProgressWarning < Plugin
-        def run
-          if (pr_body + pr_title).include?("WIP")
-            warn "Pull Request is Work in Progress"
-          end
-        end
+# module Danger
+#   class Dangerfile
+#     module DSL
+#       class WorkInProgressWarning < Plugin
+#         def run
+#           if (pr_body + pr_title).include?("WIP")
+#             warn "Pull Request is Work in Progress"
+#           end
+#         end
 
-        def self.description
-          "Add a warning to PRs with 'WIP' in their title or body"
-        end
-      end
-    end
-  end
-end
+#         def self.description
+#           "Add a warning to PRs with 'WIP' in their title or body"
+#         end
+#       end
+#     end
+#   end
+# end

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -27,6 +27,7 @@ module Danger
       ENV["LOCAL_GIT_PR_ID"] = @pr_num if @pr_num
 
       dm = Dangerfile.new
+      dm.init_plugins
       dm.env = EnvironmentManager.new(ENV)
 
       source = dm.env.ci_source

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -34,8 +34,9 @@ module Danger
     def run
       # The order of the following commands is *really* important
       dm = Dangerfile.new
-      dm.verbose = verbose
+      dm.init_plugins
       dm.env = EnvironmentManager.new(ENV)
+      dm.verbose = verbose
       return unless dm.env.ci_source # if it's not a PR
 
       dm.env.fill_environment_vars

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -21,6 +21,23 @@ module Danger
       'Dangerfile'
     end
 
+    # Iterate through available plugin classes and initialize them with
+    # a reference to this Dangerfile
+    def init_plugins
+      plugin_classes = ObjectSpace.each_object(Class).select { |klass| klass < Danger::Plugin }
+
+      @plugins = plugin_classes.map do |klass|
+        pluginn = klass.new(self)
+        next if pluginn.nil?
+
+        self.singleton_class.instance_eval { attr_reader pluginn.class.instance_name.to_sym }
+        instance_variable_set("@#{pluginn.class.instance_name}", pluginn)
+        pluginn
+      end
+      p "pluginsssss"
+      p @plugins.class
+    end
+
     # Iterates through the DSL's attributes, and table's the output
     def print_known_info
       rows = []

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -25,17 +25,15 @@ module Danger
     # a reference to this Dangerfile
     def init_plugins
       plugin_classes = ObjectSpace.each_object(Class).select { |klass| klass < Danger::Plugin }
-
       @plugins = plugin_classes.map do |klass|
-        pluginn = klass.new(self)
-        next if pluginn.nil?
+        plugin = klass.new(self)
+        next if plugin.nil?
 
-        self.singleton_class.instance_eval { attr_reader pluginn.class.instance_name.to_sym }
-        instance_variable_set("@#{pluginn.class.instance_name}", pluginn)
-        pluginn
+        name = plugin.class.instance_name
+        self.singleton_class.instance_eval { attr_reader name.to_sym }
+        instance_variable_set("@#{name}", plugin)
+        plugin
       end
-      p "pluginsssss"
-      p @plugins.class
     end
 
     # Iterates through the DSL's attributes, and table's the output

--- a/lib/danger/danger_core/dangerfile_dsl.rb
+++ b/lib/danger/danger_core/dangerfile_dsl.rb
@@ -139,25 +139,25 @@ module Danger
 
       # When an undefined method is called, we check to see if it's something
       # that the DSLs have, then starts looking at plugins support.
-      def method_missing(method_sym, *arguments, &_block)
+      def method_missing(method_sym, *_arguments, &_block)
         core_dsls.each do |dsl|
           if dsl.public_methods(false).include?(method_sym)
             return dsl.send(method_sym)
           end
         end
 
-        # Plugins
-        class_name = method_sym.to_s.danger_class
-        if Danger::Dangerfile::DSL.const_defined?(class_name)
-          plugin_ref = Danger::Dangerfile::DSL.const_get(class_name)
-          if plugin_ref < Plugin
-            plugin_ref.new(self).run(*arguments)
-          else
-            raise "'#{method_sym}' is not a valid danger plugin".red
-          end
-        else
-          raise "Unknown method '#{method_sym}', please check out the documentation for available plugins".red
-        end
+        # # Plugins
+        # class_name = method_sym.to_s.danger_class
+        # if Danger::Dangerfile::DSL.const_defined?(class_name)
+        #   plugin_ref = Danger::Dangerfile::DSL.const_get(class_name)
+        #   if plugin_ref < Plugin
+        #     plugin_ref.new(self).run(*arguments)
+        #   else
+        #     raise "'#{method_sym}' is not a valid danger plugin".red
+        #   end
+        # else
+        #   raise "Unknown method '#{method_sym}', please check out the documentation for available plugins".red
+        # end
       end
 
       def load_default_plugins

--- a/lib/danger/plugin_support/plugin.rb
+++ b/lib/danger/plugin_support/plugin.rb
@@ -1,25 +1,17 @@
 module Danger
-  class Dangerfile
-    module DSL
-      class Plugin
-        def initialize(dsl)
-          @dsl = dsl
-        end
+  class Plugin
+    def initialize(dangerfile)
+      @dangerfile = dangerfile
+    end
 
-        # Since we have a reference to the DSL containing all the information
-        # We need to redirect the self calls to the DSL
-        def method_missing(method_sym, *arguments, &_block)
-          @dsl.send(method_sym, *arguments)
-        end
+    def self.instance_name
+      self.to_s.gsub("Danger", "").danger_underscore.split('/').last
+    end
 
-        def run
-          raise "run method must be implemented"
-        end
-
-        def self.description
-          "Add plugin description here"
-        end
-      end
+    # Since we have a reference to the Dangerfile containing all the information
+    # We need to redirect the self calls to the Dangerfile
+    def method_missing(method_sym, *arguments, &_block)
+      @dangerfile.send(method_sym, *arguments)
     end
   end
 end

--- a/spec/dangerfile_spec.rb
+++ b/spec/dangerfile_spec.rb
@@ -107,18 +107,17 @@ describe Danger::Dangerfile do
   describe 'initializing plugins' do
     it 'should add a plugin to the @plugins array' do
       class DangerTestPlugin < Danger::Plugin; end
-      # allow(Danger::Plugin).to receive(:descendants).and_return([DangerTestPlugin])
+      allow(ObjectSpace).to receive(:each_object).and_return([DangerTestPlugin])
       dm = Danger::Dangerfile.new
       allow(dm).to receive(:core_dsls).and_return([])
       dm.init_plugins
 
-      puts dm.instance_variable_get('@plugins')
       expect(dm.instance_variable_get('@plugins').length).to eq(1)
     end
 
     it 'should add an instance variable to the dangerfile' do
       class DangerTestPlugin < Danger::Plugin; end
-      # allow(Danger::Plugin).to receive(:descendants).and_return([DangerTestPlugin])
+      allow(ObjectSpace).to receive(:each_object).and_return([DangerTestPlugin])
       dm = Danger::Dangerfile.new
       allow(dm).to receive(:core_dsls).and_return([])
       dm.init_plugins

--- a/spec/dangerfile_spec.rb
+++ b/spec/dangerfile_spec.rb
@@ -103,4 +103,28 @@ describe Danger::Dangerfile do
       dm.parse file.path
     end
   end
+
+  describe 'initializing plugins' do
+    it 'should add a plugin to the @plugins array' do
+      class DangerTestPlugin < Danger::Plugin; end
+      # allow(Danger::Plugin).to receive(:descendants).and_return([DangerTestPlugin])
+      dm = Danger::Dangerfile.new
+      allow(dm).to receive(:core_dsls).and_return([])
+      dm.init_plugins
+
+      puts dm.instance_variable_get('@plugins')
+      expect(dm.instance_variable_get('@plugins').length).to eq(1)
+    end
+
+    it 'should add an instance variable to the dangerfile' do
+      class DangerTestPlugin < Danger::Plugin; end
+      # allow(Danger::Plugin).to receive(:descendants).and_return([DangerTestPlugin])
+      dm = Danger::Dangerfile.new
+      allow(dm).to receive(:core_dsls).and_return([])
+      dm.init_plugins
+
+      expect { dm.test_plugin }.to_not raise_error
+      expect(dm.test_plugin.class).to eq(DangerTestPlugin)
+    end
+  end
 end

--- a/spec/fixtures/plugins/example_exact_path.rb
+++ b/spec/fixtures/plugins/example_exact_path.rb
@@ -3,7 +3,7 @@ module Danger
     module DSL
       class ExampleExactPath < Plugin
         def run
-          return "Hi there exact 🎉"
+          return "Hi there exact"
         end
 
         def self.description

--- a/spec/fixtures/plugins/example_globbing.rb
+++ b/spec/fixtures/plugins/example_globbing.rb
@@ -3,7 +3,7 @@ module Danger
     module DSL
       class ExampleGlobbing < Plugin
         def run
-          return "Hi there globbing 🎉"
+          return "Hi there globbing"
         end
 
         def self.description

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -1,66 +1,66 @@
 require 'danger/danger_core/environment_manager'
 
-describe Danger::Dangerfile::DSL do
-  describe "#import" do
-    before do
-      file = make_temp_file("")
-      @dm = Danger::Dangerfile.new
-      @dm.env = Danger::EnvironmentManager.new({ "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true", "TRAVIS_REPO_SLUG" => "KrauseFx/fastlane", "TRAVIS_PULL_REQUEST" => "12" })
-      @dm.parse(file.path)
-    end
+# describe Danger::Dangerfile::DSL do
+#   describe "#import" do
+#     before do
+#       file = make_temp_file("")
+#       @dm = Danger::Dangerfile.new
+#       @dm.env = Danger::EnvironmentManager.new({ "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true", "TRAVIS_REPO_SLUG" => "KrauseFx/fastlane", "TRAVIS_PULL_REQUEST" => "12" })
+#       @dm.parse(file.path)
+#     end
 
-    describe "#import_local" do
-      it "supports exact paths" do
-        plugin_name = "ExampleExactPath"
-        expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(false)
-        expect(@dm.import("spec/fixtures/plugins/example_exact_path.rb")).to eq(["spec/fixtures/plugins/example_exact_path.rb"])
-        expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(true)
-        expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleExactPath)
+#     describe "#import_local" do
+#       it "supports exact paths" do
+#         plugin_name = "ExampleExactPath"
+#         expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(false)
+#         expect(@dm.import("spec/fixtures/plugins/example_exact_path.rb")).to eq(["spec/fixtures/plugins/example_exact_path.rb"])
+#         expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(true)
+#         expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleExactPath)
 
-        expect(@dm.example_exact_path).to eq("Hi there exact 🎉")
-      end
+#         expect(@dm.example_exact_path).to eq("Hi there exact 🎉")
+#       end
 
-      it "supports file globbing" do
-        plugin_name = "ExampleGlobbing"
-        expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(false)
-        expect(@dm.import("spec/fixtures/plugins/*globbing*.rb")).to eq(["spec/fixtures/plugins/example_globbing.rb"])
-        expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(true)
-        expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleGlobbing)
+#       it "supports file globbing" do
+#         plugin_name = "ExampleGlobbing"
+#         expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(false)
+#         expect(@dm.import("spec/fixtures/plugins/*globbing*.rb")).to eq(["spec/fixtures/plugins/example_globbing.rb"])
+#         expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(true)
+#         expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleGlobbing)
 
-        expect(@dm.example_globbing).to eq("Hi there globbing 🎉")
-      end
+#         expect(@dm.example_globbing).to eq("Hi there globbing 🎉")
+#       end
 
-      it "raises an error when calling a plugin that's not a subclass of action" do
-        plugin_name = "ExampleBroken"
-        expect(@dm.import("spec/fixtures/plugins/example_broken.rb")).to eq(["spec/fixtures/plugins/example_broken.rb"])
-        expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleBroken)
+#       it "raises an error when calling a plugin that's not a subclass of action" do
+#         plugin_name = "ExampleBroken"
+#         expect(@dm.import("spec/fixtures/plugins/example_broken.rb")).to eq(["spec/fixtures/plugins/example_broken.rb"])
+#         expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleBroken)
 
-        expect do
-          @dm.example_broken
-        end.to raise_error("'example_broken' is not a valid danger plugin".red)
-      end
-    end
+#         expect do
+#           @dm.example_broken
+#         end.to raise_error("'example_broken' is not a valid danger plugin".red)
+#       end
+#     end
 
-    describe "#import_url" do
-      it "downloads a remote .rb file" do
-        url = "https://krausefx.com/example_remote"
-        stub_request(:get, "https://krausefx.com/example_remote.rb").
-          to_return(status: 200, body: File.read("spec/fixtures/plugins/example_remote.rb"))
+#     describe "#import_url" do
+#       it "downloads a remote .rb file" do
+#         url = "https://krausefx.com/example_remote"
+#         stub_request(:get, "https://krausefx.com/example_remote.rb").
+#           to_return(status: 200, body: File.read("spec/fixtures/plugins/example_remote.rb"))
 
-        plugin_name = "ExampleRemote"
-        expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(false)
-        expect(@dm.import(url).last).to end_with("/temporary_remote_action.rb") # fixed name when downloading
-        expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(true)
-        expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleRemote)
+#         plugin_name = "ExampleRemote"
+#         expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(false)
+#         expect(@dm.import(url).last).to end_with("/temporary_remote_action.rb") # fixed name when downloading
+#         expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(true)
+#         expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleRemote)
 
-        expect(@dm.example_remote).to eq("Hi there remote 🎉")
-      end
+#         expect(@dm.example_remote).to eq("Hi there remote 🎉")
+#       end
 
-      it "rejects unencrypted plugins" do
-        expect do
-          @dm.import("http://unecnrypted.org")
-        end.to raise_error("URL is not https, for security reasons `danger` only supports encrypted requests")
-      end
-    end
-  end
-end
+#       it "rejects unencrypted plugins" do
+#         expect do
+#           @dm.import("http://unecnrypted.org")
+#         end.to raise_error("URL is not https, for security reasons `danger` only supports encrypted requests")
+#       end
+#     end
+#   end
+# end

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -17,7 +17,7 @@ require 'danger/danger_core/environment_manager'
 #         expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(true)
 #         expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleExactPath)
 
-#         expect(@dm.example_exact_path).to eq("Hi there exact 🎉")
+#         expect(@dm.example_exact_path).to eq("Hi there exact")
 #       end
 
 #       it "supports file globbing" do
@@ -27,7 +27,7 @@ require 'danger/danger_core/environment_manager'
 #         expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(true)
 #         expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleGlobbing)
 
-#         expect(@dm.example_globbing).to eq("Hi there globbing 🎉")
+#         expect(@dm.example_globbing).to eq("Hi there globbing")
 #       end
 
 #       it "raises an error when calling a plugin that's not a subclass of action" do
@@ -53,7 +53,7 @@ require 'danger/danger_core/environment_manager'
 #         expect(Danger::Dangerfile::DSL.const_defined?(plugin_name)).to eq(true)
 #         expect(Danger::Dangerfile::DSL.const_get(plugin_name)).to eq(Danger::Dangerfile::DSL::ExampleRemote)
 
-#         expect(@dm.example_remote).to eq("Hi there remote 🎉")
+#         expect(@dm.example_remote).to eq("Hi there remote")
 #       end
 
 #       it "rejects unencrypted plugins" do

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,15 @@
+describe Danger::Plugin do
+  it 'creates an instance name based on the class name' do
+    class DangerTestPlugin < Danger::Plugin; end
+    expect(DangerTestPlugin.instance_name).to eq("test_plugin")
+  end
+
+  it 'should forward unknown method calls to the dangerfile' do
+    class DangerTestPlugin < Danger::Plugin; end
+    class DangerFileMock; attr_accessor :pants; end
+    plugin = DangerTestPlugin.new(DangerFileMock.new)
+    expect do
+      plugin.pants
+    end.to_not raise_error
+  end
+end


### PR DESCRIPTION
- disabled old style plugins
- create `Danger::Plugin`, that is a base class for plugins (look at https://github.com/dbgrandi/danger-proselint/blob/master/lib/danger_plugin.rb for what it should look like, but be aware that it has not been tested/integrated yet)
- added `init_plugins` method to `Dangerfile` that adds plugins as instance variables to a Dangerfile, allowing them to extend the DSL
- added some specs
- disabled some other specs

Rubocop will fail because some of the commented out specs have emoji, and it does not allow emoji in comments. This is known and should be okay.

Note: this will break all existing plugins.

![fde5db0aef0](https://cloud.githubusercontent.com/assets/4033/15635869/db8612a6-25b9-11e6-811b-359af6bbbac3.gif)