### PR TITLE
add http caching on GitHub API calls when running danger local [#198]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@
 
 * Breaking: `import_url` does not append `.rb` to your url anymore. - KrauseFx
 * Add http caching for Github API calls when running `danger local` - dbgrandi
-  - You can clear the cache with the `--clear-http-cache` command line arg
-  - The cache TTL is 5 minutes
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   For an example, see: https://github.com/Themoji/danger
 
 * Breaking: `import_url` does not append `.rb` to your url anymore. - KrauseFx
+* Add http caching for Github API calls when running `danger local` - dbgrandi
+  - You can clear the cache with the `--clear-http-cache` command line arg
+  - The cache TTL is 5 minutes
 
 ## 0.9.1
 

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "git", "~> 1"
   spec.add_runtime_dependency "colored", "~> 1.2"
   spec.add_runtime_dependency "faraday", "~> 0"
-  spec.add_runtime_dependency "faraday-http-cache"
+  spec.add_runtime_dependency "faraday-http-cache", "~> 1.0"
   spec.add_runtime_dependency "octokit", "~> 4.2"
   spec.add_runtime_dependency "redcarpet", "~> 3.3"
   spec.add_runtime_dependency "terminal-table", "~> 1"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "git", "~> 1"
   spec.add_runtime_dependency "colored", "~> 1.2"
   spec.add_runtime_dependency "faraday", "~> 0"
+  spec.add_runtime_dependency "faraday-http-cache"
   spec.add_runtime_dependency "octokit", "~> 4.2"
   spec.add_runtime_dependency "redcarpet", "~> 3.3"
   spec.add_runtime_dependency "terminal-table", "~> 1"

--- a/lib/danger/commands/local_helpers/http_cache.rb
+++ b/lib/danger/commands/local_helpers/http_cache.rb
@@ -1,0 +1,36 @@
+require "pstore"
+
+module Danger
+  class HTTPCache
+    attr_reader :expires_in
+    def initialize(cache_file = nil, options = {})
+      File.delete(cache_file) if options[:clear_cache]
+      @store = PStore.new(cache_file)
+      @expires_in = options[:expires_in] || 300 # 5 minutes
+    end
+
+    def read(key)
+      @store.transaction do
+        entry = @store[key]
+        return nil unless entry
+        return entry[:value] unless entry_has_expired(entry, @expires_in)
+        @store.delete key
+        return nil
+      end
+    end
+
+    def delete(key)
+      @store.transaction { @store.delete key }
+    end
+
+    def write(key, value)
+      @store.transaction do
+        @store[key] = { updated_at: Time.now.to_i, value: value }
+      end
+    end
+
+    def entry_has_expired(entry, ttl)
+      Time.now.to_i > entry[:updated_at].to_i + ttl.to_i
+    end
+  end
+end

--- a/spec/lib/danger/commands/local_helpers/http_cache_spec.rb
+++ b/spec/lib/danger/commands/local_helpers/http_cache_spec.rb
@@ -1,0 +1,68 @@
+require "danger/commands/local_helpers/http_cache"
+
+TEST_CACHE_FILE = File.join(Dir.tmpdir, "http_cache_spec")
+
+module Danger
+  describe Danger::HTTPCache do
+    after do
+      File.delete TEST_CACHE_FILE if File.exist? TEST_CACHE_FILE
+    end
+
+    it "will default to a 300 second cache expiry" do
+      cache = HTTPCache.new(TEST_CACHE_FILE)
+      expect(cache.expires_in).to eq(300)
+    end
+
+    it "will allow setting a custom cache expiry" do
+      cache = HTTPCache.new(TEST_CACHE_FILE, expires_in: 1234)
+      expect(cache.expires_in).to eq(1234)
+    end
+
+    it "will open a previous file by default" do
+      store = PStore.new(TEST_CACHE_FILE)
+      store.transaction { store["testing"] = { value: "pants", updated_at: Time.now } }
+      cache = HTTPCache.new(TEST_CACHE_FILE)
+      expect(cache.read("testing")).to eql("pants")
+    end
+
+    it "will delete a previous file if told to" do
+      store = PStore.new(TEST_CACHE_FILE)
+      store.transaction { store["testing"] = "pants" }
+      cache = HTTPCache.new(TEST_CACHE_FILE, clear_cache: true)
+      expect(cache.read("testing")).to be_nil
+    end
+
+    it "will honor the TTL when a read attempt is made" do
+      now = Time.now.to_i
+      store = PStore.new(TEST_CACHE_FILE)
+      store.transaction do
+        store["testing_valid_ttl"] = { value: "pants", updated_at: now - 280 }
+        store["testing_invalid_ttl"] = { value: "pants", updated_at: now - 301 }
+      end
+
+      cache = HTTPCache.new(TEST_CACHE_FILE)
+      expect(cache.read("testing_valid_ttl")).to eql("pants")
+      expect(cache.read("testing_invalid_ttl")).to be_nil
+    end
+
+    it "will delete a key" do
+      cache = HTTPCache.new(TEST_CACHE_FILE)
+
+      cache.write("testing_delete", "pants")
+      cache.delete("testing_delete")
+
+      expect(cache.read("testing_delete")).to be_nil
+    end
+
+    it "will write a key and timestamp" do
+      cache = HTTPCache.new(TEST_CACHE_FILE)
+      cache.write("testing_write", "pants")
+      store = PStore.new(TEST_CACHE_FILE)
+      store.transaction do
+        expect(store["testing_write"]).to_not be_nil
+        expect(store["testing_write"][:value]).to eql("pants")
+        expect(store["testing_write"][:updated_at]).to be_within(1).of(Time.now.to_i)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- You can clear the cache with the `--clear-http-cache` command line arg.
- The cache TTL is 5 minutes

Still have 2 or 3 non-cached calls to GitHub, but it used to be around 8 when I was testing locally.