### PR TITLE
Add missing `require 'set'` #trivial

### DIFF
--- a/lib/danger/ci_source/ci_source.rb
+++ b/lib/danger/ci_source/ci_source.rb
@@ -10,6 +10,7 @@ module Danger
       end
 
       def self.available_ci_sources
+        require 'set'
         @available_ci_sources ||= Set.new
       end
 


### PR DESCRIPTION
Before

```
$ danger --version
/Library/Ruby/Gems/2.0.0/gems/danger-0.8.2/lib/danger/ci_source/ci_source.rb:13:in `available_ci_sources': uninitialized constant Danger::CISource::CI::Set (NameError)
[…]
```

After

```
$ danger --version
0.8.2
```

