### PR TITLE
Moves yard require inside parse method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Renamed `branch_for_merge` to `branch_for_base` and also added `branch_for_head` - orta
 * Initial work on namespacing existing plugins - orta
 * Notify the user to add the new GitHub account as collaborator to Close Source project
+* Fixes a problem running `danger local` due to a missing dependency on yard - ashfurrow
 
 ## 0.8.3
 

--- a/lib/danger/plugin_support/plugin_parser.rb
+++ b/lib/danger/plugin_support/plugin_parser.rb
@@ -1,4 +1,3 @@
-require 'yard'
 require 'json'
 
 module Danger
@@ -16,6 +15,7 @@ module Danger
     end
 
     def parse
+      require 'yard'
       # could this go in a singleton-y place instead?
       # like class initialize?
       YARD::Tags::Library.define_tag('tags', :tags)


### PR DESCRIPTION
The yard gem is required by [`plugin_parser.rb`](https://github.com/danger/danger/blob/254b78975417fd3d2a03e87d956c1e20e7d61a7f/lib/danger/plugin_support/plugin_parser.rb#L1) but is only a [development dependency(https://github.com/danger/danger/blob/254b78975417fd3d2a03e87d956c1e20e7d61a7f/danger.gemspec#L39). This leads to the following error when running `bundle exec danger local` without yard as part of the bundle:

```
bundler: failed to load command: danger (/usr/local/lib/ruby/gems/2.2.0/bin/danger)
LoadError: cannot load such file -- yard
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/plugin_support/plugin_parser.rb:1:in `require'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/plugin_support/plugin_parser.rb:1:in `<top (required)>'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/plugins/plugin_lint.rb:2:in `require'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/plugins/plugin_lint.rb:2:in `<top (required)>'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/plugins/plugin_abstract.rb:3:in `require'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/plugins/plugin_abstract.rb:3:in `<class:PluginAbstract>'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/plugins/plugin_abstract.rb:2:in `<module:Danger>'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/plugins/plugin_abstract.rb:1:in `<top (required)>'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/runner.rb:5:in `require'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/runner.rb:5:in `<class:Runner>'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/runner.rb:2:in `<module:Danger>'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger/commands/runner.rb:1:in `<top (required)>'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger.rb:4:in `require'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/lib/danger.rb:4:in `<top (required)>'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/bin/danger:4:in `require'
  /usr/local/lib/ruby/gems/2.2.0/bundler/gems/danger-254b78975417/bin/danger:4:in `<top (required)>'
  /usr/local/lib/ruby/gems/2.2.0/bin/danger:23:in `load'
  /usr/local/lib/ruby/gems/2.2.0/bin/danger:23:in `<top (required)>'
```

Yard seems used to parse the plugin docs for static site generation, so it makes sense to keep it as a dev dependency, so moving it inside a method we don't expect to get called by `danger local` seems reasonable, but open to feedback here.