### PR TITLE
Ensure that we don't break sticky on Dangerfiles due to the new syntax

### DIFF
--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -43,14 +43,14 @@ module Danger
     # http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-warn
     # http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-fail
     # However, as we're using using them in the DSL, they won't
-    # get method_missing called.
+    # get method_missing called correctly.
 
-    def warn(message)
-      method_missing(:warn, message)
+    def warn(*args, &blk)
+      method_missing(:warn, *args, &blk)
     end
 
-    def fail(message)
-      method_missing(:fail, message)
+    def fail(*args, &blk)
+      method_missing(:fail, *args, &blk)
     end
 
     # When an undefined method is called, we check to see if it's something

--- a/lib/danger/plugin_support/plugin.rb
+++ b/lib/danger/plugin_support/plugin.rb
@@ -12,16 +12,14 @@ module Danger
     # http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-warn
     # http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-fail
     # However, as we're using using them in the DSL, they won't
-    # get method_missing called.
+    # get method_missing called correctly.
 
-    def warn(message)
-      puts "Danger warn"
-      @dangerfile.warn(message)
+    def warn(*args, &blk)
+      method_missing(:warn, *args, &blk)
     end
 
-    def fail(message)
-      puts "Danger fail"
-      @dangerfile.fail(message)
+    def fail(*args, &blk)
+      method_missing(:fail, *args, &blk)
     end
 
     # Since we have a reference to the Dangerfile containing all the information

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -29,6 +29,9 @@ module Command
       issue_comments_response = JSON.parse(fixture("issue_comments"), symbolize_names: true)
       allow(octokit_mock).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issue_comments_response)
 
+      issue_comment_response = JSON.parse(fixture("issue_response"), symbolize_names: true)
+      allow(octokit_mock).to receive(:add_comment).and_return(issue_comment_response)
+
       allow(Octokit::Client).to receive(:new).and_return octokit_mock
     end
 
@@ -42,34 +45,61 @@ module Command
       end
     end
 
-    it 'gets through the whole command' do
-      @git_mock = Danger::GitRepo.new
-      allow(Danger::GitRepo).to receive(:new).and_return @git_mock
+    describe "full run" do
+      before do
+        @git_mock = Danger::GitRepo.new
+        allow(Danger::GitRepo).to receive(:new).and_return @git_mock
 
-      git_commands = [
-        { "rev-parse --quiet --verify danger_base" => "OK" },
-        { "rev-parse --quiet --verify danger_head" => "OK" },
-        { "branch danger_base 704dc55988c6996f69b6873c2424be7d1de67bbe" => "" },
-        { "fetch origin +refs/pull/800/merge:danger_head" => "" },
-        { "branch -D danger_base" => "" }
-      ]
-
-      git_commands.each do |command|
-        allow(@git_mock).to receive(:exec).with(command.keys.first).and_return(command.values.first)
-      end
-
-      Dir.mktmpdir do |dir|
-        Dir.chdir dir do
-          `git init`
-          `git remote add origin git@github.com:artsy/eigen.git`
-          `touch Dangerfile`
-          Danger::Runner.run([])
+        git_commands = [
+          { "rev-parse --quiet --verify danger_base" => "OK" },
+          { "rev-parse --quiet --verify danger_head" => "OK" },
+          { "branch danger_base 704dc55988c6996f69b6873c2424be7d1de67bbe" => "" },
+          { "fetch origin +refs/pull/800/merge:danger_head" => "" },
+          { "branch -D danger_base" => "" }
+        ]
+        git_commands.each do |command|
+          allow(@git_mock).to receive(:exec).with(command.keys.first).and_return(command.values.first)
         end
       end
-    end
 
-    it 'has the correct version' do
-      expect(Danger::Runner.version).to eq(Danger::VERSION)
+      it 'gets through the whole command' do
+        Dir.mktmpdir do |dir|
+          Dir.chdir dir do
+            `git init`
+            `git remote add origin git@github.com:artsy/eigen.git`
+            `touch Dangerfile`
+            Danger::Runner.run([])
+          end
+        end
+      end
+
+      it 'handles an example dangerfile well' do
+        allow(STDOUT).to receive(:puts) # this disables puts
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir dir do
+            `git init`
+            `git remote add origin git@github.com:artsy/eigen.git`
+            File.write("Dangerfile", %{
+              message "Hi"
+              warn "OK"
+              fail "Not OK"
+              markdown "OK [link](http://sure.com)"
+
+              warn("ok", sticky: false)
+              fail("not ok", sticky: false)
+              message("hi", sticky: false)
+    })
+
+            # This will call `abort` due to the fails in the Dangerfile
+            expect { Danger::Runner.run([]) }.to raise_error(SystemExit)
+          end
+        end
+      end
+
+      it 'has the correct version' do
+        expect(Danger::Runner.version).to eq(Danger::VERSION)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #235 and adds an end-to-end test that covers every messaging aspect of the DSL. #trivial