### PR TITLE
Messages don't need mapping when presenting status reports

### DIFF
--- a/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
@@ -66,7 +66,7 @@ module Danger
         errors: @errors.map(&:message).clone.freeze,
         warnings: @warnings.map(&:message).clone.freeze,
         messages: @messages.map(&:message).clone.freeze,
-        markdowns: @markdowns.map(&:message).clone.freeze
+        markdowns: @markdowns.map.clone.freeze
       }
     end
 


### PR DESCRIPTION
I had thought they were violations, but they weren't. Types.` /shrug`. I should improve the tests around this.
#trivial