### PR TITLE
Allow Dangerfile path to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Initial work on the Plugin -> JSON mapper - orta
 * Add support for Semaphore CI - starsirius
 * Add Ruby 2.3 support - segiddins
+* Allow Dangerfile path to be configured - gabro
 
 ## 0.7.4
 

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -11,7 +11,8 @@ module Danger
     self.plugin_prefixes = %w(claide danger)
 
     def initialize(argv)
-      @dangerfile_path = "Dangerfile" if File.exist? "Dangerfile"
+      dangerfile = argv.option('dangerfile', 'Dangerfile')
+      @dangerfile_path = dangerfile if File.exist? dangerfile
       @base = argv.option('base')
       @head = argv.option('head')
       super
@@ -27,7 +28,8 @@ module Danger
     def self.options
       [
         ['--base=[master|dev|stable]', 'A branch/tag/commit to use as the base of the diff'],
-        ['--head=[master|dev|stable]', 'A branch/tag/commit to use as the head']
+        ['--head=[master|dev|stable]', 'A branch/tag/commit to use as the head'],
+        ['--dangerfile=<path/to/dangerfile>', 'The location of your Dangerfile']
       ].concat(super)
     end
 

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -42,6 +42,20 @@ module Command
       end
     end
 
+    it 'allows overriding the Dangerfile location' do
+      allow(STDOUT).to receive(:puts) # this disables puts
+
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          Dir.mkdir 'subdir'
+          Dir.chdir 'subdir' do
+            `touch Dangerfile`
+          end
+          expect { Danger::Runner.run(['--dangerfile=subdir/Dangerfile']) }.not_to raise_error SystemExit
+        end
+      end
+    end
+
     it 'gets through the whole command' do
       @git_mock = Danger::GitRepo.new
       allow(Danger::GitRepo).to receive(:new).and_return @git_mock


### PR DESCRIPTION
Resolves #219 

Add `--dangerfile=<path/to/dangerfile>` option to override the default `Dangerfile` location.