### PR TITLE
Adds plugin lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Master
 
 * Initial work on `danger plugin lint` command - orta
+* `danger plugin lint` can run with either:
+  - a list of file paths
+  - a list of gems
+  - no arguments, which will parse `lib/**/**/*` to lint your local plugins
+* Moved new plugin to `danger plugin new` - orta
 
 ## 0.8.3
 

--- a/lib/danger/commands/new_plugin.rb
+++ b/lib/danger/commands/new_plugin.rb
@@ -1,7 +1,7 @@
 module Danger
-  class NewPlugin < Runner
+  class NewPlugin < PluginAbstract
     self.summary = 'Generate a new danger plugin.'
-    self.command = 'new_plugin'
+    self.command = 'new'
 
     def run
       require 'fileutils'

--- a/lib/danger/commands/plugin_abstract.rb
+++ b/lib/danger/commands/plugin_abstract.rb
@@ -1,5 +1,10 @@
 module Danger
   class PluginAbstract < Runner
     require 'danger/commands/plugin_lint'
+    require 'danger/commands/new_plugin'
+
+    self.command = 'plugin'
+
+    self.abstract_command = true
   end
 end

--- a/lib/danger/commands/plugin_lint.rb
+++ b/lib/danger/commands/plugin_lint.rb
@@ -7,37 +7,66 @@ module Danger
     self.command = 'lint'
 
     def initialize(argv)
-      @plugin_ref = argv.shift_argument
+      @refs = argv.arguments! unless argv.arguments.empty?
       super
     end
 
-    def self.options
-      [
-        ['[path]', 'The path of the ruby file you want to lint']
-      ].concat(super)
-    end
+    self.summary = 'Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success.'
+
+    self.description = <<-DESC
+      Converts a collection of file paths of Danger plugins into a JSON format. 
+      Note: Before 1.0, it will also parse the represented JSON to validate whether http://danger.systems would
+      show the plugin on the website.
+    DESC
+
+    self.arguments = [
+      CLAide::Argument.new('Paths, Gems or Nothing', false, true),
+    ]
 
     def run
-      require 'yard'
+      paths = nil
 
-      # Sometimes there's caching issues, they look like this:
-      #  TypeError:
-      #   incompatible marshal file format (can't be read)
-      #     format version 4.8 required; 109.111 given
+      # When given existing paths, map to absolute & existing paths
+      if @refs != nil and @refs.select { |ref| File.file? ref }.any?
+        paths = @refs.select { |ref| File.file? ref }
+                     .map { |path| File.expand_path(path) }
 
-      # `rm -rf '~/.yard/'`
+      # When given a list of gems
+      elsif @refs and @refs.is_a? Array 
+        require 'bundler'
+        require 'pathname'
 
-      if File.exist? @plugin_ref
-        path = @plugin_ref
+        Dir.mktmpdir do |dir|
+          gem_names = @refs
+          deps = gem_names.map { |name| Bundler::Dependency.new(name, ">= 0") }
+
+          # Use Gems from rubygems.org
+          source = Bundler::SourceList.new
+          source.add_rubygems_remote("https://rubygems.org")
+
+          # Create a definition to bundle, make sure it always updates
+          # and uses the latest version from the server
+          bundler = Bundler::Definition.new(nil, deps, source, true)
+          bundler.resolve_remotely!
+
+          # Install the gems into a tmp dir
+          options = { :path => dir }
+          Bundler::Installer.install(Pathname.new(dir), bundler, options)
+
+          # Get the name'd gems out of bundler, then pull out all their paths 
+          gems = gem_names.map { |name| bundler.specs[name] }.flatten
+          paths = gems.map { |gem| Dir.glob(File.join(gem.gem_dir, "lib/**/**/**.rb")) }.flatten
+        end
+      
+      # When empty, imply you want to test the current lib folder as a plugin
       else
-        raise "Could not find a file at path"
+        paths = Dir.glob(File.join(".", "lib/*.rb"))
       end
 
-      parser = PluginParser.new(path)
+      parser = PluginParser.new(paths)
       parser.parse
       json = parser.to_json
-
-      cork.message json
+      cork.puts json
     end
   end
 end

--- a/lib/danger/commands/plugin_lint.rb
+++ b/lib/danger/commands/plugin_lint.rb
@@ -14,25 +14,25 @@ module Danger
     self.summary = 'Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success.'
 
     self.description = <<-DESC
-      Converts a collection of file paths of Danger plugins into a JSON format. 
+      Converts a collection of file paths of Danger plugins into a JSON format.
       Note: Before 1.0, it will also parse the represented JSON to validate whether http://danger.systems would
       show the plugin on the website.
     DESC
 
     self.arguments = [
-      CLAide::Argument.new('Paths, Gems or Nothing', false, true),
+      CLAide::Argument.new('Paths, Gems or Nothing', false, true)
     ]
 
     def run
       paths = nil
 
       # When given existing paths, map to absolute & existing paths
-      if @refs != nil and @refs.select { |ref| File.file? ref }.any?
+      if !@refs.nil? and @refs.select { |ref| File.file? ref }.any?
         paths = @refs.select { |ref| File.file? ref }
                      .map { |path| File.expand_path(path) }
 
       # When given a list of gems
-      elsif @refs and @refs.is_a? Array 
+      elsif @refs and @refs.kind_of? Array
         require 'bundler'
         require 'pathname'
 
@@ -50,14 +50,14 @@ module Danger
           bundler.resolve_remotely!
 
           # Install the gems into a tmp dir
-          options = { :path => dir }
+          options = { path: dir }
           Bundler::Installer.install(Pathname.new(dir), bundler, options)
 
-          # Get the name'd gems out of bundler, then pull out all their paths 
+          # Get the name'd gems out of bundler, then pull out all their paths
           gems = gem_names.map { |name| bundler.specs[name] }.flatten
           paths = gems.map { |gem| Dir.glob(File.join(gem.gem_dir, "lib/**/**/**.rb")) }.flatten
         end
-      
+
       # When empty, imply you want to test the current lib folder as a plugin
       else
         paths = Dir.glob(File.join(".", "lib/*.rb"))

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -2,7 +2,7 @@ module Danger
   class Runner < CLAide::Command
     require 'danger/commands/init'
     require 'danger/commands/local'
-    require 'danger/commands/new_plugin'
+    require 'danger/commands/plugin_abstract'
 
     self.summary = 'Run the Dangerfile.'
     self.command = 'danger'

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -30,7 +30,7 @@ module Danger
 
     # These are the classes that are allowed to also use method_missing
     # in order to provide broader plugin support
-    def core_plugin_classes
+    def self.core_plugin_classes
       [
         Danger::DangerfileMessagingPlugin,
         Danger::DangerfileImportPlugin,
@@ -94,7 +94,7 @@ module Danger
         instance_variable_set("@#{name}", plugin)
 
         @plugins[klass] = plugin
-        @core_plugins << plugin if core_plugin_classes.include? klass
+        @core_plugins << plugin if self.class.core_plugin_classes.include? klass
       end
     end
     alias init_plugins refresh_plugins

--- a/lib/danger/plugin_support/plugin.rb
+++ b/lib/danger/plugin_support/plugin.rb
@@ -25,6 +25,10 @@ module Danger
       @all_plugins ||= []
     end
 
+    def self.clear_external_plugins
+      @all_plugins = @all_plugins.select { |plugin| Dangerfile.core_plugin_classes.include? plugin }
+    end
+
     def self.inherited(plugin)
       Plugin.all_plugins.push(plugin)
     end

--- a/spec/lib/danger/commands/plugin_lint_spec.rb
+++ b/spec/lib/danger/commands/plugin_lint_spec.rb
@@ -2,6 +2,10 @@ require 'danger/commands/plugin_lint'
 
 module Danger
   describe Danger::PluginLint do
+    after do
+      Plugin.clear_external_plugins
+    end
+
     it "runs the command" do
       # allow(STDOUT).to receive(:puts) # this disables puts
       Danger::PluginLint.run(["spec/fixtures/plugins/example_fully_documented.rb"])

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -148,7 +148,7 @@ describe Danger::Dangerfile do
     it "exposes no external attributes by default" do
       dm = testing_dangerfile
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
-      expect(methods).to eq [:protect_files]
+      expect(methods).to eq []
     end
 
     it "exposes plugin external attributes by default" do
@@ -158,7 +158,7 @@ describe Danger::Dangerfile do
 
       dm = testing_dangerfile
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
-      expect(methods).to eq [:my_thing, :protect_files]
+      expect(methods).to eq [:my_thing]
     end
 
     def sort_data(data)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,10 @@ require 'webmock'
 require 'webmock/rspec'
 require 'json'
 
+RSpec.configure do |config|
+  config.filter_gems_from_backtrace "bundler"
+end
+
 WebMock.disable_net_connect!(allow: 'coveralls.io')
 
 def make_temp_file(contents)


### PR DESCRIPTION
Adds a command `danger plugin lint` which can take the following types of args:

* a list of file paths
* a list of gems
* no arguments, which will parse lib/**/**/* to lint your local plugins

The website danger.systems will be using the list of gems to generate all of the up-to-date documentation. The list of file paths is good for testing, and no arguments is good for building plugins ( e.g. it'll be something you want on travisCI )