### PR TITLE
Support for other code collaboration tools than GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Support multiple Danger instances with `--dangerId` - marcelofabri
+* Add base request source so services other than GitHub could be used with Danger. - justMaku
 
 ## 0.8.1
 

--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -17,6 +17,10 @@ module Danger
 
         self.pull_request_id = env["BUILDKITE_PULL_REQUEST"]
       end
+
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
     end
   end
 end

--- a/lib/danger/ci_source/ci_source.rb
+++ b/lib/danger/ci_source/ci_source.rb
@@ -2,7 +2,15 @@ module Danger
   module CISource
     # "abstract" CI class
     class CI
-      attr_accessor :repo_slug, :pull_request_id
+      attr_accessor :repo_slug, :pull_request_id, :supported_request_sources
+
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
+
+      def supports?(request_source)
+        supported_request_sources.include? request_source
+      end
 
       def self.validates?(_env)
         false

--- a/lib/danger/ci_source/ci_source.rb
+++ b/lib/danger/ci_source/ci_source.rb
@@ -5,7 +5,7 @@ module Danger
       attr_accessor :repo_slug, :pull_request_id, :supported_request_sources
 
       def supported_request_sources
-        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+        @supported_request_sources ||= []
       end
 
       def supports?(request_source)

--- a/lib/danger/ci_source/ci_source.rb
+++ b/lib/danger/ci_source/ci_source.rb
@@ -5,7 +5,7 @@ module Danger
       attr_accessor :repo_slug, :pull_request_id, :supported_request_sources
 
       def supported_request_sources
-        @supported_request_sources ||= []
+        raise "CISource subclass must specify the supported request sources"
       end
 
       def supports?(request_source)

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -12,6 +12,10 @@ module Danger
         return !env["CIRCLE_PROJECT_USERNAME"].nil? && !env["CIRCLE_PROJECT_REPONAME"].nil?
       end
 
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
+
       def client
         @client ||= CircleAPI.new(@circle_token)
       end

--- a/lib/danger/ci_source/drone.rb
+++ b/lib/danger/ci_source/drone.rb
@@ -7,6 +7,10 @@ module Danger
         return !env["DRONE"].nil?
       end
 
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
+
       def initialize(env)
         self.repo_slug = env["DRONE_REPO"]
         if env["DRONE_PULL_REQUEST"].to_i > 0

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -8,6 +8,10 @@ module Danger
         return !env["ghprbPullId"].nil? && !env["GIT_URL"].nil?
       end
 
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
+
       def initialize(env)
         repo = env["GIT_URL"]
         unless repo.nil?

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -20,6 +20,10 @@ module Danger
         git.exec command
       end
 
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
+
       def initialize(env = {})
         github_host = env["DANGER_GITHUB_HOST"] || "github.com"
 

--- a/lib/danger/ci_source/semaphore.rb
+++ b/lib/danger/ci_source/semaphore.rb
@@ -7,6 +7,10 @@ module Danger
         return !env["SEMAPHORE"].nil?
       end
 
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
+
       def initialize(env)
         self.repo_slug = env["SEMAPHORE_REPO_SLUG"]
         if env["PULL_REQUEST_NUMBER"].to_i > 0

--- a/lib/danger/ci_source/travis.rb
+++ b/lib/danger/ci_source/travis.rb
@@ -8,6 +8,10 @@ module Danger
         return !env["HAS_JOSH_K_SEAL_OF_APPROVAL"].nil?
       end
 
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
+
       def initialize(env)
         self.repo_slug = env["TRAVIS_REPO_SLUG"]
         # from https://docs.travis-ci.com/user/pull-requests, as otherwise it's "false"

--- a/lib/danger/ci_source/xcode_server.rb
+++ b/lib/danger/ci_source/xcode_server.rb
@@ -7,6 +7,10 @@ module Danger
         return !env["XCS_BOT_NAME"].nil?
       end
 
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
+
       def initialize(env)
         bot_name = env["XCS_BOT_NAME"]
         return if bot_name.nil?

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -49,8 +49,8 @@ module Danger
           dm.env.ensure_danger_branches_are_setup
 
           # Offer the chance for a user to specify a branch through the command line
-          ci_base = @base || dm.env.danger_head_branch
-          ci_head = @head || dm.env.danger_base_branch
+          ci_base = @base || EnvironmentManager.danger_base_branch
+          ci_head = @head || EnvironmentManager.danger_head_branch
           dm.env.scm.diff_for_folder(".", from: ci_base, to: ci_head)
 
           dm.parse Pathname.new(@dangerfile_path)

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -22,12 +22,10 @@ module Danger
 
       raise "Could not find a CI source".red unless self.ci_source
 
-      RequestSources.constants.each do |symb|
-        c = RequestSources.const_get(symb)
-        next unless c.kind_of?(Class)
-        next unless self.ci_source.supports?(c)
+      RequestSources::RequestSource.available_request_sources.each do |klass|
+        next unless self.ci_source.supports?(klass)
 
-        request_source = c.new(self.ci_source, ENV)
+        request_source = klass.new(self.ci_source, ENV)
         next unless request_source.validates?
         self.request_source = request_source
       end

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -40,7 +40,7 @@ module Danger
     end
 
     def fill_environment_vars
-      self.request_source.fetch_details
+      request_source.fetch_details
     end
 
     def ensure_danger_branches_are_setup

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -4,7 +4,7 @@ module Danger
   class DangerfileGitHubPlugin < Plugin
     def initialize(dangerfile)
       super(dangerfile)
-      return nil unless dangerfile.env.request_source.class == Danger::GitHub
+      return nil unless dangerfile.env.request_source.class == Danger::RequestSources::GitHub
 
       @github = dangerfile.env.request_source
     end

--- a/lib/danger/request_source/github.rb
+++ b/lib/danger/request_source/github.rb
@@ -126,7 +126,7 @@ module Danger
         end
       end
 
-    # Get rid of the previously posted comment, to only have the latest one
+      # Get rid of the previously posted comment, to only have the latest one
       def delete_old_comments!(except: nil, danger_id: 'danger')
         issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
         issues.each do |issue|

--- a/lib/danger/request_source/github.rb
+++ b/lib/danger/request_source/github.rb
@@ -3,203 +3,225 @@ require 'octokit'
 require 'redcarpet'
 
 module Danger
-  class GitHub
-    attr_accessor :ci_source, :pr_json, :issue_json, :environment, :support_tokenless_auth, :ignored_violations, :github_host
+  module RequestSources
+    class GitHub < RequestSource
+      attr_accessor :pr_json, :issue_json, :support_tokenless_auth
 
-    def initialize(ci_source, environment)
-      self.ci_source = ci_source
-      self.environment = environment
-      self.support_tokenless_auth = false
+      def initialize(ci_source, environment)
+        self.ci_source = ci_source
+        self.environment = environment
+        self.support_tokenless_auth = false
 
-      Octokit.auto_paginate = true
-      @token = @environment["DANGER_GITHUB_API_TOKEN"]
-      self.github_host = @environment["DANGER_GITHUB_HOST"] || "github.com"
-      if @environment["DANGER_GITHUB_API_HOST"]
-        Octokit.api_endpoint = @environment["DANGER_GITHUB_API_HOST"]
-      end
-    end
-
-    def client
-      raise "No API token given, please provide one using `DANGER_GITHUB_API_TOKEN`" if !@token && !support_tokenless_auth
-      @client ||= Octokit::Client.new(access_token: @token)
-    end
-
-    def markdown_parser
-      @markdown_parser ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML, no_intra_emphasis: true)
-    end
-
-    def fetch_details
-      self.pr_json = client.pull_request(ci_source.repo_slug, ci_source.pull_request_id)
-      fetch_issue_details(self.pr_json)
-      self.ignored_violations = ignored_violations_from_pr(self.pr_json)
-    end
-
-    def ignored_violations_from_pr(pr_json)
-      pr_body = pr_json[:body]
-      return [] if pr_body.nil?
-      pr_body.chomp.scan(/>\s*danger\s*:\s*ignore\s*"(.*)"/i).flatten
-    end
-
-    def fetch_issue_details(pr_json)
-      href = pr_json[:_links][:issue][:href]
-      self.issue_json = client.get(href)
-    end
-
-    # Sending data to GitHub
-    def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: 'danger')
-      comment_result = {}
-
-      issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
-      editable_issues = issues.reject { |issue| issue[:body].include?("generated_by_#{danger_id}") == false }
-
-      if editable_issues.empty?
-        previous_violations = {}
-      else
-        comment = editable_issues.first[:body]
-        previous_violations = parse_comment(comment)
-      end
-
-      if previous_violations.empty? && (warnings + errors + messages + markdowns).empty?
-        # Just remove the comment, if there's nothing to say.
-        delete_old_comments!(danger_id: danger_id)
-      else
-        body = generate_comment(warnings: warnings,
-                                  errors: errors,
-                                messages: messages,
-                               markdowns: markdowns,
-                     previous_violations: previous_violations,
-                               danger_id: danger_id)
-
-        if editable_issues.empty?
-          comment_result = client.add_comment(ci_source.repo_slug, ci_source.pull_request_id, body)
-        else
-          original_id = editable_issues.first[:id]
-          comment_result = client.update_comment(ci_source.repo_slug, original_id, body)
+        Octokit.auto_paginate = true
+        @token = @environment["DANGER_GITHUB_API_TOKEN"]
+        if @environment["DANGER_GITHUB_API_HOST"]
+          Octokit.api_endpoint = @environment["DANGER_GITHUB_API_HOST"]
         end
       end
 
-      # Now, set the pull request status.
-      # Note: this can terminate the entire process.
-      submit_pull_request_status!(warnings: warnings,
-                                    errors: errors,
-                               details_url: comment_result['html_url'])
-    end
-
-    def submit_pull_request_status!(warnings: nil, errors: nil, details_url: nil)
-      status = (errors.count == 0 ? 'success' : 'failure')
-      message = generate_github_description(warnings: warnings, errors: errors)
-      client.create_status(ci_source.repo_slug, latest_pr_commit_ref, status, {
-        description: message,
-        context: "danger/danger",
-        target_url: details_url
-      })
-    rescue
-      # This usually means the user has no commit access to this repo
-      # That's always the case for open source projects where you can only
-      # use a read-only GitHub account
-      if errors.count > 0
-        # We need to fail the actual build here
-        abort("\nDanger has failed this build. \nFound #{'error'.danger_pluralize(errors.count)} and I don't have write access to the PR set a PR status.")
-      else
-        puts message
+      def scm
+        @scm ||= GitRepo.new
       end
-    end
+
+      def host
+        @host = @environment["DANGER_GITHUB_HOST"] || "github.com"
+      end
+
+      def client
+        raise "No API token given, please provide one using `DANGER_GITHUB_API_TOKEN`" if !@token && !support_tokenless_auth
+        @client ||= Octokit::Client.new(access_token: @token)
+      end
+
+      def markdown_parser
+        @markdown_parser ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML, no_intra_emphasis: true)
+      end
+
+      def setup_danger_branches
+        # we can use a github specific feature here:
+        pull_id = self.ci_source.pull_request_id
+        test_branch = self.pr_json[:base][:sha]
+
+        # Next, we want to ensure that we have a version of the current branch at a known location
+        self.scm.exec "branch #{EnvironmentManager.danger_base_branch} #{test_branch}"
+
+        # OK, so we want to ensure that we have a known head branch, this will always represent
+        # the head of the PR ( e.g. the most recent commit that will be merged. )
+        self.scm.exec "fetch origin +refs/pull/#{pull_id}/merge:#{EnvironmentManager.danger_head_branch}"
+      end
+
+      def fetch_details
+        self.pr_json = client.pull_request(ci_source.repo_slug, ci_source.pull_request_id)
+        fetch_issue_details(self.pr_json)
+        self.ignored_violations = ignored_violations_from_pr(self.pr_json)
+      end
+
+      def ignored_violations_from_pr(pr_json)
+        pr_body = pr_json[:body]
+        return [] if pr_body.nil?
+        pr_body.chomp.scan(/>\s*danger\s*:\s*ignore\s*"(.*)"/i).flatten
+      end
+
+      def fetch_issue_details(pr_json)
+        href = pr_json[:_links][:issue][:href]
+        self.issue_json = client.get(href)
+      end
+
+      # Sending data to GitHub
+      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: 'danger')
+        comment_result = {}
+
+        issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
+        editable_issues = issues.reject { |issue| issue[:body].include?("generated_by_#{danger_id}") == false }
+
+        if editable_issues.empty?
+          previous_violations = {}
+        else
+          comment = editable_issues.first[:body]
+          previous_violations = parse_comment(comment)
+        end
+
+        if previous_violations.empty? && (warnings + errors + messages + markdowns).empty?
+          # Just remove the comment, if there's nothing to say.
+          delete_old_comments!(danger_id: danger_id)
+        else
+          body = generate_comment(warnings: warnings,
+                                    errors: errors,
+                                  messages: messages,
+                                 markdowns: markdowns,
+                       previous_violations: previous_violations,
+                                 danger_id: danger_id)
+
+          if editable_issues.empty?
+            comment_result = client.add_comment(ci_source.repo_slug, ci_source.pull_request_id, body)
+          else
+            original_id = editable_issues.first[:id]
+            comment_result = client.update_comment(ci_source.repo_slug, original_id, body)
+          end
+        end
+
+        # Now, set the pull request status.
+        # Note: this can terminate the entire process.
+        submit_pull_request_status!(warnings: warnings,
+                                      errors: errors,
+                                 details_url: comment_result['html_url'])
+      end
+
+      def submit_pull_request_status!(warnings: nil, errors: nil, details_url: nil)
+        status = (errors.count == 0 ? 'success' : 'failure')
+        message = generate_github_description(warnings: warnings, errors: errors)
+        client.create_status(ci_source.repo_slug, latest_pr_commit_ref, status, {
+          description: message,
+          context: "danger/danger",
+          target_url: details_url
+        })
+      rescue
+        # This usually means the user has no commit access to this repo
+        # That's always the case for open source projects where you can only
+        # use a read-only GitHub account
+        if errors.count > 0
+          # We need to fail the actual build here
+          abort("\nDanger has failed this build. \nFound #{'error'.danger_pluralize(errors.count)} and I don't have write access to the PR set a PR status.")
+        else
+          puts message
+        end
+      end
 
     # Get rid of the previously posted comment, to only have the latest one
-    def delete_old_comments!(except: nil, danger_id: 'danger')
-      issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
-      issues.each do |issue|
-        next unless issue[:body].include?("generated_by_#{danger_id}")
-        next if issue[:id] == except
-        client.delete_comment(ci_source.repo_slug, issue[:id])
-      end
-    end
-
-    def random_compliment
-      compliment = ["Well done.", "Congrats.", "Woo!",
-                    "Yay.", "Jolly good show.", "Good on 'ya.", "Nice work."]
-      compliment.sample
-    end
-
-    def generate_github_description(warnings: nil, errors: nil)
-      if errors.empty? && warnings.empty?
-        return "All green. #{random_compliment}"
-      else
-        message = "⚠ "
-        message += "#{'Error'.danger_pluralize(errors.count)}. " unless errors.empty?
-        message += "#{'Warning'.danger_pluralize(warnings.count)}. " unless warnings.empty?
-        message += "Don't worry, everything is fixable."
-        return message
-      end
-    end
-
-    def generate_comment(warnings: [], errors: [], messages: [], markdowns: [], previous_violations: {}, danger_id: 'danger')
-      require 'erb'
-
-      md_template = File.join(Danger.gem_path, "lib/danger/comment_generators/github.md.erb")
-
-      # erb: http://www.rrn.dk/rubys-erb-templating-system
-      # for the extra args: http://stackoverflow.com/questions/4632879/erb-template-removing-the-trailing-line
-      @tables = [
-        table("Error", "no_entry_sign", errors, previous_violations),
-        table("Warning", "warning", warnings, previous_violations),
-        table("Message", "book", messages, previous_violations)
-      ]
-      @markdowns = markdowns
-      @danger_id = danger_id
-
-      return ERB.new(File.read(md_template), 0, "-").result(binding)
-    end
-
-    def table(name, emoji, violations, all_previous_violations)
-      content = violations.map { |v| process_markdown(v) }
-      kind = table_kind_from_title(name)
-      previous_violations = all_previous_violations[kind] || []
-      messages = content.map(&:message)
-      resolved_violations = previous_violations.reject { |s| messages.include? s }
-      count = content.count
-      { name: name, emoji: emoji, content: content, resolved: resolved_violations, count: count }
-    end
-
-    def parse_comment(comment)
-      tables = parse_tables_from_comment(comment)
-      violations = {}
-      tables.each do |table|
-        next unless table =~ %r{<th width="100%"(.*?)</th>}im
-        title = Regexp.last_match(1)
-        kind = table_kind_from_title(title)
-        next unless kind
-
-        violations[kind] = violations_from_table(table)
+      def delete_old_comments!(except: nil, danger_id: 'danger')
+        issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
+        issues.each do |issue|
+          next unless issue[:body].include?("generated_by_#{danger_id}")
+          next if issue[:id] == except
+          client.delete_comment(ci_source.repo_slug, issue[:id])
+        end
       end
 
-      violations.reject { |_, v| v.empty? }
-    end
-
-    def violations_from_table(table)
-      regex = %r{<td data-sticky="true">(?:<del>)?(.*?)(?:</del>)?\s*</td>}im
-      table.scan(regex).flatten.map(&:strip)
-    end
-
-    def table_kind_from_title(title)
-      if title =~ /error/i
-        :error
-      elsif title =~ /warning/i
-        :warning
-      elsif title =~ /message/i
-        :message
+      def random_compliment
+        compliment = ["Well done.", "Congrats.", "Woo!",
+                      "Yay.", "Jolly good show.", "Good on 'ya.", "Nice work."]
+        compliment.sample
       end
-    end
 
-    def parse_tables_from_comment(comment)
-      comment.split('</table>')
-    end
+      def generate_github_description(warnings: nil, errors: nil)
+        if errors.empty? && warnings.empty?
+          return "All green. #{random_compliment}"
+        else
+          message = "⚠ "
+          message += "#{'Error'.danger_pluralize(errors.count)}. " unless errors.empty?
+          message += "#{'Warning'.danger_pluralize(warnings.count)}. " unless warnings.empty?
+          message += "Don't worry, everything is fixable."
+          return message
+        end
+      end
 
-    def process_markdown(violation)
-      html = markdown_parser.render(violation.message)
-      match = html.match(%r{^<p>(.*)</p>$})
-      message = match.nil? ? html : match.captures.first
-      Violation.new(message, violation.sticky)
+      def generate_comment(warnings: [], errors: [], messages: [], markdowns: [], previous_violations: {}, danger_id: 'danger')
+        require 'erb'
+
+        md_template = File.join(Danger.gem_path, "lib/danger/comment_generators/github.md.erb")
+
+        # erb: http://www.rrn.dk/rubys-erb-templating-system
+        # for the extra args: http://stackoverflow.com/questions/4632879/erb-template-removing-the-trailing-line
+        @tables = [
+          table("Error", "no_entry_sign", errors, previous_violations),
+          table("Warning", "warning", warnings, previous_violations),
+          table("Message", "book", messages, previous_violations)
+        ]
+        @markdowns = markdowns
+        @danger_id = danger_id
+
+        return ERB.new(File.read(md_template), 0, "-").result(binding)
+      end
+
+      def table(name, emoji, violations, all_previous_violations)
+        content = violations.map { |v| process_markdown(v) }
+        kind = table_kind_from_title(name)
+        previous_violations = all_previous_violations[kind] || []
+        messages = content.map(&:message)
+        resolved_violations = previous_violations.reject { |s| messages.include? s }
+        count = content.count
+        { name: name, emoji: emoji, content: content, resolved: resolved_violations, count: count }
+      end
+
+      def parse_comment(comment)
+        tables = parse_tables_from_comment(comment)
+        violations = {}
+        tables.each do |table|
+          next unless table =~ %r{<th width="100%"(.*?)</th>}im
+          title = Regexp.last_match(1)
+          kind = table_kind_from_title(title)
+          next unless kind
+
+          violations[kind] = violations_from_table(table)
+        end
+
+        violations.reject { |_, v| v.empty? }
+      end
+
+      def violations_from_table(table)
+        regex = %r{<td data-sticky="true">(?:<del>)?(.*?)(?:</del>)?\s*</td>}im
+        table.scan(regex).flatten.map(&:strip)
+      end
+
+      def table_kind_from_title(title)
+        if title =~ /error/i
+          :error
+        elsif title =~ /warning/i
+          :warning
+        elsif title =~ /message/i
+          :message
+        end
+      end
+
+      def parse_tables_from_comment(comment)
+        comment.split('</table>')
+      end
+
+      def process_markdown(violation)
+        html = markdown_parser.render(violation.message)
+        match = html.match(%r{^<p>(.*)</p>$})
+        message = match.nil? ? html : match.captures.first
+        Violation.new(message, violation.sticky)
+      end
     end
   end
 end

--- a/lib/danger/request_source/request_source.rb
+++ b/lib/danger/request_source/request_source.rb
@@ -1,0 +1,39 @@
+module Danger
+  module RequestSources
+    class RequestSource
+      attr_accessor :ci_source, :environment, :scm, :host, :ignored_violations
+
+      def initialize(_ci_source, _environment)
+        raise "Subclass and overwrite initialize"
+      end
+
+      def validates?
+        !!self.scm.origins.match(%r{#{Regexp.escape self.host}(:|/)(?<repo_slug>.+/.+?)(?:\.git)?$})
+      end
+
+      def scm
+        @scm ||= nil
+      end
+
+      def host
+        @host ||= nil
+      end
+
+      def ignored_violations
+        @ignored_violations ||= []
+      end
+
+      def update_pull_request!(_warnings: [], _errors: [], _messages: [], _markdowns: [])
+        raise "Subclass and overwrite update_pull_request!"
+      end
+
+      def setup_danger_branches
+        raise "Subclass and overwrite setup_danger_branches"
+      end
+
+      def fetch_details
+        raise "Subclass and overwrite initialize"
+      end
+    end
+  end
+end

--- a/lib/danger/request_source/request_source.rb
+++ b/lib/danger/request_source/request_source.rb
@@ -3,6 +3,15 @@ module Danger
     class RequestSource
       attr_accessor :ci_source, :environment, :scm, :host, :ignored_violations
 
+      def self.inherited(child_class)
+        available_request_sources.add child_class
+        super
+      end
+
+      def self.available_request_sources
+        @available_request_sources ||= Set.new
+      end
+
       def initialize(_ci_source, _environment)
         raise "Subclass and overwrite initialize"
       end

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -15,5 +15,9 @@ module Danger
     def exec(string)
       `git #{string}`.strip
     end
+
+    def origins
+      exec "remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-"
+    end
   end
 end

--- a/rake/dsl_generator.rb
+++ b/rake/dsl_generator.rb
@@ -18,16 +18,14 @@ def public_api_methods
   files = [
     "lib/danger/danger_core/dangerfile_dsl.rb",
     "lib/danger/scm_source/git_repo.rb",
-    "lib/danger/request_source/github.rb"
   ]
   docs = YARD::Registry.load(files, true)
 
   danger_dsl = docs.at("Danger::Dangerfile::DSL").meths(visibility: :public)
-  github_dsls = docs.at("Danger::GitHubDSL").meths(visibility: :public)
   git_dsls = docs.at("Danger::GitRepoDSL").meths(visibility: :public)
 
   # Remove init functions
-  (danger_dsl + git_dsls + github_dsls).reject { |m| m.name == :initialize }
+  (danger_dsl + git_dsls).reject { |m| m.name == :initialize }
 end
 
 def loop_group(methods)

--- a/rake/dsl_generator.rb
+++ b/rake/dsl_generator.rb
@@ -17,7 +17,7 @@ def public_api_methods
   require 'yard'
   files = [
     "lib/danger/danger_core/dangerfile_dsl.rb",
-    "lib/danger/scm_source/git_repo.rb",
+    "lib/danger/scm_source/git_repo.rb"
   ]
   docs = YARD::Registry.load(files, true)
 

--- a/spec/lib/danger/ci_sources/ci_source.rb
+++ b/spec/lib/danger/ci_sources/ci_source.rb
@@ -1,0 +1,18 @@
+require 'danger/ci_source/ci_source'
+
+describe Danger::CISource::Buildkite do
+  before do
+    @request_source = Danger::RequestSources::GitHub
+    @ci_source = stub_ci
+  end
+
+  it "fails if given request source is not supported" do
+    allow(@ci_source).to receive(:supported_request_sources).and_return([])
+    expect(@ci_source.supports?(@request_source)).to be false
+  end
+
+  it "supports a supported request source" do
+    allow(@ci_source).to receive(:supported_request_sources).and_return([Danger::RequestSources::GitHub])
+    expect(@ci_source.supports?(@request_source)).to be true
+  end
+end

--- a/spec/lib/danger/ci_sources/github_spec.rb
+++ b/spec/lib/danger/ci_sources/github_spec.rb
@@ -1,27 +1,27 @@
 # coding: utf-8
-require 'danger/request_source/github'
+require 'danger/request_source/request_source'
 require 'danger/ci_source/circle'
 require 'danger/ci_source/travis'
 require 'danger/danger_core/violation'
 
-describe Danger::GitHub do
+describe Danger::RequestSources::GitHub do
   describe "the github host" do
     it 'sets a default GitHub host' do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi" }
-      g = Danger::GitHub.new(stub_ci, gh_env)
+      g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
       expect(g.github_host).to eql("github.com")
     end
 
     it 'allows the GitHub host to be overridden' do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com" }
-      g = Danger::GitHub.new(stub_ci, gh_env)
+      g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
       expect(g.github_host).to eql("git.club-mateusa.com")
     end
 
     it 'allows the GitHub API host to be overridden' do
       api_endpoint = "https://git.club-mateusa.com/api/v3/"
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_API_HOST" => api_endpoint }
-      g = Danger::GitHub.new(stub_ci, gh_env)
+      g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
       expect(Octokit.api_endpoint).to eql(api_endpoint)
     end
   end

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -55,8 +55,11 @@ module Command
           { "rev-parse --quiet --verify danger_head" => "OK" },
           { "branch danger_base 704dc55988c6996f69b6873c2424be7d1de67bbe" => "" },
           { "fetch origin +refs/pull/800/merge:danger_head" => "" },
-          { "branch -D danger_base" => "" }
+          { "remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-" => "git@github.com:artsy/eigen.git" },
+          { "branch -D danger_base" => "" },
+          { "branch -D danger_head" => "" }
         ]
+
         git_commands.each do |command|
           allow(@git_mock).to receive(:exec).with(command.keys.first).and_return(command.values.first)
         end
@@ -80,6 +83,7 @@ module Command
           Dir.chdir dir do
             `git init`
             `git remote add origin git@github.com:artsy/eigen.git`
+
             File.write("Dangerfile", %{
               message "Hi"
               warn "OK"
@@ -89,7 +93,7 @@ module Command
               warn("ok", sticky: false)
               fail("not ok", sticky: false)
               message("hi", sticky: false)
-    })
+            })
 
             # This will call `abort` due to the fails in the Dangerfile
             expect { Danger::Runner.run([]) }.to raise_error(SystemExit)

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -18,6 +18,7 @@ module Command
       allow(ENV).to receive(:[]).with("TMP").and_return(nil)
       allow(ENV).to receive(:[]).with("TEMP").and_return(nil)
       allow(ENV).to receive(:[]).with("CLAIDE_DISABLE_AUTO_WRAP").and_return(nil)
+      allow(ENV).to receive(:[]).with("GEM_REQUIREMENT_DANGER").and_return(nil)
 
       # Mock out the octokit object with our fixtured data
       octokit_mock = Object

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -9,13 +9,13 @@ describe Danger::RequestSources::GitHub do
     it 'sets a default GitHub host' do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi" }
       g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
-      expect(g.github_host).to eql("github.com")
+      expect(g.host).to eql("github.com")
     end
 
     it 'allows the GitHub host to be overridden' do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com" }
       g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
-      expect(g.github_host).to eql("git.club-mateusa.com")
+      expect(g.host).to eql("git.club-mateusa.com")
     end
 
     it 'allows the GitHub API host to be overridden' do
@@ -29,7 +29,7 @@ describe Danger::RequestSources::GitHub do
   describe "valid server response" do
     before do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi" }
-      @g = Danger::GitHub.new(stub_ci, gh_env)
+      @g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
 
       pr_response = JSON.parse(fixture("pr_response"), symbolize_names: true)
       allow(@g.client).to receive(:pull_request).with("artsy/eigen", "800").and_return(pr_response)

--- a/spec/lib/danger/request_sources/request_source_spec.rb
+++ b/spec/lib/danger/request_sources/request_source_spec.rb
@@ -1,0 +1,34 @@
+require 'danger/request_source/github'
+
+describe Danger::RequestSources::RequestSource do
+  describe "the base request source" do
+    it 'validates when passed a corresponding repository' do
+      git_mock = Danger::GitRepo.new
+      allow(git_mock).to receive(:exec).with("remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-").and_return("git@github.com:artsy/eigen.git")
+
+      g = stub_request_source
+      g.scm = git_mock
+      expect(g.validates?).to be true
+    end
+
+    it 'validates when passed a corresponding repository with custom host' do
+      git_mock = Danger::GitRepo.new
+
+      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com" }
+      g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
+      g.scm = git_mock
+
+      allow(git_mock).to receive(:exec).with("remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-").and_return("git@git.club-mateusa.com:artsy/eigen.git")
+      expect(g.validates?).to be true
+    end
+
+    it 'doesn\'t validate when passed a wrong repository' do
+      git_mock = Danger::GitRepo.new
+      allow(git_mock).to receive(:exec).with("remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-").and_return("git@bitbucket.org:artsy/eigen.git")
+
+      g = stub_request_source
+      g.scm = git_mock
+      expect(g.validates?).to be false
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,20 +13,27 @@ def make_temp_file(contents)
   file
 end
 
-def stub_ci
-  env = { "CI_PULL_REQUEST" => "https://github.com/artsy/eigen/pull/800" }
-  Danger::CISource::CircleCI.new(env)
-end
-
-def testing_dangerfile
-  outer_env = {
+def stub_env
+  {
     "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
     "TRAVIS_PULL_REQUEST" => "800",
     "TRAVIS_REPO_SLUG" => "artsy/eigen",
     "TRAVIS_COMMIT_RANGE" => "759adcbd0d8f...13c4dc8bb61d",
     "DANGER_GITHUB_API_TOKEN" => "hi"
   }
-  env = Danger::EnvironmentManager.new(outer_env)
+end
+
+def stub_ci
+  env = { "CI_PULL_REQUEST" => "https://github.com/artsy/eigen/pull/800" }
+  Danger::CISource::CircleCI.new(env)
+end
+
+def stub_request_source
+  Danger::RequestSources::GitHub.new(stub_ci, stub_env)
+end
+
+def testing_dangerfile
+  env = Danger::EnvironmentManager.new(stub_env)
   dm = Danger::Dangerfile.new(env)
 end
 


### PR DESCRIPTION
This PR to implement #221 and establishes a base upon which support for other services (like BitBucket or GitLab) could be build. This doesn't solve the problem of #226, just separates it a little bit better. 

I tried to decouple current GitHub requirement as much as possible, but there still some parts of the code that will only work with GitHub (most notably: running danger locally). 

**Important note**: I'm not fluent in Ruby so there might be some beginner mistakes :) 