### PR TITLE
Add `danger local --pry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Add `danger local --pry`, which drops into a Pry shell after eval-ing the Dangerfile - dbgrandi
+
 ## 0.10.0
 
 * Improves wording when failing a OSS build - orta

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -12,18 +12,23 @@ module Danger
     def initialize(argv)
       @pr_num = argv.option("use-merged-pr")
       @clear_http_cache = argv.flag?("clear-http-cache", false)
-      @should_pry = argv.flag?("pry", false)
 
       super
 
-      if @should_pry && !@dangerfile_path.empty? && validate_pry_available
-        File.delete "_Dangerfile.tmp" if File.exist? "_Dangerfile.tmp"
-        FileUtils.cp @dangerfile_path, "_Dangerfile.tmp"
-        File.open("_Dangerfile.tmp", "a") do |f|
-          f.write("binding.pry; File.delete(\"_Dangerfile.tmp\")")
-        end
-        @dangerfile_path = "_Dangerfile.tmp"
+      setup_pry if should_pry?(argv)
+    end
+
+    def should_pry?(argv)
+      argv.flag?("pry", false) && !@dangerfile_path.empty? && validate_pry_available
+    end
+
+    def setup_pry
+      File.delete "_Dangerfile.tmp" if File.exist? "_Dangerfile.tmp"
+      FileUtils.cp @dangerfile_path, "_Dangerfile.tmp"
+      File.open("_Dangerfile.tmp", "a") do |f|
+        f.write("binding.pry; File.delete(\"_Dangerfile.tmp\")")
       end
+      @dangerfile_path = "_Dangerfile.tmp"
     end
 
     def validate_pry_available

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -27,13 +27,11 @@ module Danger
     end
 
     def validate_pry_available
-      begin
-        require 'pry'
-      rescue LoadError
-        cork.warn "Pry was not found, and is required for 'danger local --pry'."
-        cork.print_warnings
-        abort
-      end
+      require "pry"
+    rescue LoadError
+      cork.warn "Pry was not found, and is required for 'danger local --pry'."
+      cork.print_warnings
+      abort
     end
 
     def self.options

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -20,7 +20,7 @@ module Danger
         File.delete "_Dangerfile.tmp" if File.exist? "_Dangerfile.tmp"
         FileUtils.cp @dangerfile_path, "_Dangerfile.tmp"
         File.open("_Dangerfile.tmp", "a") do |f|
-          f.write("binding.pry")
+          f.write("binding.pry; File.delete(\"_Dangerfile.tmp\")")
         end
         @dangerfile_path = "_Dangerfile.tmp"
       end

--- a/lib/danger/plugin_support/plugin.rb
+++ b/lib/danger/plugin_support/plugin.rb
@@ -32,5 +32,16 @@ module Danger
     def self.inherited(plugin)
       Plugin.all_plugins.push(plugin)
     end
+
+    private
+
+    # When using `danger local --pry`, every plugin had an unreasonable
+    # amount of text output due to the dangefile. So, it is filtered
+    # out. Users will start out in the context of the Dangerfile,
+    # and can view it by just typing `self` into the REPL.
+    #
+    def pretty_print_instance_variables
+      super - [:@dangerfile]
+    end
   end
 end

--- a/lib/danger/plugin_support/plugin.rb
+++ b/lib/danger/plugin_support/plugin.rb
@@ -36,9 +36,9 @@ module Danger
     private
 
     # When using `danger local --pry`, every plugin had an unreasonable
-    # amount of text output due to the dangefile. So, it is filtered
-    # out. Users will start out in the context of the Dangerfile,
-    # and can view it by just typing `self` into the REPL.
+    # amount of text output due to the Dangerfile reference in every
+    # plugin. So, it is filtered out. Users will start out in the context
+    # of the Dangerfile, and can view it by just typing `self` into the REPL.
     #
     def pretty_print_instance_variables
       super - [:@dangerfile]


### PR DESCRIPTION
Drops into a Pry shell after evaluating the Dangerfile. Great way to explore how Danger works and what tools you have to use in your Dangerfile.

Removed a reference that created `@dangerfile_path` because it's a duplicate of logic in the parent class.
