### PR TITLE
Breaking - Remove git, github, and import from the internal plugins list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 ## Master
 
+* **BREAKING** Removes a lot of top-level attributes in the DSL - orta
+
+Full list of changes:
+
+```
+# Git Stuff
+modified_files -> git.modified_files
+added_files -> git.added_files
+deleted_files -> git.deleted_files
+lines_of_code -> git.lines_of_code
+deletions -> git.deletions
+insertions -> git.insertions
+commits -> git.commits
+
+# GitHub Stuff
+pr_title ->  github.deleted
+pr_body -> github.body
+pr_author -> github.author
+pr_label -> github.label
+branch_for_base -> github.branch_for_base
+branch_for_head -> github.branch_for_head
+base_commit -> github.base_commit
+head_commit -> github.head_commit
+env.request_source.pr_json -> github.pr_json
+env.request_source.api -> github.api
+
+# Importing Stuff
+import -> plugin.import
+```
+
+The main reason for this is that we can support many code review APIs without having to fudge the Dangerfile DSL to make them conform to GitHub standards. This would mean a gitlab user could write `gitlab.mr_author` to access the author once [#229](https://github.com/danger/danger/pull/299) lands.
+
+It also ensures that Danger's plugins are treated like external plugins. This means any work going into improving core plugins (via documentation or automation for example) will improve the upcoming plugin community.
+
+I don't like breaking backwards comparability. Sorry, for as far as I can see at this point, this is the only one Danger needs.
+
 ## 0.10.1
 
 * Add `danger local --pry`, which drops into a Pry shell after eval-ing the Dangerfile - dbgrandi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ insertions -> git.insertions
 commits -> git.commits
 
 # GitHub Stuff
-pr_title ->  github.deleted
-pr_body -> github.body
-pr_author -> github.author
-pr_label -> github.label
+pr_title ->  github.pr_title
+pr_body -> github.pr_body
+pr_author -> github.pr_author
+pr_labels -> github.pr_labels
 branch_for_base -> github.branch_for_base
 branch_for_head -> github.branch_for_head
 base_commit -> github.base_commit

--- a/Dangerfile
+++ b/Dangerfile
@@ -8,8 +8,8 @@ if has_app_changes && !has_test_changes
 end
 
 # Make a note about contributors not in the organization
-unless github.api.organization_member?('danger', pr_author)
-  message "@#{pr_author} is not a contributor yet, would you like to join the Danger org?"
+unless github.api.organization_member?('danger', github.pr_author)
+  message "@#{github.pr_author} is not a contributor yet, would you like to join the Danger org?"
 
   # Pay extra attention if they modify the gemspec
   if git.modified_files.include?("*.gemspec")

--- a/danger_plugins/protect_files.rb
+++ b/danger_plugins/protect_files.rb
@@ -4,7 +4,7 @@ module Danger
       raise "You have to provide a message" if message.to_s.empty?
       raise "You have to provide a path" if path.to_s.empty?
 
-      broken_rule = modified_files.include?(path)
+      broken_rule = git.modified_files.include?(path)
 
       return unless broken_rule
       fail_build ? fail(message) : warn(message)

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -31,19 +31,14 @@ module Danger
     # These are the classes that are allowed to also use method_missing
     # in order to provide broader plugin support
     def self.core_plugin_classes
-      [
-        Danger::DangerfileMessagingPlugin,
-        Danger::DangerfileImportPlugin,
-        Danger::DangerfileGitHubPlugin,
-        Danger::DangerfileGitPlugin
-      ]
+      [Danger::DangerfileMessagingPlugin]
     end
 
     # Both of these methods exist on all objects
     # http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-warn
     # http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-fail
     # However, as we're using using them in the DSL, they won't
-    # get method_missing called correctly.
+    # get method_missing called correctly without overriding them.
 
     def warn(*args, &blk)
       method_missing(:warn, *args, &blk)
@@ -54,7 +49,8 @@ module Danger
     end
 
     # When an undefined method is called, we check to see if it's something
-    # that the DSLs have, then starts looking at plugins support.
+    # that the core DSLs have, then starts looking at plugins support.
+
     def method_missing(method_sym, *arguments, &_block)
       @core_plugins.each do |plugin|
         if plugin.public_methods(false).include?(method_sym)

--- a/spec/lib/danger/ci_sources/git_spec.rb
+++ b/spec/lib/danger/ci_sources/git_spec.rb
@@ -20,15 +20,15 @@ describe Danger::GitRepo do
     end
 
     it "#modified_files returns a FileList object" do
-      expect(@dm.modified_files.class).to eql(Danger::FileList)
+      expect(@dm.git.modified_files.class).to eql(Danger::FileList)
     end
 
     it "#added_files returns a FileList object" do
-      expect(@dm.added_files.class).to eql(Danger::FileList)
+      expect(@dm.git.added_files.class).to eql(Danger::FileList)
     end
 
     it "#deleted_files returns a FileList object" do
-      expect(@dm.deleted_files.class).to eql(Danger::FileList)
+      expect(@dm.git.deleted_files.class).to eql(Danger::FileList)
     end
   end
 
@@ -50,7 +50,7 @@ describe Danger::GitRepo do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.added_files).to eql(["file2"])
+        expect(@dm.git.added_files).to eql(["file2"])
       end
     end
 
@@ -71,7 +71,7 @@ describe Danger::GitRepo do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.deleted_files).to eql(["file"])
+        expect(@dm.git.deleted_files).to eql(["file"])
       end
     end
 
@@ -92,7 +92,7 @@ describe Danger::GitRepo do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.modified_files).to eql(["file"])
+        expect(@dm.git.modified_files).to eql(["file"])
       end
     end
   end
@@ -115,7 +115,7 @@ describe Danger::GitRepo do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.insertions).to eql(3)
+        expect(@dm.git.insertions).to eql(3)
       end
     end
 
@@ -136,7 +136,7 @@ describe Danger::GitRepo do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.deletions).to eql(1)
+        expect(@dm.git.deletions).to eql(1)
       end
     end
 
@@ -158,7 +158,7 @@ describe Danger::GitRepo do
           @dm = testing_dangerfile
           @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-          messages = @dm.commits.map(&:message)
+          messages = @dm.git.commits.map(&:message)
           expect(messages).to eq(["another"])
         end
       end

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -115,33 +115,7 @@ describe Danger::Dangerfile do
       dm = testing_dangerfile
       methods = dm.core_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
 
-      expect(methods).to eq [
-        :added_files,
-        :api,
-        :base_commit,
-        :branch_for_base,
-        :branch_for_head,
-        :commits,
-        :deleted_files,
-        :deletions,
-        :download,
-        :fail,
-        :head_commit,
-        :import,
-        :insertions,
-        :lines_of_code,
-        :markdown,
-        :message,
-        :modified_files,
-        :pr_author,
-        :pr_body,
-        :pr_json,
-        :pr_labels,
-        :pr_title,
-        :status_report,
-        :violation_report,
-        :warn
-      ]
+      expect(methods).to eq [:fail, :markdown, :message, :status_report, :violation_report, :warn]
     end
 
     # NOTE: :protect_files comes from this repo, it is considered a "Danger" plugin, for
@@ -195,23 +169,6 @@ describe Danger::Dangerfile do
       data = sort_data(data)
 
       expect(data).to eq [
-        ["added_files", []],
-        ["api", "Octokit::Client"],
-        ["base_commit", "704dc55988c6996f69b6873c2424be7d1de67bbe"],
-        ["branch_for_base", "master"],
-        ["branch_for_head", "orta-circle_ci2"],
-        ["commits", []],
-        ["deleted_files", []],
-        ["deletions", 60],
-        ["head_commit", "561827e46167077b5e53515b4b7349b8ae04610b"],
-        ["insertions", 15],
-        ["lines_of_code", 75],
-        ["modified_files", "CHANGELOG.md\nlib/danger/ci_source/local_git_repo.rb\nlib/danger/commands/local.rb\nlib/danger/commands/new_plugin.rb\nlib/danger/commands/runner.rb\nlib/danger/environment_manager.rb\nspec/sources/local_git_repo_spec.rb"],
-        ["pr_author", "orta"],
-        ["pr_body", "![](http://media4.giphy.com/media/Ksn86eRmE2taM/giphy.gif)\n\n> Danger: Ignore \"Developer Specific file shouldn't be changed\"\n\n> Danger: Ignore \"Some warning\"\n"],
-        ["pr_json", "[Skipped]"],
-        ["pr_labels", "D:2\nMaintenance Work"],
-        ["pr_title", "[CI] Use Xcode 7 for Circle CI"],
         ["status_report", { errors: [], warnings: [], messages: [], markdowns: [] }],
         ["violation_report", { errors: [], warnings: [], messages: [] }]
       ]

--- a/spec/lib/danger/import_spec.rb
+++ b/spec/lib/danger/import_spec.rb
@@ -1,24 +1,24 @@
 require 'danger/danger_core/environment_manager'
+require 'danger/danger_core/plugins/dangerfile_import_plugin'
 
 describe Danger::Dangerfile::DSL do
   describe '#import' do
     before do
-      file = make_temp_file('')
-      env = Danger::EnvironmentManager.new({ 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true', 'TRAVIS_REPO_SLUG' => 'KrauseFx/fastlane', 'TRAVIS_PULL_REQUEST' => '12' })
-      @dm = Danger::Dangerfile.new(env, testing_ui)
-      @dm.parse(file.path)
+      # Normally this happens during launch, but tests will clear this out
+      Danger::Plugin.all_plugins.push(Danger::DangerfileImportPlugin)
+      @dm = testing_dangerfile
     end
 
     describe '#import_local' do
       it 'supports exact paths' do
-        @dm.import('spec/fixtures/plugins/example_exact_path.rb')
+        @dm.plugin.import('spec/fixtures/plugins/example_exact_path.rb')
 
         expect { @dm.example_exact_path }.to_not raise_error
         expect(@dm.example_exact_path.echo).to eq('Hi there exact')
       end
 
       it 'supports file globbing' do
-        @dm.import('spec/fixtures/plugins/*globbing*.rb')
+        @dm.plugin.import('spec/fixtures/plugins/*globbing*.rb')
 
         expect(@dm.example_globbing.echo).to eq('Hi there globbing')
       end
@@ -26,7 +26,7 @@ describe Danger::Dangerfile::DSL do
       # This is going to become a lot more complicated in the future, so I'm
       # happy to have it pending for now.
       xit "raises an error when calling a plugin that's not a subclass of Plugin" do
-        @dm.import('spec/fixtures/plugins/example_broken.rb')
+        @dm.plugin.import('spec/fixtures/plugins/example_broken.rb')
 
         expect do
           @dm.example_broken
@@ -42,14 +42,14 @@ describe Danger::Dangerfile::DSL do
         stub_request(:get, 'https://krausefx.com/example_remote.rb').
           to_return(status: 200, body: File.read('spec/fixtures/plugins/example_remote.rb'))
 
-        @dm.import(url)
+        @dm.plugin.import(url)
 
         expect(@dm.example_remote.echo).to eq("Hi there remote 🎉")
       end
 
       it 'rejects unencrypted plugins' do
         expect do
-          @dm.import('http://unecnrypted.org')
+          @dm.plugin.import('http://unecnrypted.org')
         end.to raise_error('URL is not https, for security reasons `danger` only supports encrypted requests')
       end
     end


### PR DESCRIPTION
This has big ramifications for Dangerfiles. It scopes the git, github, and import plugins.

```
# Git Stuff
modified_files -> git.modified_files
added_files -> git.added_files
deleted_files -> git.deleted_files
lines_of_code -> git.lines_of_code
deletions -> git.deletions
insertions -> git.insertions
commits -> git.commits

# GitHub Stuff
pr_title ->  github.deleted
pr_body -> github.body
pr_author -> github.author
pr_labels -> github.labels
branch_for_base -> github.branch_for_base
branch_for_head -> github.branch_for_head
base_commit -> github.base_commit
head_commit -> github.head_commit
env.request_source.pr_json -> github.pr_json
env.request_source.api -> github.api

# Importing Stuff
import -> plugin.import
```

This should be the last big breaking change before the major release.