### PR TITLE
Show a helpful warning if danger can not access a local repo on GitHub

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -24,7 +24,7 @@ end
 
 declared_trivial = (pr_title + pr_body).include?("#trivial") || !has_app_changes
 if !modified_files.include?("CHANGELOG.md") && !declared_trivial
-  fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/danger/danger/blob/master/CHANGELOG.md).", sticky: false)
+  fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/danger/danger/blob/master/CHANGELOG.md).")
 end
 
 ### Oddly enough, it's quite possible to do some testing of Danger, inside Danger

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -60,11 +60,14 @@ module Danger
 
       dm.env.request_source = gh
 
-      dm.env.ensure_danger_branches_are_setup
-      dm.env.scm.diff_for_folder(".", from: dm.env.ci_source.base_commit, to: dm.env.ci_source.head_commit)
-      dm.parse(Pathname.new(@dangerfile_path))
-      dm.print_results
-      dm.env.clean_up
+      begin
+        dm.env.ensure_danger_branches_are_setup
+        dm.env.scm.diff_for_folder(".", from: dm.env.ci_source.base_commit, to: dm.env.ci_source.head_commit)
+        dm.parse(Pathname.new(@dangerfile_path))
+        dm.print_results
+      ensure
+        dm.env.clean_up
+      end
     end
   end
 end

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -40,19 +40,22 @@ module Danger
         dm.init_plugins
 
         dm.env.fill_environment_vars
-        dm.env.ensure_danger_branches_are_setup
 
-        # Offer the chance for a user to specify a branch through the command line
-        ci_base = @base || dm.env.danger_head_branch
-        ci_head = @head || dm.env.danger_base_branch
-        dm.env.scm.diff_for_folder(".", from: ci_base, to: ci_head)
+        begin
+          dm.env.ensure_danger_branches_are_setup
 
-        dm.parse Pathname.new(@dangerfile_path)
+          # Offer the chance for a user to specify a branch through the command line
+          ci_base = @base || dm.env.danger_head_branch
+          ci_head = @head || dm.env.danger_base_branch
+          dm.env.scm.diff_for_folder(".", from: ci_base, to: ci_head)
 
-        post_results dm
-        dm.print_results
+          dm.parse Pathname.new(@dangerfile_path)
 
-        dm.env.clean_up
+          post_results dm
+          dm.print_results
+        ensure
+          dm.env.clean_up
+        end
       else
         puts "Not a Pull Request - skipping `danger` run"
       end


### PR DESCRIPTION
"Fixes" #231 #trivial

Also included: danger will now clean up after itself when running in local mode.