### PR TITLE
Add CI support for the Surf CI server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Warn users not to store GitHub tokens in the repository -- dantoml
 * Crash on load fix for `danger plugins readme` -- orta
+* Add support for Surf CI (https://github.com/surf-build/surf) -- paulcbetts
 
 ## 0.8.5
 

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,10 @@
-gem install rubygems-bundler
 gem install bundler
 bundle exec rake spec
+
+if [-z "$SURF_BUILD_NAME" ]; then
+	## Posting to GitHub
+	bundle exec danger
+else
+	## Local clean build, just print to console
+	bundle exec danger local
+fi

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+gem install rubygems-bundler
+gem install bundler
+bundle exec rake spec

--- a/lib/danger/ci_source/surf.rb
+++ b/lib/danger/ci_source/surf.rb
@@ -4,7 +4,7 @@ module Danger
   module CISource
     class Surf < CI
       def self.validates?(env)
-        return ['SURF_REPO', 'SURF_NWO'].all? {|x| env[x]}
+        return ["SURF_REPO", "SURF_NWO"].all? { |x| env[x] }
       end
 
       def supported_request_sources
@@ -12,12 +12,12 @@ module Danger
       end
 
       def initialize(env)
-        self.repo_slug = env['SURF_NWO']
-        if env['SURF_PR_NUM'].to_i > 0
-          self.pull_request_id = env['SURF_PR_NUM']
+        self.repo_slug = env["SURF_NWO"]
+        if env["SURF_PR_NUM"].to_i > 0
+          self.pull_request_id = env["SURF_PR_NUM"]
         end
-        
-        self.repo_url = env['SURF_REPO'];
+
+        self.repo_url = env["SURF_REPO"]
       end
     end
   end

--- a/lib/danger/ci_source/surf.rb
+++ b/lib/danger/ci_source/surf.rb
@@ -1,0 +1,24 @@
+# http://github.com/surf-build/surf
+
+module Danger
+  module CISource
+    class Surf < CI
+      def self.validates?(env)
+        return ['SURF_REPO', 'SURF_NWO'].all? {|x| env[x]}
+      end
+
+      def supported_request_sources
+        @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      end
+
+      def initialize(env)
+        self.repo_slug = env['SURF_NWO']
+        if env['SURF_PR_NUM'].to_i > 0
+          self.pull_request_id = env['SURF_PR_NUM']
+        end
+        
+        self.repo_url = env['SURF_REPO'];
+      end
+    end
+  end
+end

--- a/spec/lib/danger/ci_sources/surf_spec.rb
+++ b/spec/lib/danger/ci_sources/surf_spec.rb
@@ -4,7 +4,7 @@ describe Danger::CISource::Surf do
   it "validates when all Surf environment vars are set" do
     env = { "SURF_REPO" => "https://github.com/surf-build/surf",
             "SURF_NWO" => "surf-build/surf" }
-          
+
     expect(Danger::CISource::Surf.validates?(env)).to be true
   end
 
@@ -29,7 +29,7 @@ describe Danger::CISource::Surf do
     env = {
       "SURF_PR_NUM" => "800",
       "SURF_NWO" => "artsy/eigen",
-      "SURF_REPO" => "https://github.com/artsy/eigen",
+      "SURF_REPO" => "https://github.com/artsy/eigen"
     }
     t = Danger::CISource::Surf.new(env)
     expect(t.repo_slug).to eql("artsy/eigen")

--- a/spec/lib/danger/ci_sources/surf_spec.rb
+++ b/spec/lib/danger/ci_sources/surf_spec.rb
@@ -1,0 +1,38 @@
+require "danger/ci_source/surf"
+
+describe Danger::CISource::Surf do
+  it "validates when all Surf environment vars are set" do
+    env = { "SURF_REPO" => "https://github.com/surf-build/surf",
+            "SURF_NWO" => "surf-build/surf" }
+          
+    expect(Danger::CISource::Surf.validates?(env)).to be true
+  end
+
+  it "doesnt validate when Surf aint around" do
+    env = { "CIRCLE" => "true" }
+    expect(Danger::CISource::Surf.validates?(env)).to be false
+  end
+
+  it "gets the pull request ID" do
+    env = { "SURF_PR_NUM" => "2" }
+    t = Danger::CISource::Surf.new(env)
+    expect(t.pull_request_id).to eql("2")
+  end
+
+  it "gets the repo address" do
+    env = { "SURF_NWO" => "orta/danger" }
+    t = Danger::CISource::Surf.new(env)
+    expect(t.repo_slug).to eql("orta/danger")
+  end
+
+  it "gets out a repo slug and pull request number" do
+    env = {
+      "SURF_PR_NUM" => "800",
+      "SURF_NWO" => "artsy/eigen",
+      "SURF_REPO" => "https://github.com/artsy/eigen",
+    }
+    t = Danger::CISource::Surf.new(env)
+    expect(t.repo_slug).to eql("artsy/eigen")
+    expect(t.pull_request_id).to eql("800")
+  end
+end


### PR DESCRIPTION
This PR adds CI support for [Surf](https://github.com/surf-build/surf), a toolkit for folx to create local build servers.

Refs https://github.com/surf-build/surf/pull/32, which adds Danger support for Surf (i.e. projects that have a Dangerfile will automatically be run if CI status will be posted)