### PR TITLE
when outputing the summary, consider file and line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* add `file` and `line` optional parameters to methods on the messaging plugin
+
 ## 2.0
 
 * **BREAKING** Removes a lot of top-level attributes in the DSL, moving them into scoped plugins - orta
@@ -42,7 +44,6 @@ I don't like breaking backwards compatibility. Sorry, for as far as I can see at
 * Add `html_link` to the GitHub plugin - marcelofabri
 I don't like breaking backwards comparability. Sorry, for as far as I can see at this point, this is the only one Danger needs.
 * add `pr_diff` exposing the unified diff for the PR to the Github plugin - champo
-* add `file` and `line` optional parameters to methods on the messaging plugin
 * Improvements to the linter, readme generator and the JSON output for plugin docs - orta
 
 ## 0.10.1

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -197,7 +197,8 @@ module Danger
 
     def print_results
       status = status_report
-      return if (status[:errors] + status[:warnings] + status[:messages] + status[:markdowns]).count.zero?
+      violations = violation_report
+      return if (violations[:errors] + violations[:warnings] + violations[:messages] + status[:markdowns]).count.zero?
 
       ui.section("Results:") do
         [:errors, :warnings, :messages].each do |key|
@@ -210,14 +211,15 @@ module Danger
                   else
                     formatted
                   end
-          rows = status[key]
+          rows = violations[key]
           print_list(title, rows)
         end
 
         if status[:markdowns].count > 0
-          ui.section("Markdown:") do
+          ui.title("Markdown:") do
             status[:markdowns].each do |current_markdown|
-              ui.puts current_markdown
+              ui.puts "#{current_markdown.file} line #{current_markdown.line}" if current_markdown.file && current_markdown.line
+              ui.puts current_markdown.message
             end
           end
         end
@@ -229,7 +231,13 @@ module Danger
     def print_list(title, rows)
       ui.title(title) do
         rows.each do |row|
-          ui.puts("- [ ] #{row}")
+          if row.file && row.line
+            path = "#{row.file} line #{row.line}: "
+          else
+            path = ""
+          end
+
+          ui.puts("- [ ] #{path}#{row.message}")
         end
       end unless rows.empty?
     end

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -218,7 +218,7 @@ module Danger
         if status[:markdowns].count > 0
           ui.title("Markdown:") do
             status[:markdowns].each do |current_markdown|
-              ui.puts "#{current_markdown.file} line #{current_markdown.line}" if current_markdown.file && current_markdown.line
+              ui.puts "#{current_markdown.file}\#L#{current_markdown.line}" if current_markdown.file && current_markdown.line
               ui.puts current_markdown.message
             end
           end
@@ -232,7 +232,7 @@ module Danger
       ui.title(title) do
         rows.each do |row|
           if row.file && row.line
-            path = "#{row.file} line #{row.line}: "
+            path = "#{row.file}\#L#{row.line}: "
           else
             path = ""
           end

--- a/lib/danger/danger_core/messages/markdown.rb
+++ b/lib/danger/danger_core/messages/markdown.rb
@@ -8,6 +8,15 @@ module Danger
       self.line = line
     end
 
+    def ==(other)
+      return false if other.nil?
+      return false unless other.kind_of? self.class
+
+      other.message == message &&
+        other.file == file &&
+        other.line == line
+    end
+
     def to_s
       extra = []
       extra << "file: #{file}" unless file.nil?

--- a/lib/danger/danger_core/messages/violation.rb
+++ b/lib/danger/danger_core/messages/violation.rb
@@ -9,6 +9,16 @@ module Danger
       self.line = line
     end
 
+    def ==(other)
+      return false if other.nil?
+      return false unless other.kind_of? self.class
+
+      other.message == message &&
+        other.sticky == sticky &&
+        other.file == file &&
+        other.line == line
+    end
+
     def to_s
       extra = []
       extra << "sticky: true" if sticky

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -60,9 +60,9 @@ describe Danger::Dangerfile do
 
       dm.parse Pathname.new(""), code
 
-      expect(dm).to receive(:print_list).with("Errors:".red, ["Another error", "An error"])
-      expect(dm).to receive(:print_list).with("Warnings:".yellow, ["Another warning", "A warning"])
-      expect(dm).to receive(:print_list).with("Messages:", ["A message"])
+      expect(dm).to receive(:print_list).with("Errors:".red, violations(["Another error", "An error"], sticky: true))
+      expect(dm).to receive(:print_list).with("Warnings:".yellow, violations(["Another warning", "A warning"], sticky: true))
+      expect(dm).to receive(:print_list).with("Messages:", violations(["A message"], sticky: true))
 
       dm.print_results
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,12 +68,12 @@ def diff_fixture(file)
   File.read("spec/fixtures/#{file}.diff")
 end
 
-def violation(message)
-  Danger::Violation.new(message, false, nil, nil)
+def violation(message, sticky: false)
+  Danger::Violation.new(message, sticky, nil, nil)
 end
 
-def violations(messages)
-  messages.map { |s| violation(s) }
+def violations(messages, sticky: false)
+  messages.map { |s| violation(s, sticky: sticky) }
 end
 
 def markdown(message)


### PR DESCRIPTION
Print out the file and line on the summary if present.

```markdown
Results:

Warnings:
- [ ] Gemfile line 3: Recursive warn - inline false
- [ ] Gemfile line 1: Recursive warn - inline false
- [ ] Gemfile.lock line 15: Recursive warn 2 - inline false
- [ ] .gitignore line 10: ignore - inline false
```