### PR TITLE
Fail CI Source validation early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Support multiple Danger instances with `--dangerId` - marcelofabri
 * Add base request source so services other than GitHub could be used with Danger. - justMaku
+* Don't validate CI sources that don't expose all required environment variables.
 
 ## 0.8.1
 

--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -5,17 +5,19 @@ module Danger
   module CISource
     class Buildkite < CI
       def self.validates?(env)
-        return !env["BUILDKITE"].nil?
+        return false unless env["BUILDKITE"]
+        return false unless env["BUILDKITE_REPO"]
+        return false unless env["BUILDKITE_PULL_REQUEST"]
+
+        return true
       end
 
       def initialize(env)
-        repo = env["BUILDKITE_REPO"]
-        unless repo.nil?
-          repo_matches = repo.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
-          self.repo_slug = repo_matches[2] unless repo_matches.nil?
-        end
-
+        self.repo_url = env["BUILDKITE_REPO"]
         self.pull_request_id = env["BUILDKITE_PULL_REQUEST"]
+
+        repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
+        self.repo_slug = repo_matches[2] unless repo_matches.nil?
       end
 
       def supported_request_sources

--- a/lib/danger/ci_source/ci_source.rb
+++ b/lib/danger/ci_source/ci_source.rb
@@ -2,7 +2,7 @@ module Danger
   module CISource
     # "abstract" CI class
     class CI
-      attr_accessor :repo_slug, :pull_request_id, :supported_request_sources
+      attr_accessor :repo_slug, :pull_request_id, :repo_url, :supported_request_sources
 
       def self.inherited(child_class)
         available_ci_sources.add child_class

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -6,10 +6,12 @@ module Danger
   module CISource
     class CircleCI < CI
       def self.validates?(env)
-        return false if env["CIRCLE_BUILD_NUM"].nil?
-        return true unless env["CI_PULL_REQUEST"].nil?
+        return false unless env["CIRCLE_BUILD_NUM"]
+        return false unless env["CI_PULL_REQUEST"]
+        return false unless env["CIRCLE_PROJECT_USERNAME"]
+        return false unless env["CIRCLE_PROJECT_REPONAME"]
 
-        return !env["CIRCLE_PROJECT_USERNAME"].nil? && !env["CIRCLE_PROJECT_REPONAME"].nil?
+        return true
       end
 
       def supported_request_sources
@@ -37,6 +39,8 @@ module Danger
       end
 
       def initialize(env)
+        self.repo_url = GitRepo.new.origins # CircleCI doesn't provide a repo url env variable :/
+
         @circle_token = env["CIRCLE_CI_API_TOKEN"]
         url = pull_request_url(env)
 

--- a/lib/danger/ci_source/drone.rb
+++ b/lib/danger/ci_source/drone.rb
@@ -4,7 +4,11 @@ module Danger
   module CISource
     class Drone < CI
       def self.validates?(env)
-        return !env["DRONE"].nil?
+        return false unless env["DRONE"]
+        return false unless env["DRONE_REPO"]
+        return false unless env["DRONE_PULL_REQUEST"].to_i > 0
+
+        return true
       end
 
       def supported_request_sources
@@ -13,9 +17,8 @@ module Danger
 
       def initialize(env)
         self.repo_slug = env["DRONE_REPO"]
-        if env["DRONE_PULL_REQUEST"].to_i > 0
-          self.pull_request_id = env["DRONE_PULL_REQUEST"]
-        end
+        self.pull_request_id = env["DRONE_PULL_REQUEST"]
+        self.repo_url = GitRepo.new.origins # Drone doesn't provide a repo url env variable :/
       end
     end
   end

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -5,7 +5,10 @@ module Danger
   module CISource
     class Jenkins < CI
       def self.validates?(env)
-        return !env["ghprbPullId"].nil? && !env["GIT_URL"].nil?
+        return false unless env["ghprbPullId"].to_i > 0
+        return false unless env["GIT_URL"]
+
+        return true
       end
 
       def supported_request_sources
@@ -13,16 +16,11 @@ module Danger
       end
 
       def initialize(env)
-        repo = env["GIT_URL"]
-        unless repo.nil?
-          repo_matches = repo.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
-          self.repo_slug = repo_matches[2] unless repo_matches.nil?
-        end
+        self.repo_url = env["GIT_URL"]
+        self.pull_request_id = env["ghprbPullId"]
 
-        # from https://docs.travis-ci.com/user/pull-requests, as otherwise it's "false"
-        if env["ghprbPullId"].to_i > 0
-          self.pull_request_id = env["ghprbPullId"]
-        end
+        repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
+        self.repo_slug = repo_matches[2] unless repo_matches.nil?
       end
     end
   end

--- a/lib/danger/ci_source/semaphore.rb
+++ b/lib/danger/ci_source/semaphore.rb
@@ -4,7 +4,11 @@ module Danger
   module CISource
     class Semaphore < CI
       def self.validates?(env)
-        return !env["SEMAPHORE"].nil?
+        return false unless env["SEMAPHORE"]
+        return false unless env["SEMAPHORE_REPO_SLUG"]
+        return false unless env["PULL_REQUEST_NUMBER"].to_i > 0
+
+        return true
       end
 
       def supported_request_sources
@@ -13,9 +17,8 @@ module Danger
 
       def initialize(env)
         self.repo_slug = env["SEMAPHORE_REPO_SLUG"]
-        if env["PULL_REQUEST_NUMBER"].to_i > 0
-          self.pull_request_id = env["PULL_REQUEST_NUMBER"]
-        end
+        self.pull_request_id = env["PULL_REQUEST_NUMBER"]
+        self.repo_url = GitRepo.new.origins # Semaphore doesn't provide a repo url env variable :/
       end
     end
   end

--- a/lib/danger/ci_source/travis.rb
+++ b/lib/danger/ci_source/travis.rb
@@ -5,7 +5,11 @@ module Danger
   module CISource
     class Travis < CI
       def self.validates?(env)
-        return !env["HAS_JOSH_K_SEAL_OF_APPROVAL"].nil?
+        return false unless env["HAS_JOSH_K_SEAL_OF_APPROVAL"]
+        return false unless env["TRAVIS_REPO_SLUG"]
+        return false unless env["TRAVIS_PULL_REQUEST"]
+
+        return true
       end
 
       def supported_request_sources
@@ -14,10 +18,10 @@ module Danger
 
       def initialize(env)
         self.repo_slug = env["TRAVIS_REPO_SLUG"]
-        # from https://docs.travis-ci.com/user/pull-requests, as otherwise it's "false"
         if env["TRAVIS_PULL_REQUEST"].to_i > 0
           self.pull_request_id = env["TRAVIS_PULL_REQUEST"]
         end
+        self.repo_url = GitRepo.new.origins # Travis doesn't provide a repo url env variable :/
       end
     end
   end

--- a/lib/danger/ci_source/xcode_server.rb
+++ b/lib/danger/ci_source/xcode_server.rb
@@ -4,7 +4,9 @@ module Danger
   module CISource
     class XcodeServer < CI
       def self.validates?(env)
-        return !env["XCS_BOT_NAME"].nil?
+        return false unless env["XCS_BOT_NAME"]
+
+        return true
       end
 
       def supported_request_sources
@@ -19,6 +21,7 @@ module Danger
         self.repo_slug = repo_matches[1] unless repo_matches.nil?
         pull_request_id_matches = bot_name.match(/#(\d+)/)
         self.pull_request_id = pull_request_id_matches[1] unless pull_request_id_matches.nil?
+        self.repo_url = GitRepo.new.origins # Xcode Server doesn't provide a repo url env variable :/
       end
     end
   end

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -18,7 +18,7 @@ module Danger
         end
       end
 
-      raise "Could not find a CI source".red unless self.ci_source
+      raise "Could not find a valid pull request within the known CI sources".red unless self.ci_source
 
       RequestSources::RequestSource.available_request_sources.each do |klass|
         next unless self.ci_source.supports?(klass)

--- a/spec/lib/danger/ci_sources/buildkite_spec.rb
+++ b/spec/lib/danger/ci_sources/buildkite_spec.rb
@@ -1,8 +1,10 @@
 require 'danger/ci_source/buildkite'
 
 describe Danger::CISource::Buildkite do
-  it "validates when buildkite env var is found" do
-    env = { "BUILDKITE" => "true" }
+  it "validates when buildkite all env vars is found" do
+    env = { "BUILDKITE" => "true",
+            "BUILDKITE_REPO" => "git@github.com:KrauseFx/danger.git",
+            "BUILDKITE_PULL_REQUEST" => 1 }
     expect(Danger::CISource::Buildkite.validates?(env)).to be true
   end
 

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -4,27 +4,36 @@ describe Danger::CISource::CircleCI do
   legit_pr = "https://github.com/orta/thing/pulls/45"
   not_legit_pr = "https://github.com/orta"
 
-  it 'validates when circle env var is found and it has a real PR url' do
-    env = { "CIRCLE_BUILD_NUM" => "true", "CI_PULL_REQUEST" => legit_pr }
+  it 'validates when circle all env vars are set' do
+    env = { "CIRCLE_BUILD_NUM" => "true",
+            "CI_PULL_REQUEST" => legit_pr,
+            "CIRCLE_PROJECT_USERNAME" => "orta",
+            "CIRCLE_PROJECT_REPONAME" => "thing" }
     expect(Danger::CISource::CircleCI.validates?(env)).to be true
   end
 
   it 'validates when circle env var is found and it has a bad PR url' do
-    env = { "CIRCLE_BUILD_NUM" => "true", "CI_PULL_REQUEST" => not_legit_pr }
-    expect(Danger::CISource::CircleCI.validates?(env)).to be true
-  end
-
-  it 'validates when circle env var is found and it has no PR url' do
     env = { "CIRCLE_BUILD_NUM" => "true",
-      "CIRCLE_PROJECT_USERNAME" => "orta",
-      "CIRCLE_PROJECT_REPONAME" => "thing" }
+            "CI_PULL_REQUEST" => not_legit_pr,
+            "CIRCLE_PROJECT_USERNAME" => "orta",
+            "CIRCLE_PROJECT_REPONAME" => "thing" }
     expect(Danger::CISource::CircleCI.validates?(env)).to be true
   end
 
   it 'doesnt get a PR id when it has a bad PR url' do
-    env = { "CIRCLE_BUILD_NUM" => "true", "CI_PULL_REQUEST" => not_legit_pr }
+    env = { "CIRCLE_BUILD_NUM" => "true",
+            "CI_PULL_REQUEST" => not_legit_pr,
+            "CIRCLE_PROJECT_USERNAME" => "orta",
+            "CIRCLE_PROJECT_REPONAME" => "thing" }
     t = Danger::CISource::CircleCI.new(env)
     expect(t.pull_request_id).to be nil
+  end
+
+  it 'doesnt validate when circle env var is found and it has no PR url' do
+    env = { "CIRCLE_BUILD_NUM" => "true",
+            "CIRCLE_PROJECT_USERNAME" => "orta",
+            "CIRCLE_PROJECT_REPONAME" => "thing" }
+    expect(Danger::CISource::CircleCI.validates?(env)).to be false
   end
 
   it 'doesnt validate when circle ci is not found' do

--- a/spec/lib/danger/ci_sources/drone_spec.rb
+++ b/spec/lib/danger/ci_sources/drone_spec.rb
@@ -2,12 +2,28 @@ require 'danger/ci_source/drone'
 
 describe Danger::CISource::Drone do
   it 'validates when DRONE variable is set' do
-    env = { "DRONE" => "true" }
+    env = { "DRONE" => "true",
+            "DRONE_REPO" => "danger/danger",
+            "DRONE_PULL_REQUEST" => 1 }
     expect(Danger::CISource::Drone.validates?(env)).to be true
   end
 
   it 'does not validate when DRONE is not set' do
     env = { "CIRCLE" => "true" }
+    expect(Danger::CISource::Drone.validates?(env)).to be false
+  end
+
+  it 'does not validate when DRONE_PULL_REQUEST is set to non int value' do
+    env = { "CIRCLE" => "true",
+            "DRONE_REPO" => "danger/danger",
+            "DRONE_PULL_REQUEST" => "maku" }
+    expect(Danger::CISource::Drone.validates?(env)).to be false
+  end
+
+  it 'does not validate when DRONE_PULL_REQUEST is set to non positive int value' do
+    env = { "CIRCLE" => "true",
+            "DRONE_REPO" => "danger/danger",
+            "DRONE_PULL_REQUEST" => -1 }
     expect(Danger::CISource::Drone.validates?(env)).to be false
   end
 

--- a/spec/lib/danger/ci_sources/semaphore_spec.rb
+++ b/spec/lib/danger/ci_sources/semaphore_spec.rb
@@ -1,8 +1,10 @@
 require 'danger/ci_source/travis'
 
 describe Danger::CISource::Semaphore do
-  it 'validates when semaphore' do
-    env = { "SEMAPHORE" => "true" }
+  it 'validates when all semaphore variables are set' do
+    env = { "SEMAPHORE" => "true",
+            "PULL_REQUEST_NUMBER" => "800",
+            "SEMAPHORE_REPO_SLUG" => "artsy/eigen" }
     expect(Danger::CISource::Semaphore.validates?(env)).to be true
   end
 

--- a/spec/lib/danger/ci_sources/travis_spec.rb
+++ b/spec/lib/danger/ci_sources/travis_spec.rb
@@ -1,8 +1,10 @@
 require 'danger/ci_source/travis'
 
 describe Danger::CISource::Travis do
-  it 'validates when Josh K says so' do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true" }
+  it 'validates when all Travis environment vars are set and Josh K says so' do
+    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
+            "TRAVIS_PULL_REQUEST" => "800",
+            "TRAVIS_REPO_SLUG" => "artsy/eigen" }
     expect(Danger::CISource::Travis.validates?(env)).to be true
   end
 

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -4,7 +4,7 @@ describe Danger::EnvironmentManager do
   it 'raises without enough info in the ENV' do
     expect do
       Danger::EnvironmentManager.new({ "KEY" => "VALUE" })
-    end.to raise_error("Could not find a CI source".red)
+    end.to raise_error("Could not find a valid pull request within the known CI sources".red)
   end
 
   it 'stores travis in the source' do
@@ -16,19 +16,26 @@ describe Danger::EnvironmentManager do
 
   it 'stores circle in the source' do
     number = 800
-    env = { "CIRCLE_BUILD_NUM" => "true", "CI_PULL_REQUEST" => "https://github.com/artsy/eigen/pull/#{number}" }
+    env = { "CIRCLE_BUILD_NUM" => "true",
+            "CI_PULL_REQUEST" => "https://github.com/artsy/eigen/pull/#{number}",
+            "CIRCLE_PROJECT_USERNAME" => "orta",
+            "CIRCLE_PROJECT_REPONAME" => "thing" }
     e = Danger::EnvironmentManager.new(env)
     expect(e.ci_source.pull_request_id).to eq(number.to_s)
   end
 
   it 'creates a GitHub attr' do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true", "TRAVIS_REPO_SLUG" => "KrauseFx/fastlane", "TRAVIS_PULL_REQUEST" => 123.to_s }
+    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
+            "TRAVIS_REPO_SLUG" => "KrauseFx/fastlane",
+            "TRAVIS_PULL_REQUEST" => 123.to_s }
     e = Danger::EnvironmentManager.new(env)
     expect(e.request_source).to be_truthy
   end
 
   it 'skips push runs and only runs for pull requests' do
-    env = { "TRAVIS_REPO_SLUG" => "orta/danger", "TRAVIS_PULL_REQUEST" => "false", "HAS_JOSH_K_SEAL_OF_APPROVAL" => "1" }
+    env = { "TRAVIS_REPO_SLUG" => "orta/danger",
+            "TRAVIS_PULL_REQUEST" => "false",
+            "HAS_JOSH_K_SEAL_OF_APPROVAL" => "1" }
     e = Danger::EnvironmentManager.new(env)
     expect(e.ci_source).to eq(nil)
   end


### PR DESCRIPTION
There's no point in creating a CI Source only to dismiss it later on because it doesn't contain all of the information required. This PR makes sure we catch those situations early.