### PR TITLE
Improve init description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - a list of gems
   - no arguments, which will parse `lib/**/**/*` to lint your local plugins
 * Moved new plugin to `danger plugin new` - orta
+* Notify the user to add the new GitHub account as collaborator to Close Source project
 
 ## 0.8.3
 

--- a/lib/danger/commands/init.rb
+++ b/lib/danger/commands/init.rb
@@ -121,6 +121,8 @@ module Danger
         ui.pause 1
         ui.say "It's worth noting that you " + "should not".bold.white + " re-use this token for OSS repos."
         ui.say "Make a new one for those repos with just " + "public_repo".yellow + "."
+        ui.pause 1
+        ui.say "Additionally, don't forget to add your new GitHub account as a collaborator to your Closed Source project."
       end
 
       ui.say "\n👍, please press return when you have your token set up..."


### PR DESCRIPTION
I followed every single `init` step and I really like the way the `init` is "communicating" with me, but it somehow failed to mention that I also have to add the GitHub Bot Account as an collaborator to my private repo and I ran into an error, when the PR got built by travis. 

I know that I could have inferred this from the fact that my repo is private, but if the installation instructions are so detailed, it should just work after following every step 😉

And since you already ask if it is an open or closed repo, I added one sentence to notify the user to add the new GitHub user as collaborator.