### PR TITLE
Allow Circle CI to pass validation without a PR check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Initial work on namespacing existing plugins - orta
 * Notify the user to add the new GitHub account as collaborator to Close Source project
 * Fixes a problem running `danger local` due to a missing dependency on yard - ashfurrow
+* Improvements for CircleCI CI detection - orta
+
 
 ## 0.8.3
 

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -7,7 +7,6 @@ module Danger
     class CircleCI < CI
       def self.validates?(env)
         return false unless env["CIRCLE_BUILD_NUM"]
-        return false unless env["CI_PULL_REQUEST"]
         return false unless env["CIRCLE_PROJECT_USERNAME"]
         return false unless env["CIRCLE_PROJECT_REPONAME"]
 

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -29,11 +29,11 @@ describe Danger::CISource::CircleCI do
     expect(t.pull_request_id).to be nil
   end
 
-  it 'doesnt validate when circle env var is found and it has no PR url' do
+  it 'does validate when circle env var is found and it has no PR url' do
     env = { "CIRCLE_BUILD_NUM" => "true",
             "CIRCLE_PROJECT_USERNAME" => "orta",
             "CIRCLE_PROJECT_REPONAME" => "thing" }
-    expect(Danger::CISource::CircleCI.validates?(env)).to be false
+    expect(Danger::CISource::CircleCI.validates?(env)).to be true
   end
 
   it 'doesnt validate when circle ci is not found' do


### PR DESCRIPTION
So that we can ask for the metadata a bit later.

I think I'd rather move the API check into the validation, so this is WIP until I get to a computer to do that.

/cc @ashfurrow 