### PR TITLE
Correct formatting of the fdescribe/fit grep calls #trivial

### DIFF
--- a/lib/assets/DangerfileTemplate
+++ b/lib/assets/DangerfileTemplate
@@ -9,5 +9,5 @@ warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
 warn("Big PR") if git.lines_of_code > 500
 
 # Don't let testing shortcuts get into master by accident
-fail("fdescribe left in tests") if `grep -r fdescribe specs/`.length > 1
-fail("fit left in tests") if `grep -r "fit specs/ `.length > 1
+fail("fdescribe left in tests") if `grep -r fdescribe specs/ `.length > 1
+fail("fit left in tests") if `grep -r fit specs/ `.length > 1


### PR DESCRIPTION
I cheered a bit too early in #374, the 2.0.1 release solved the crashers, but still didn't produce an error-free `Dangerfile` when running `danger init`.

```shell
sh: -c: line 0: unexpected EOF while looking for matching `"'
sh: -c: line 1: syntax error: unexpected end of file
```

This PR removes one space and one dquote to get rid of the shell warnings. The output then becomes something more along the lines of:

```shell
Results:

Errors:
- [ ] fit left in tests
```

