### PR TITLE
Fix for danger plugins readme crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - `create` uses https://github.com/danger/danger-plugin-template to bootstrap a new danger plugin
 
 * Warn users not to store GitHub tokens in the repository -- dantoml
+* Crash on load fix for `danger plugins readme` -- orta
 
 ## 0.8.5
 

--- a/lib/danger/commands/plugins/plugin_readme.rb
+++ b/lib/danger/commands/plugins/plugin_readme.rb
@@ -1,6 +1,7 @@
 require "danger/plugin_support/plugin_parser"
 require "danger/plugin_support/plugin_file_resolver"
 require "json"
+require "erb"
 
 module Danger
   class PluginReadme < CLAide::Command::Plugins


### PR DESCRIPTION
Turns out if you want to use ERB, you should require it 👍 