### PR TITLE
show a link to the line when setting inline comments

### DIFF
--- a/spec/fixtures/comment_with_file_link.html
+++ b/spec/fixtures/comment_with_file_link.html
@@ -1,0 +1,14 @@
+<table>
+  <thead>
+    <tr>
+      <th width="50"></th>
+      <th width="100%">1 Warning</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>:warning:</td>
+    <td data-sticky="true"><a href="https://github.com/artsy/eigen/blob/13c4dc8bb61d/.gitignore#L10">.gitignore:10</a> - some warning</td>
+  </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
Add a link to the file & line the message is for in GitHub. Like: `https://github.com/danger/danger/blob/744eefaf2f9338ef373e06d5156dda9d51375390/lib/danger/request_source/github.rb#L5`.

I've added a test around the parsing of this new messages. I'm not sure if more tests would be useful. @orta does it seem right to you?