### PR TITLE
Add git.diff_for_file("some/file.txt") to get a Git::Diff::DiffFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Merges some of the work on splitting the request source done in #299 - orta, who merged k0nserv's work.
+* Add `git.diff_for_file("some/file.txt")` to get a Git::Diff::DiffFile - dbgrandi
 
 ## 2.0.1
 

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -100,5 +100,13 @@ module Danger
     def commits
       @git.log.to_a
     end
+
+    # @!group Git Metadata
+    # Details for a specific file in this diff
+    # @return [Git::Diff::DiffFile] from the gem `git`
+    #
+    def diff_for_file(file)
+      modified_files.include?(file) ? @git.diff[file] : nil
+    end
   end
 end

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -23,9 +23,15 @@ module Danger
   # @example Warn when there are merge commits in the diff
   #
   #          if commits.any? { |c| c.message =~ /^Merge branch 'master'/ }
-  #             warn 'Please rebase to get rid of the merge commits in this PR'
+  #            warn 'Please rebase to get rid of the merge commits in this PR'
   #          end
   #
+  # @example Warn when somebody tries to add nokogiri to the project
+  #
+  #          diff = git.diff_for_file["Gemfile.lock"]
+  #          if diff && diff.patch =~ "nokogiri"
+  #            warn 'Please do not add nokogiri to the project. Thank you.'
+  #          end
   #
   # @see  danger/danger
   # @tags core, git


### PR DESCRIPTION
I wanted a way to get file level diff info so I could inspect the changes to our `.xcodeproj` to make sure nobody adds a specific setting.

May also use it to add a Danger message anytime a `TODO` comment is added to source files.
