### PR TITLE
Adds an option for only showing the filename for a path with `html_link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add `git.diff_for_file("some/file.txt")` to get a Git::Diff::DiffFile - dbgrandi
 * Improves the default file resolves for all the `danger plugins` commands, it will now work with a new plugin by default. - orta
 * \n now works in HTML tables - marcelofabri
+* You can now pass `full_path: false` to `github.html_link("/path/file.txt", full_path: false)` to have it only show the filename. - orta
 
 ## 2.0.1
 

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -182,16 +182,23 @@ module Danger
     end
 
     # @!group GitHub Misc
-    # Returns a HTML anchor for a file, or files in the head repository. An example would be:
-    # `<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>`
+    # Returns a list of HTML anchors for a file, or files in the head repository. An example would be:
+    # `<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>`. It returns a string of multiple anchors if passed an array.
+    # @param    [String or Array<String>] paths
+    #           A list of strings to convert to github anchors
+    # @param    [Bool] full_path
+    #           Shows the full path as the link's text, defaults to `true`.
+    #
     # @return [String]
-    def html_link(paths)
+    def html_link(paths, full_path: true)
       paths = [paths] unless paths.kind_of?(Array)
       commit = head_commit
       repo = pr_json[:head][:repo][:html_url]
+
       paths = paths.map do |path|
-        path_with_slash = "/#{path}" unless path.start_with? "/"
-        create_link("#{repo}/blob/#{commit}#{path_with_slash}", path)
+        url_path = path.start_with?("/") ? path : "/#{path}"
+        text = full_path ? path : File.basename(path)
+        create_link("#{repo}/blob/#{commit}#{url_path}", text)
       end
 
       return paths.first if paths.count < 2

--- a/spec/lib/danger/plugins/dangerfile_github_plugin_spec.rb
+++ b/spec/lib/danger/plugins/dangerfile_github_plugin_spec.rb
@@ -14,6 +14,11 @@ module Danger
           expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>")
         end
 
+        it "can show just a path" do
+          link = @dsl.html_link("/path/file.txt", full_path: false)
+          expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/path/file.txt'>file.txt</a>")
+        end
+
         it "works with 2 paths" do
           link = @dsl.html_link(["file.txt", "example.json"])
           expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a> & " \


### PR DESCRIPTION
Also fixes a bug - it wouldn't work if you gave a path which began with a `/`