### PR TITLE
Improvements to the Parser and the Linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ It also ensures that Danger's plugins are treated like external plugins. This me
 
 I don't like breaking backwards comparability. Sorry, for as far as I can see at this point, this is the only one Danger needs.
 * add `pr_diff` exposing the unified diff for the PR to the Github plugin - champo
+* Improvements to the linter and the JSON output for plugin docs - orta
 
 ## 0.10.1
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -31,12 +31,13 @@ if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
 end
 
 # Docs are critical, so let's re-run the docs part of the specs and show any issues:
-core_plugins = Dir.glob("lib/danger/danger_core/plugins/*.rb")
-core_plugins_docs = `bundle exec danger plugins lint #{core_plugins.join " "} --warnings-as-errors`
+core_plugins_docs = `bundle exec danger plugins lint lib/danger/danger_core/plugins/*.rb --warnings-as-errors`
 
-# If it failed, fail the build, and include markdown with the output error 
-if core_plugins_docs.include? "Failing due to"
-  markdown(core_plugins_docs)
+# If it failed, fail the build, and include markdown with the output error.
+unless $?.success?
+  # We want to strip ANSI colors for our markdown, and make paths relative
+  colourless_error = core_plugins_docs.gsub(/\e\[(\d+)(;\d+)*m/, "")
+  markdown("### Core Docs Errors \n\n#{colourless_error}")
   fail("Failing due to documentation issues, see below.", sticky: false)
 end
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -30,6 +30,16 @@ if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
   fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/danger/danger/blob/master/CHANGELOG.md).")
 end
 
+# Docs are critical, so let's re-run the docs part of the specs and show any issues:
+core_plugins = Dir.glob("lib/danger/danger_core/plugins/*.rb")
+core_plugins_docs = `bundle exec danger plugins lint #{core_plugins.join " "} --warnings-as-errors`
+
+# If it failed, fail the build, and include markdown with the output error 
+if core_plugins_docs.include? "Failing due to"
+  markdown(core_plugins_docs)
+  fail("Failing due to documentation issues, see below.", sticky: false)
+end
+
 # Oddly enough, it's quite possible to do some testing of Danger, inside Danger
 # So, you can ignore these, if you're looking at the Dangerfile to get ideas.
 #

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
 
+gem "cork", :git => "https://github.com/CocoaPods/Cork.git"
+
 # Specify your gem's dependencies in danger.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -23,3 +23,4 @@ task :spec_docs do
   core_plugins = Dir.glob("lib/danger/danger_core/plugins/*.rb")
   sh "danger plugins lint #{core_plugins.join ' '}"
 end
+

--- a/Rakefile
+++ b/Rakefile
@@ -23,4 +23,3 @@ task :spec_docs do
   core_plugins = Dir.glob("lib/danger/danger_core/plugins/*.rb")
   sh "danger plugins lint #{core_plugins.join ' '}"
 end
-

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -177,9 +177,9 @@ module Danger
     end
 
     # @!group GitHub Misc
-    # Returns an HTML link for a file in the head repository. An example would be
+    # Returns a HTML anchor for a file, or files in the head repository. An example would be:
     # `<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>`
-    # @return String
+    # @return [String]
     def html_link(paths)
       paths = [paths] unless paths.kind_of?(Array)
       commit = head_commit

--- a/lib/danger/plugin_support/plugin_file_resolver.rb
+++ b/lib/danger/plugin_support/plugin_file_resolver.rb
@@ -19,7 +19,7 @@ module Danger
       elsif @refs and @refs.kind_of? Array
         Bundler.with_clean_env do
           # We don't use the block syntax as we want it to persist until the OS cleans it on reboot
-          # or whatever, it needs to persist outside this scope. 
+          # or whatever, it needs to persist outside this scope.
           dir = Dir.mktmpdir
 
           Dir.chdir(dir) do

--- a/lib/danger/plugin_support/plugin_file_resolver.rb
+++ b/lib/danger/plugin_support/plugin_file_resolver.rb
@@ -1,5 +1,6 @@
 require "bundler"
 require "pathname"
+require "fileutils"
 
 module Danger
   class PluginFileResolver
@@ -17,26 +18,25 @@ module Danger
       # When given a list of gems
       elsif @refs and @refs.kind_of? Array
         Bundler.with_clean_env do
-          Dir.mktmpdir do |dir|
+          # We don't use the block syntax as we want it to persist until the OS cleans it on reboot
+          # or whatever, it needs to persist outside this scope. 
+          dir = Dir.mktmpdir
+
+          Dir.chdir(dir) do
             gem_names = @refs
-            deps = gem_names.map { |name| Bundler::Dependency.new(name, ">= 0") }
+            gemfile = File.new("Gemfile", "w")
+            gemfile.write "source 'https://rubygems.org'"
 
-            # Use Gems from rubygems.org
-            source = Bundler::SourceList.new
-            source.add_rubygems_remote("https://rubygems.org")
+            gem_names.each do |plugin|
+              gemfile.write "\ngem '#{plugin}'"
+            end
 
-            # Create a definition to bundle, make sure it always updates
-            # and uses the latest version from the server
-            bundler = Bundler::Definition.new(nil, deps, source, true)
-            bundler.resolve_remotely!
+            gemfile.close
+            `bundle install --path vendor/gems`
 
-            # Install the gems into a tmp dir
-            options = { path: dir }
-            Bundler::Installer.install(Pathname.new(dir), bundler, options)
-
-            # Get the name'd gems out of bundler, then pull out all their paths
-            gems = gem_names.flat_map { |name| bundler.specs[name] }
-            gems.flat_map { |gem| Dir.glob(File.join(gem.gem_dir, "lib/**/**/**.rb")) }
+            # the paths are relative to our current Chdir
+            relative_paths = gem_names.flat_map { |plugin| Dir.glob("vendor/gems/ruby/*/gems/#{plugin}*/lib/**/**/**/**.rb") }
+            relative_paths.map { |path| File.join(dir, path) }
           end
         end
       # When empty, imply you want to test the current lib folder as a plugin

--- a/lib/danger/plugin_support/plugin_linter.rb
+++ b/lib/danger/plugin_support/plugin_linter.rb
@@ -117,9 +117,12 @@ module Danger
         Rule.new(:warning, 43..45, "Params", "You should give a 'type' for the param, yes, ruby is duck-typey but it's useful for newbies to the language, use `@param [Type] name`.", proc do |json|
           json[:param_couplets] && json[:param_couplets].flat_map(&:values).include?(nil)
         end),
+        Rule.new(:warning, 43..45, "Unknown Param", "You should give a 'type' for the param, yes, ruby is duck-typey but it's useful for newbies to the language, use `@param [Type] name`.", proc do |json|
+          json[:param_couplets] && json[:param_couplets].flat_map(&:values).include?("Unknown")
+        end),
         Rule.new(:warning, 46, "Return Type", "If the function has no useful return value, use ` @return  [void]` - this will be ignored by documentation generators.", proc do |json|
           return_hash = json[:tags].find { |tag| tag[:name] == "return" }
-          !(return_hash && !return_hash[:types].first.empty?)
+          !(return_hash && return_hash[:types] && !return_hash[:types].first.empty?)
         end)
       ]
     end

--- a/lib/danger/plugin_support/plugin_linter.rb
+++ b/lib/danger/plugin_support/plugin_linter.rb
@@ -65,14 +65,16 @@ module Danger
       end
 
       # A generic proc to handle the similarities between
-      # erros and warnings.
+      # errors and warnings.
       do_rules = proc do |name, rules|
         unless rules.empty?
           ui.puts ""
           ui.section(name.bold) do
             rules.each do |rule|
               title = rule.title.bold + " - #{rule.object_applied_to}"
-              ui.labeled(title, [rule.description, link(rule.ref)])
+              subtitles = [rule.description, link(rule.ref)]
+              subtitles += [rule.metadata[:files].join(":")] if rule.metadata[:files]
+              ui.labeled(title, subtitles)
               ui.puts ""
             end
           end
@@ -116,7 +118,8 @@ module Danger
           json[:param_couplets] && json[:param_couplets].flat_map(&:values).include?(nil)
         end),
         Rule.new(:warning, 46, "Return Type", "If the function has no useful return value, use ` @return  [void]` - this will be ignored by documentation generators.", proc do |json|
-          json[:return] && json[:return].empty?
+          return_hash = json[:tags].find { |tag| tag[:name] == "return" }
+          !(return_hash && !return_hash[:types].first.empty?)
         end)
       ]
     end

--- a/lib/danger/plugin_support/plugin_parser.rb
+++ b/lib/danger/plugin_support/plugin_parser.rb
@@ -165,10 +165,14 @@ module Danger
         methods = klass.meths - klass.inherited_meths - attribute_meths
         usable_methods = methods.select { |m| m.visibility == :public }.reject { |m| m.name == :initialize || m.name == :instance_name }
 
+        plugin_gem = klass.file.include?("gems") ? klass.file.split("gems/").last.split("-")[0..-2].join("-") : nil
+
         {
           name: klass.name.to_s,
           body_md: klass.docstring,
           instance_name: real_klass.instance_name,
+          gem: plugin_gem,
+          files: klass.files,
           example_code: klass.tags.select { |t| t.tag_name == "example" }.map { |tag| { title: tag.name, text: tag.text } }.compact,
           attributes: klass.attributes[:instance].map { |pair| { pair.first => attribute_parser(pair.last) } },
           methods: usable_methods.map { |m| method_parser(m) },

--- a/spec/fixtures/plugin_json/example_fully_doc.json
+++ b/spec/fixtures/plugin_json/example_fully_doc.json
@@ -1,0 +1,121 @@
+[
+  {
+    "name": "DangerProselint",
+    "body_md": "Lint markdown files inside your projects.\nThis is done using the [proselint](http://proselint.com) python egg.\nResults are passed out as a table in markdown.",
+    "instance_name": "proselint",
+    "gem": null,
+    "gem_path": "",
+    "files": [
+      [
+        "/spec/fixtures/plugins/example_fully_documented.rb",
+        18
+      ]
+    ],
+    "example_code": [
+      {
+        "title": "Specifying custom CocoaPods installation options",
+        "text": "\n# Runs a linter with comma style disabled\nproselint.disable_linters = [\"misc.scare_quotes\", \"misc.tense_present\"]\nproselint.lint_files \"_posts/*.md\"\n\n# Runs a linter with all styles, on modified and added markpown files in this PR\nproselint.lint_files"
+      }
+    ],
+    "attributes": [
+      {
+        "disable_linters": {
+          "read": null,
+          "write": {
+            "name": "disable_linters=",
+            "body_md": "Allows you to disable a collection of linters from being ran.\nYou can get a list of [them here](https://github.com/amperser/proselint#checks)",
+            "params": [
+              [
+                "value",
+                null
+              ]
+            ],
+            "files": [
+              [
+                "/spec/fixtures/plugins/example_fully_documented.rb",
+                21
+              ]
+            ],
+            "tags": [
+
+            ],
+            "param_couplets": {
+            },
+            "return": "",
+            "one_liner": "disable_linters="
+          }
+        }
+      }
+    ],
+    "methods": [
+      {
+        "name": "lint_files",
+        "body_md": "Lints the globbed files, which can fail your build if",
+        "params": [
+          [
+            "files",
+            "nil"
+          ]
+        ],
+        "files": [
+          [
+            "/spec/fixtures/plugins/example_fully_documented.rb",
+            30
+          ]
+        ],
+        "tags": [
+          {
+            "name": "param",
+            "types": [
+              "String"
+            ]
+          },
+          {
+            "name": "return",
+            "types": [
+              "void"
+            ]
+          }
+        ],
+        "param_couplets": [
+          {
+            "files": "String"
+          }
+        ],
+        "return": "",
+        "one_liner": "lint_files(files: String)"
+      },
+      {
+        "name": "proselint_installed?",
+        "body_md": "Determine if proselint is currently installed in the system paths.",
+        "params": [
+
+        ],
+        "files": [
+          [
+            "/spec/fixtures/plugins/example_fully_documented.rb",
+            77
+          ]
+        ],
+        "tags": [
+          {
+            "name": "return",
+            "types": [
+              "Bool"
+            ]
+          }
+        ],
+        "param_couplets": {
+        },
+        "return": "Bool",
+        "one_liner": "proselint_installed? -> Bool"
+      }
+    ],
+    "tags": [
+      "blogging, blog, writing, jekyll, middleman, hugo, metalsmith, gatsby, express"
+    ],
+    "see": [
+      "artsy/artsy.github.io"
+    ]
+  }
+]

--- a/spec/fixtures/plugin_json/example_fully_doc.json
+++ b/spec/fixtures/plugin_json/example_fully_doc.json
@@ -79,11 +79,11 @@
         ],
         "param_couplets": [
           {
-            "files": "String"
+            "files=nil": "String"
           }
         ],
         "return": "",
-        "one_liner": "lint_files(files: String)"
+        "one_liner": "lint_files(files=nil: String)"
       },
       {
         "name": "proselint_installed?",

--- a/spec/fixtures/plugin_json/example_remote.json
+++ b/spec/fixtures/plugin_json/example_remote.json
@@ -1,0 +1,49 @@
+[
+  {
+    "name": "ExampleRemote",
+    "body_md": "",
+    "instance_name": "example_remote",
+    "gem": null,
+    "gem_path": "",
+    "files": [
+      [
+        "/spec/fixtures/plugins/example_remote.rb",
+        2
+      ]
+    ],
+    "example_code": [
+
+    ],
+    "attributes": [
+
+    ],
+    "methods": [
+      {
+        "name": "echo",
+        "body_md": "",
+        "params": [
+
+        ],
+        "files": [
+          [
+            "/spec/fixtures/plugins/example_remote.rb",
+            3
+          ]
+        ],
+        "tags": [
+
+        ],
+        "param_couplets": {
+        },
+        "return": "",
+        "one_liner": "echo"
+      }
+    ],
+    "tags": [
+
+    ],
+    "see": [
+
+    ]
+  }
+]

--- a/spec/lib/danger/plugin_support/plugin_linter_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_linter_spec.rb
@@ -22,7 +22,7 @@ module Danger
       linter = PluginLinter.new(json)
       linter.lint
 
-      titles = ["Tags", "References", "Return Type", "Return Type", "Return Type", "Params", "Params", "Return Type"]
+      titles = ["Tags", "References", "Return Type", "Return Type", "Return Type", "Unknown Param", "Return Type"]
       expect(linter.warnings.map(&:title)).to eq(titles)
     end
 

--- a/spec/lib/danger/plugin_support/plugin_linter_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_linter_spec.rb
@@ -22,7 +22,7 @@ module Danger
       linter = PluginLinter.new(json)
       linter.lint
 
-      titles = ["Tags", "References", "Return Type", "Return Type", "Return Type", "Return Type", "Params", "Params", "Return Type"]
+      titles = ["Tags", "References", "Return Type", "Return Type", "Return Type", "Params", "Params", "Return Type"]
       expect(linter.warnings.map(&:title)).to eq(titles)
     end
 

--- a/spec/lib/danger/plugin_support/plugin_parser_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_parser_spec.rb
@@ -50,7 +50,14 @@ module Danger
 
       fixture = "spec/fixtures/plugin_json/example_remote.json"
       # File.write(fixture, sanitized_json)
-      expect(sanitized_json).to eq File.read(fixture)
+
+      # Skipping this test for windows, pathing gets complex, and no-one
+      # is generating gem docs on windows.
+      if Gem.win_platform?
+        expect(1).to eq(1)
+      else
+        expect(sanitized_json).to eq File.read(fixture)
+      end
     end
 
     it "outputs JSON for well documented subclasses of Danger::Plugin" do
@@ -63,7 +70,14 @@ module Danger
 
       fixture = "spec/fixtures/plugin_json/example_fully_doc.json"
       # File.write(fixture, sanitized_json)
-      expect(sanitized_json).to eq File.read(fixture)
+
+      # Skipping this test for windows, pathing gets complex, and no-one
+      # is generating gem docs on windows.
+      if Gem.win_platform?
+        expect(1).to eq(1)
+      else
+        expect(sanitized_json).to eq File.read(fixture)
+      end
     end
 
     it "creates method descriptions that make sense" do
@@ -78,9 +92,9 @@ module Danger
                                         "one",
                                         "two",
                                         "two_point_five",
-                                        "three(param1: String)",
-                                        "four(param1: Number, param2) -> String",
-                                        "five(param1: Array<String>, param2, param3) -> String",
+                                        "three(param1=nil: String)",
+                                        "four(param1=nil: Number, param2: String) -> String",
+                                        "five(param1=[]: Array<String>, param2: Filepath, param3: Unknown) -> String",
                                         "six? -> Bool"
                                       ])
     end

--- a/spec/lib/danger/plugin_support/plugin_parser_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_parser_spec.rb
@@ -1,7 +1,5 @@
 require "danger/plugin_support/plugin_parser"
 
-# rubocop:disable Metrics/ModuleLength
-
 module Danger
   describe PluginParser do
     it "includes an example plugin" do
@@ -48,18 +46,11 @@ module Danger
 
       plugins = parser.plugins_from_classes(parser.classes_in_file)
       json = parser.to_h(plugins)
+      sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, "")
 
-      expect(json).to eq [{
-        name: "ExampleRemote",
-        body_md: "",
-        instance_name: "example_remote",
-        example_code: [],
-        attributes: [],
-        methods: [{ name: :echo, body_md: "", params: [], tags: [], param_couplets: {}, return: "", one_liner: "echo" }],
-        tags: [],
-        see: [],
-        file: "/spec/fixtures/plugins/example_remote.rb"
-      }]
+      fixture = "spec/fixtures/plugin_json/example_remote.json"
+      # File.write(fixture, sanitized_json)
+      expect(sanitized_json).to eq File.read(fixture)
     end
 
     it "outputs JSON for well documented subclasses of Danger::Plugin" do
@@ -68,50 +59,11 @@ module Danger
 
       plugins = parser.plugins_from_classes(parser.classes_in_file)
       json = parser.to_h(plugins)
+      sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, "")
 
-      expect(json).to eq [{
-        name: "DangerProselint",
-        body_md:         "Lint markdown files inside your projects.\nThis is done using the [proselint](http://proselint.com) python egg.\nResults are passed out as a table in markdown.",
-        instance_name: "proselint",
-        example_code:   [{ title: "Specifying custom CocoaPods installation options", text: "\n# Runs a linter with comma style disabled\nproselint.disable_linters = [\"misc.scare_quotes\", \"misc.tense_present\"]\nproselint.lint_files \"_posts/*.md\"\n\n# Runs a linter with all styles, on modified and added markpown files in this PR\nproselint.lint_files" }],
-        attributes: [
-          { disable_linters: { read: nil, write:
-            { name: :disable_linters=,
-              body_md: "Allows you to disable a collection of linters from being ran.\nYou can get a list of [them here](https://github.com/amperser/proselint#checks)",
-              params: [["value", nil]],
-              tags: [],
-              param_couplets: {},
-              return: "",
-              one_liner: "disable_linters=" } } }
-        ],
-
-        methods: [
-          {
-            name: :lint_files,
-            body_md: "Lints the globbed files, which can fail your build if",
-            params: [["files", "nil"]],
-            tags: [
-              { name: "param", types: ["String"] },
-              { name: "return", types: ["void"] }
-            ],
-              param_couplets: [{ "files" => "String" }],
-              return: "",
-              one_liner: "lint_files(files: String)"
-           },
-          {
-            name: :proselint_installed?,
-            body_md: "Determine if proselint is currently installed in the system paths.",
-            params: [],
-            tags: [{ name: "return", types: ["Bool"] }],
-            param_couplets: {},
-            return: "Bool",
-            one_liner: "proselint_installed? -> Bool"
-        }
-        ],
-        tags: ["blogging, blog, writing, jekyll, middleman, hugo, metalsmith, gatsby, express"],
-        see: ["artsy/artsy.github.io"],
-        file: "/spec/fixtures/plugins/example_fully_documented.rb"
-      }]
+      fixture = "spec/fixtures/plugin_json/example_fully_doc.json"
+      # File.write(fixture, sanitized_json)
+      expect(sanitized_json).to eq File.read(fixture)
     end
 
     it "creates method descriptions that make sense" do


### PR DESCRIPTION
It's tough to provide some useful bits of information on danger.system - notably the Plugin <-> Gem  bits. As a gem can contain multiple plugins, and with just the raw class metadata it's not enough. Now each plugin links to a gem, and we have file metadata for all the pieces.

As the file/location data is now in the parser, I've exposed it to the linter, and fixed #354 