### PR TITLE
Shows attributes correctly in `danger plugins readme`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Improves the default file resolves for all the `danger plugins` commands, it will now work with a new plugin by default. - orta
 * \n now works in HTML tables - marcelofabri
 * You can now pass `full_path: false` to `github.html_link("/path/file.txt", full_path: false)` to have it only show the filename. - orta
+* `danger plugins readme` shows attributes correctly. - orta
 
 ## 2.0.1
 

--- a/lib/danger/plugin_support/templates/readme_table.html.erb
+++ b/lib/danger/plugin_support/templates/readme_table.html.erb
@@ -11,14 +11,16 @@
 
 <%- unless plugin["attributes"].empty? %>
 #### Attributes
-<%- plugin["attributes"].each do |attribute| %><tr>
+<%- plugin["attributes"].each do |attribute| %>
 `<%= attribute.keys.first %>` - <%= attribute.values.first["write"]["body_md"] %>
 <%- end %>
 <%- end %>
 
+<%- unless plugin["methods"].empty? %>
 #### Methods
 <%- plugin["methods"].each do |method| %>
 `<%= method["name"] %>` - <%= method["body_md"] %>
+<%- end %>
 <%- end %>
 
 <% end %>


### PR DESCRIPTION
There was an extra `<tr>`left over
Also there is now a check for the methods before showing the headline. Can't _easily_ see a use for attributes only, but sure.