### PR TITLE
Prepare for 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+## 0.10.0
+
 * Improves wording when failing a OSS build - orta
 * Add support for org-wide Dangerfile -- KrauseFx
   - To use this, create a repo on your GitHub organization called "danger" (or "Danger")
@@ -11,6 +13,7 @@
 
 * Breaking: `import_url` does not append `.rb` to your url anymore. - KrauseFx
 * Minor core documentation updates - orta
+* `danger plugin lint` now says it's failed when it's failed, not when it succeeds - orta
 * Fixes to the markdown support in `warn`, `fail` and `message` - orta
 * Add http caching for Github API calls when running `danger local` - dbgrandi
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,37 +1,41 @@
 # Sometimes its a README fix, or something like that - which isn't relevant for
 # including in a CHANGELOG for example
-
 has_app_changes = !git.modified_files.grep(/lib/).empty?
 has_test_changes = !git.modified_files.grep(/spec/).empty?
-
-# Make a note about contributors not in the organization
-unless github.api.organization_member?('danger', pr_author)
-  message "@#{pr_author} is not a contributor yet, would you like to join the Danger org?"
-
-  if git.modified_files.include?("*.gemspec")
-    warn "External contributor has edited the Gemspec"
-  end
-end
 
 if has_app_changes && !has_test_changes
   warn "Tests were not updated"
 end
 
+# Make a note about contributors not in the organization
+unless github.api.organization_member?('danger', pr_author)
+  message "@#{pr_author} is not a contributor yet, would you like to join the Danger org?"
+
+  # Pay extra attention if they modify the gemspec
+  if git.modified_files.include?("*.gemspec")
+    warn "External contributor has edited the Gemspec"
+  end
+end
+
+# Mainly to encourage writing up some reasoning about the PR, rather than
+# just leaving a title
 if github.pr_body.length < 5
   fail "Please provide a summary in the Pull Request description"
 end
 
+# Let people say that this isn't worth a CHANGELOG entry in the PR if they choose
 declared_trivial = (github.pr_title + github.pr_body).include?("#trivial") || !has_app_changes
+
 if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
   fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/danger/danger/blob/master/CHANGELOG.md).")
 end
 
-### Oddly enough, it's quite possible to do some testing of Danger, inside Danger
-### So, you can ignore these, if you're looking at the Dangerfile to get ideas.
-
+# Oddly enough, it's quite possible to do some testing of Danger, inside Danger
+# So, you can ignore these, if you're looking at the Dangerfile to get ideas.
+#
 # If these are all empty something has gone wrong, better to raise it in a comment
 if git.modified_files.empty? && git.added_files.empty? && git.deleted_files.empty?
-  fail "This PR has no changes at all, this is likely a developer issue."
+  fail "This PR has no changes at all, this is likely an issue during development."
 end
 
 # This comes from `./danger_plugins/protect_files.rb` which is automatically parsed by Danger
@@ -40,6 +44,7 @@ files.protect_files(path: "danger.gemspec", message: ".gemspec modified", fail_b
 # Ensure that our core plugins all have 100% documentation
 core_plugins = Dir.glob("lib/danger/danger_core/plugins/*.rb")
 core_lint_output = `bundle exec yard stats #{core_plugins.join ' '} --list-undoc --tag tags`
+
 if !core_lint_output.include?("100.00%")
   fail "The core plugins are not at 100% doc'd - see: \n\n```\n\n#{core_lint_output}\n```"
 elsif core_lint_output.include? "warning"

--- a/lib/danger/version.rb
+++ b/lib/danger/version.rb
@@ -1,4 +1,4 @@
 module Danger
-  VERSION = "0.9.1".freeze
+  VERSION = "0.10.0".freeze
   DESCRIPTION = "Automate your PR etiquette.".freeze
 end


### PR DESCRIPTION
I wanna hold off on the big 2.0 release for a few days, should just be these two issues https://github.com/danger/danger/milestone/1 - pretty trivial to do, but I wanna time it with the website being ready.

Updates the Dangerfile because now it's shown on Danger.systems