### PR TITLE
Support plugin lint on plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Master
 
 * Converts the message link  to be http://danger.systems - orta
+* Fix `danger lib lint` with no params not finding the plugin paths - orta
 
-## 0.8.3
+## 0.8.4
 
 * Initial work on `danger plugin lint` command - orta
 * `danger plugin lint` can run with either:

--- a/lib/danger/plugin_support/plugin_file_resolver.rb
+++ b/lib/danger/plugin_support/plugin_file_resolver.rb
@@ -41,7 +41,7 @@ module Danger
         end
       # When empty, imply you want to test the current lib folder as a plugin
       else
-        Dir.glob(File.join(".", "lib/*.rb"))
+        Dir.glob(File.join(".", "lib/*.rb")).map { |path| File.expand_path(path) }
       end
     end
   end


### PR DESCRIPTION
`plugin lint` doesn't work well with the relative links passed back from `Dir.glob`.

![screen shot 2016-07-04 at 3 12 38 pm](https://cloud.githubusercontent.com/assets/49038/16568563/e17e0928-41f9-11e6-921b-dca7547a1711.png)
