### PR TITLE
Created a plugin documentation parser in Danger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for Drone CI = gabro
 * [BREAKING] Add initial support for more expressive and documented plugins. Breaks all existing plugins. - dbgrandi/orta
 * All core DSL attributes are handled via Danger Plugins - orta
+* Initial work on the Plugin -> JSON mapper - orta
 
 ## 0.7.4
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -24,7 +24,7 @@ end
 
 declared_trivial = (pr_title + pr_body).include?("#trivial") || !has_app_changes
 if !modified_files.include?("CHANGELOG.md") && !declared_trivial
-  fail "Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/danger/danger/blob/master/CHANGELOG.md)."
+  fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/danger/danger/blob/master/CHANGELOG.md).", sticky: false)
 end
 
 ### Oddly enough, it's quite possible to do some testing of Danger, inside Danger

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'octokit', '~> 4.2'
   spec.add_runtime_dependency 'redcarpet', '~> 3.3'
   spec.add_runtime_dependency 'terminal-table', '~> 1'
-
+  
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"

--- a/lib/danger/plugin_support/plugin_parser.rb
+++ b/lib/danger/plugin_support/plugin_parser.rb
@@ -1,0 +1,70 @@
+require 'yard'
+
+module Danger
+  class PluginParser
+    attr_accessor :registry
+
+    def initialize(path)
+      @path = path
+    end
+
+    def parse
+      # could this go in a singleton-y place instead?
+      # like class initialize?
+      YARD::Tags::Library.define_tag('tags', :tags)
+
+      files = ["lib/danger/plugin_support/plugin.rb", @path]
+      self.registry = YARD::Registry.load(files, true)
+    end
+
+    def classes_in_file
+      self.registry.all
+          .select { |thing| thing.type == :class }
+          .select { |klass| klass.file == @path }
+    end
+
+    def plugins_from_classes(classes)
+      classes.select { |klass| klass.inheritance_tree.map(&:name).include? :Plugin }
+    end
+
+    def to_dict(classes)
+      d_meth = lambda do |meth|
+        return nil if meth.nil?
+        {
+          name: meth.name,
+          body_md: meth.docstring,
+          tags: meth.tags.map do |t|
+            {
+               name: t.tag_name,
+               types: t.types
+            }
+          end
+        }
+      end
+
+      d_attr = lambda do |attribute|
+        {
+          read: d_meth.call(attribute[:read]),
+          write: d_meth.call(attribute[:write])
+        }
+      end
+
+      classes.map do |klass|
+        {
+        name: klass.name.to_s,
+        body_md: klass.docstring,
+        example_code: klass.tags.select { |t| t.tag_name == "example" }.map(&:text).compact,
+        attributes: klass.attributes[:instance].map do |pair|
+          {
+          pair.first => d_attr.call(pair.last)
+        }
+        end,
+        methods: (klass.meths - klass.inherited_meths).select { |m| m.visibility == :public }.map { |m| d_meth.call(m) },
+        tags: klass.tags.select { |t| t.tag_name == "tags" }.map(&:name).compact,
+        see: klass.tags.select { |t| t.tag_name == "see" }.map(&:name).map(&:split).flatten.compact,
+        file: klass.file
+      }
+      end
+    end
+  end
+end

--- a/spec/fixtures/plugins/example_full_plugin.rb
+++ b/spec/fixtures/plugins/example_full_plugin.rb
@@ -1,0 +1,81 @@
+module Danger
+  # Lint markdown files inside your projects.
+  # This is done using the [proselint](http://proselint.com) python egg.
+  # Results are passed out as a table in markdown.
+  #
+  # @example Specifying custom CocoaPods installation options
+  #
+  #          # Runs a linter with comma style disabled
+  #          proselint.disable_linters = ["misc.scare_quotes", "misc.tense_present"]
+  #          proselint.lint_files "_posts/*.md"
+  #
+  #          # Runs a linter with all styles, on modified and added markpown files in this PR
+  #          proselint.lint_files
+  #
+  # @see     artsy/artsy.github.io
+  # @tags    blogging, blog, writing, jekyll, middleman, hugo, metalsmith, gatsby, express
+  #
+  class DangerProselint < Plugin
+    # Allows you to disable a collection of linters from being ran.
+    # You can get a list of [them here](https://github.com/amperser/proselint#checks)
+    attr_writer :disable_linters
+
+    # Lints the globbed files, which can fail your build if
+    #
+    # @param   [String] files
+    #          A globbed string which should return the files that you want to lint, defaults to nil.
+    #          if nil, modified and added files will be used.
+    # @return  [void]
+    #
+    def lint_files(files = nil)
+      # Installs a prose checker if needed
+      system "pip install --user proselint" unless proselint_installed?
+
+      # Check that this is in the user's PATH
+      if `which proselint`.strip.empty?
+        fail "proselint is not in the user's PATH, or it failed to install"
+      end
+
+      # Either use files provided, or use the modified + added
+      markdown_files = files ? Dir.glob(files) : (modified_files + added_files)
+      markdown_files.select! { |line| line.end_with?(".markdown", ".md") }
+
+      # TODO: create the disabled linters JSON in ~/.proselintrc
+      # using @disable_linter
+
+      # Convert paths to proselint results
+      require 'json'
+      result_jsons = Hash[markdown_files.uniq.collect { |v| [v, JSON.parse(`proselint #{v} --json`.strip)] }]
+      proses = result_jsons.select { |path, prose| prose['data']['errors'].count }
+
+      # Get some metadata about the local setup
+      current_branch = env.request_source.pr_json["head"]["ref"]
+      current_slug = env.ci_source.repo_slug
+
+      # We got some error reports back from proselint
+      if proses.count > 0
+        message = "### Proselint found issues\n\n"
+        proses.each do |path, prose|
+          github_loc = "/#{current_slug}/tree/#{current_branch}/#{path}"
+          message << "#### [#{path}](#{github_loc})\n\n"
+
+          message << "Line | Message | Severity |\n"
+          message << "| --- | ----- | ----- |\n"
+
+          prose["data"]["errors"].each do |error|
+            message << "#{error['line']} | #{error['message']} | #{error['severity']}\n"
+          end
+        end
+
+        markdown message
+      end
+    end
+
+    # Determine if proselint is currently installed in the system paths.
+    # @return  [Bool]
+    #
+    def proselint_installed?
+      `which proselint`.strip.empty?
+    end
+  end
+end

--- a/spec/fixtures/plugins/example_remote.rb
+++ b/spec/fixtures/plugins/example_remote.rb
@@ -1,11 +1,7 @@
 module Danger
-  class Dangerfile
-    module DSL
-      class ExampleRemote < Plugin
-        def echo
-          return "Hi there remote 🎉"
-        end
-      end
+  class ExampleRemote < Plugin
+    def echo
+      return "Hi there remote 🎉"
     end
   end
 end

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -17,8 +17,7 @@ describe Danger::CISource::CircleCI do
   it 'validates when circle env var is found and it has no PR url' do
     env = { "CIRCLE_BUILD_NUM" => "true",
       "CIRCLE_PROJECT_USERNAME" => "orta",
-      "CIRCLE_PROJECT_REPONAME" => "thing"
-    }
+      "CIRCLE_PROJECT_REPONAME" => "thing" }
     expect(Danger::CISource::CircleCI.validates?(env)).to be true
   end
 

--- a/spec/lib/danger/plugin_support/plugin_parser_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_parser_spec.rb
@@ -1,0 +1,114 @@
+require "danger/plugin_support/plugin_parser"
+
+module Danger
+  describe PluginParser do
+    it 'includes Danger::Plugin in the yard registry' do
+      parser = PluginParser.new ""
+      parser.parse
+
+      plugin_docs = parser.registry.at("Danger::Plugin")
+      expect(plugin_docs).to be_truthy
+    end
+
+    it 'includes an example plugin' do
+      parser = PluginParser.new "spec/fixtures/plugins/example_broken.rb"
+      parser.parse
+
+      plugin_docs = parser.registry.at("Danger::Dangerfile::ExampleBroken")
+      expect(plugin_docs).to be_truthy
+    end
+
+    it 'finds classes from inside the file' do
+      parser = PluginParser.new "spec/fixtures/plugins/example_broken.rb"
+      parser.parse
+
+      classes = parser.classes_in_file
+
+      class_syms = classes.map(&:name)
+      expect(class_syms).to eq [:Dangerfile, :ExampleBroken]
+    end
+
+    it 'skips non-subclasses of Danger::Plugin' do
+      parser = PluginParser.new "spec/fixtures/plugins/example_broken.rb"
+      parser.parse
+
+      plugins = parser.plugins_from_classes(parser.classes_in_file)
+
+      class_syms = plugins.map(&:name)
+      expect(class_syms).to eq []
+    end
+
+    it 'find subclasses of Danger::Plugin' do
+      parser = PluginParser.new "spec/fixtures/plugins/example_remote.rb"
+      parser.parse
+
+      plugins = parser.plugins_from_classes(parser.classes_in_file)
+
+      class_syms = plugins.map(&:name)
+      expect(class_syms).to eq [:ExampleRemote]
+    end
+
+    it 'outputs JSON for badly documented subclasses of Danger::Plugin' do
+      parser = PluginParser.new "spec/fixtures/plugins/example_remote.rb"
+      parser.parse
+
+      plugins = parser.plugins_from_classes(parser.classes_in_file)
+      json = parser.to_dict(plugins)
+
+      expect(json).to eq [{
+        name: "ExampleRemote",
+        body_md: "",
+        example_code: [],
+        attributes: [],
+        methods: [{ name: :echo, body_md: "", tags: [] }],
+        tags: [],
+        see: [],
+        file: "spec/fixtures/plugins/example_remote.rb"
+      }]
+    end
+
+    it 'outputs JSON for well documented subclasses of Danger::Plugin' do
+      parser = PluginParser.new "spec/fixtures/plugins/example_full_plugin.rb"
+      parser.parse
+
+      plugins = parser.plugins_from_classes(parser.classes_in_file)
+      json = parser.to_dict(plugins)
+
+      expect(json).to eq [{
+        name: "DangerProselint",
+        body_md:         "Lint markdown files inside your projects.\nThis is done using the [proselint](http://proselint.com) python egg.\nResults are passed out as a table in markdown.",
+        example_code:         ["\n# Runs a linter with comma style disabled\nproselint.disable_linters = [\"misc.scare_quotes\", \"misc.tense_present\"]\nproselint.lint_files \"_posts/*.md\"\n\n# Runs a linter with all styles, on modified and added markpown files in this PR\nproselint.lint_files"],
+        attributes: [
+          { disable_linters: { read: nil, write:
+            { name: :disable_linters=,
+              body_md: "Allows you to disable a collection of linters from being ran.\nYou can get a list of [them here](https://github.com/amperser/proselint#checks)",
+              tags: [] } } }
+        ],
+
+        methods: [
+          {
+            name: :disable_linters=,
+            body_md: "Allows you to disable a collection of linters from being ran.\nYou can get a list of [them here](https://github.com/amperser/proselint#checks)",
+            tags: []
+          },
+          {
+            name: :lint_files,
+            body_md: "Lints the globbed files, which can fail your build if",
+            tags: [
+              { name: "param", types: ["String"] },
+              { name: "return", types: ["void"] }
+            ]
+           },
+          {
+            name: :proselint_installed?,
+            body_md: "Determine if proselint is currently installed in the system paths.",
+            tags: [{ name: "return", types: ["Bool"] }]
+        }
+        ],
+        tags: [],
+        see: ["artsy/artsy.github.io"],
+        file: "spec/fixtures/plugins/example_full_plugin.rb"
+      }]
+    end
+  end
+end


### PR DESCRIPTION
@KrauseFx was correct to be suspicious when I introduced the revised plugin support ( #223 ) it was a significant change from all of our exist discussion about what a plugin could look like.

If there's anything I've learned from 90k CocoaPods versions and from managing CocoaPods, it's that the initial expectations will stick with you for years. I need Danger to stay small, because I don't have time to product manage another project as big as Danger could become. So, Danger needs to be _extremely_ easy to build a plugin for. 

I think there's two spaces for plugins, private plugins ( like we have in Danger - [protect_files](https://github.com/danger/danger/blob/dfa3fe611ef331955a2cf7a2ab9b8a99981fbcf0/danger_plugins/protect_files.rb) and some of the things [SoundCloud](http://ppinera.es/2016/05/23/danger-and-boyscout-rule.html) do ) and public plugins. A private plugin can be a quick throwaway class, easy to iterate, and you can copy & paste some code directly from your Dangerfile into a plugin template, and you're good.

Public Plugins however need to hold themselves to a higher standard. In order for Danger to be seen as more than "just and iOS project" and applicable to basically every project using code review, the website has to really showcase a lot of interesting use cases. Public plugins can provide this. 

This was what I had in mind when I started roughing the design of what plugin support should look like:

![screen shot 2016-05-31 at 9 41 57 pm](https://cloud.githubusercontent.com/assets/49038/15695755/88613658-2778-11e6-9c49-7c3c4ab70be7.png)

The usage of CocoaPods sky-rocketed once I re-designed the website with search in mind. Since then most (updated) package managers have taken similar approaches to their sites. It's not novel, it's a simple approach based on our analytics. In the future, Danger's plugin search may move to the top of the site.

To do this right, we need to be able to document public plugins easily. [rubydocs](http://www.rubydoc.info) won't do in this case. It's too opaque for non-rubyists, so we need to pull out the metadata we need and convert that into something we _can_ work with. This is a pattern @fabiopelosin used in the CocoaPods guides, we pull all the useful data out of the ruby code. It's how our [references are built](https://guides.cocoapods.org/syntax/podfile.html). We'll be using this in http://danger.systems.

So, this provides the kernel of the idea, it is a class that maps a plugin into a hash. We can then build a linter for public documentation, and well, the documentation engine. Really glad to be feeling close.

Example:

This JSON:

```son

[
  {
    "name": "DangerProselint",
    "body_md": "Lint markdown files inside your projects.\nThis is done using the [proselint](http:\/\/proselint.com) python egg.\nResults are passed out as a table in markdown.",
    "example_code": [
      "\n# Runs a linter with comma style disabled\nproselint.disable_linters = [\"misc.scare_quotes\", \"misc.tense_present\"]\nproselint.lint_files \"_posts\/*.md\"\n\n# Runs a linter with all styles, on modified and added markpown files in this PR\nproselint.lint_files"
    ],
    "attributes": [
      {
        "disable_linters": {
          "read": null,
          "write": {
            "name": "disable_linters=",
            "body_md": "Allows you to disable a collection of linters from being ran.\nYou can get a list of [them here](https:\/\/github.com\/amperser\/proselint#checks)",
            "tags": [
              
            ]
          }
        }
      }
    ],
    "methods": [
      {
        "name": "disable_linters=",
        "body_md": "Allows you to disable a collection of linters from being ran.\nYou can get a list of [them here](https:\/\/github.com\/amperser\/proselint#checks)",
        "tags": [
          
        ]
      },
      {
        "name": "lint_files",
        "body_md": "Lints the globbed files, which can fail your build if",
        "tags": [
          {
            "name": "param",
            "types": [
              "String"
            ]
          },
          {
            "name": "return",
            "types": [
              "void"
            ]
          }
        ]
      },
      {
        "name": "proselint_installed?",
        "body_md": "Determine if proselint is currently installed in the system paths.",
        "tags": [
          {
            "name": "return",
            "types": [
              "Bool"
            ]
          }
        ]
      }
    ],
    "tags": [
      
    ],
    "see": [
      "artsy\/artsy.github.io"
    ],
    "file": "spec\/fixtures\/plugins\/example_full_plugin.rb"
  }
]
```

Represents this Plugin:

```ruby
module Danger
  # Lint markdown files inside your projects.
  # This is done using the [proselint](http://proselint.com) python egg.
  # Results are passed out as a table in markdown.
  #
  # @example Specifying custom CocoaPods installation options
  #
  #          # Runs a linter with comma style disabled
  #          proselint.disable_linters = ["misc.scare_quotes", "misc.tense_present"]
  #          proselint.lint_files "_posts/*.md"
  #
  #          # Runs a linter with all styles, on modified and added markpown files in this PR
  #          proselint.lint_files
  #
  # @see     artsy/artsy.github.io
  # @tags    blogging, blog, writing, jekyll, middleman, hugo, metalsmith, gatsby, express
  #
  class DangerProselint < Plugin
    # Allows you to disable a collection of linters from being ran.
    # You can get a list of [them here](https://github.com/amperser/proselint#checks)
    attr_writer :disable_linters

    # Lints the globbed files, which can fail your build if
    #
    # @param   [String] files
    #          A globbed string which should return the files that you want to lint, defaults to nil.
    #          if nil, modified and added files will be used.
    # @return  [void]
    #
    def lint_files(files = nil)
      # Installs a prose checker if needed
      system "pip install --user proselint" unless proselint_installed?

      # Check that this is in the user's PATH
      if `which proselint`.strip.empty?
        fail "proselint is not in the user's PATH, or it failed to install"
      end

      # Either use files provided, or use the modified + added
      markdown_files = files ? Dir.glob(files) : (modified_files + added_files)
      markdown_files.select! { |line| line.end_with?(".markdown", ".md") }

      # TODO: create the disabled linters JSON in ~/.proselintrc
      # using @disable_linter

      # Convert paths to proselint results
      require 'json'
      result_jsons = Hash[markdown_files.uniq.collect { |v| [v, JSON.parse(`proselint #{v} --json`.strip)] }]
      proses = result_jsons.select { |path, prose| prose['data']['errors'].count }

      # Get some metadata about the local setup
      current_branch = env.request_source.pr_json["head"]["ref"]
      current_slug = env.ci_source.repo_slug

      # We got some error reports back from proselint
      if proses.count > 0
        message = "### Proselint found issues\n\n"
        proses.each do |path, prose|
          github_loc = "/#{current_slug}/tree/#{current_branch}/#{path}"
          message << "#### [#{path}](#{github_loc})\n\n"

          message << "Line | Message | Severity |\n"
          message << "| --- | ----- | ----- |\n"

          prose["data"]["errors"].each do |error|
            message << "#{error['line']} | #{error['message']} | #{error['severity']}\n"
          end
        end

        markdown message
      end
    end

    # Determine if proselint is currently installed in the system paths.
    # @return  [Bool]
    #
    def proselint_installed?
      `which proselint`.strip.empty?
    end
  end
end
```

At some point I will do a larger scale post on how [working on CocoaPods infrastructure affected Danger](https://github.com/artsy/mobile/issues/96)