### PR TITLE
Enforce single quotes for non-interpolated strings.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,6 @@ AllCops:
     - 'spec/fixtures/**/*'
     - 'lib/danger/plugin_support/plugin_parser.rb'
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-  Enabled: true
-
 # kind_of? is a good way to check a type
 Style/ClassCheck:
   EnforcedStyle: kind_of?

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # This should move to the next release, see https://github.com/CocoaPods/Cork/pull/10
-gem "cork", git: "https://github.com/CocoaPods/Cork.git"
+gem 'cork', git: 'https://github.com/CocoaPods/Cork.git'
 
 # Specify your gem's dependencies in danger.gemspec
 gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -3,8 +3,8 @@
 
 # To run, use `guard`.
 
-guard :rspec, cmd: "bundle exec rspec" do
-  require "guard/rspec/dsl"
+guard :rspec, cmd: 'bundle exec rspec' do
+  require 'guard/rspec/dsl'
   dsl = Guard::RSpec::Dsl.new(self)
 
   # Feel free to open issues for suggestions and improvements

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-require "rubocop/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:specs)
 
@@ -8,19 +8,19 @@ task default: :spec
 
 desc "Danger's tests"
 task :spec do
-  Rake::Task["specs"].invoke
-  Rake::Task["rubocop"].invoke
-  Rake::Task["spec_docs"].invoke
+  Rake::Task['specs'].invoke
+  Rake::Task['rubocop'].invoke
+  Rake::Task['spec_docs'].invoke
 end
 
-desc "Run RuboCop on the lib/specs directory"
+desc 'Run RuboCop on the lib/specs directory'
 RuboCop::RakeTask.new(:rubocop) do |task|
-  task.patterns = Dir.glob(["lib/**/*.rb", "spec/**/*.rb"]) - Dir.glob(["spec/fixtures/**/*", "lib/danger/plugin_support/plugin_parser.rb"])
+  task.patterns = Dir.glob(['lib/**/*.rb', 'spec/**/*.rb']) - Dir.glob(['spec/fixtures/**/*', 'lib/danger/plugin_support/plugin_parser.rb'])
 end
 
-desc "Tests that the core documentation is up to snuff"
+desc 'Tests that the core documentation is up to snuff'
 task :spec_docs do
-  core_plugins = Dir.glob("lib/danger/danger_core/plugins/*.rb")
+  core_plugins = Dir.glob('lib/danger/danger_core/plugins/*.rb')
   sh "danger plugins lint #{core_plugins.join ' '}"
-  sh "danger systems ci_docs"
+  sh 'danger systems ci_docs'
 end

--- a/bin/danger
+++ b/bin/danger
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-$LOAD_PATH.push File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.push File.expand_path('../../lib', __FILE__)
 
-require "danger"
+require 'danger'
 Danger::Runner.run ARGV

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -1,47 +1,47 @@
 # coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "danger/version"
+require 'danger/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "danger"
+  spec.name          = 'danger'
   spec.version       = Danger::VERSION
-  spec.authors       = ["Orta Therox", "Felix Krause"]
-  spec.email         = ["orta.therox@gmail.com", "danger@krausefx.com"]
-  spec.license       = "MIT"
+  spec.authors       = ['Orta Therox', 'Felix Krause']
+  spec.email         = ['orta.therox@gmail.com', 'danger@krausefx.com']
+  spec.license       = 'MIT'
 
   spec.summary       = Danger::DESCRIPTION
   spec.description   = "Stop Saying 'You Forgot To…' in Code Review"
-  spec.homepage      = "http://github.com/danger/danger"
+  spec.homepage      = 'http://github.com/danger/danger'
 
-  spec.files         = Dir["lib/**/*"] + %w(bin/danger README.md LICENSE)
+  spec.files         = Dir['lib/**/*'] + %w(bin/danger README.md LICENSE)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_runtime_dependency "claide", "~> 1.0"
-  spec.add_runtime_dependency "claide-plugins", "> 0.9.0"
-  spec.add_runtime_dependency "git", "~> 1"
-  spec.add_runtime_dependency "colored", "~> 1.2"
-  spec.add_runtime_dependency "faraday", "~> 0"
-  spec.add_runtime_dependency "faraday-http-cache", "~> 1.0"
-  spec.add_runtime_dependency "octokit", "~> 4.2"
-  spec.add_runtime_dependency "redcarpet", "~> 3.3"
-  spec.add_runtime_dependency "terminal-table", "~> 1"
-  spec.add_runtime_dependency "cork", "~> 0.1"
+  spec.add_runtime_dependency 'claide', '~> 1.0'
+  spec.add_runtime_dependency 'claide-plugins', '> 0.9.0'
+  spec.add_runtime_dependency 'git', '~> 1'
+  spec.add_runtime_dependency 'colored', '~> 1.2'
+  spec.add_runtime_dependency 'faraday', '~> 0'
+  spec.add_runtime_dependency 'faraday-http-cache', '~> 1.0'
+  spec.add_runtime_dependency 'octokit', '~> 4.2'
+  spec.add_runtime_dependency 'redcarpet', '~> 3.3'
+  spec.add_runtime_dependency 'terminal-table', '~> 1'
+  spec.add_runtime_dependency 'cork', '~> 0.1'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "webmock", "~> 2.1"
-  spec.add_development_dependency "pry", "~> 0.10"
+  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.4'
+  spec.add_development_dependency 'webmock', '~> 2.1'
+  spec.add_development_dependency 'pry', '~> 0.10'
 
-  spec.add_development_dependency "rubocop", "~> 0.38"
-  spec.add_development_dependency "yard", "~> 0.8"
+  spec.add_development_dependency 'rubocop', '~> 0.38'
+  spec.add_development_dependency 'yard', '~> 0.8'
 
-  spec.add_development_dependency "listen", "3.0.7"
-  spec.add_development_dependency "guard", "~> 2.14"
-  spec.add_development_dependency "guard-rspec", "~> 4.7"
-  spec.add_development_dependency "guard-rubocop", "~> 1.2"
+  spec.add_development_dependency 'listen', '3.0.7'
+  spec.add_development_dependency 'guard', '~> 2.14'
+  spec.add_development_dependency 'guard-rspec', '~> 4.7'
+  spec.add_development_dependency 'guard-rubocop', '~> 1.2'
 end

--- a/danger_plugins/protect_files.rb
+++ b/danger_plugins/protect_files.rb
@@ -1,8 +1,8 @@
 module Danger
   class Files < Plugin
     def protect_files(path: nil, message: nil, fail_build: true)
-      raise "You have to provide a message" if message.to_s.empty?
-      raise "You have to provide a path" if path.to_s.empty?
+      raise 'You have to provide a message' if message.to_s.empty?
+      raise 'You have to provide a path' if path.to_s.empty?
 
       broken_rule = git.modified_files.include?(path)
 

--- a/lib/danger.rb
+++ b/lib/danger.rb
@@ -1,26 +1,26 @@
-require "danger/version"
-require "danger/danger_core/dangerfile"
-require "danger/danger_core/environment_manager"
-require "danger/commands/runner"
-require "danger/plugin_support/plugin"
-require "danger/core_ext/string"
-require "danger/danger_core/executor"
+require 'danger/version'
+require 'danger/danger_core/dangerfile'
+require 'danger/danger_core/environment_manager'
+require 'danger/commands/runner'
+require 'danger/plugin_support/plugin'
+require 'danger/core_ext/string'
+require 'danger/danger_core/executor'
 
-require "claide"
-require "colored"
-require "pathname"
-require "terminal-table"
-require "cork"
+require 'claide'
+require 'colored'
+require 'pathname'
+require 'terminal-table'
+require 'cork'
 
 # Import all the Sources (CI, Request and SCM)
-Dir[File.expand_path("danger/*source/*.rb", File.dirname(__FILE__))].each do |file|
+Dir[File.expand_path('danger/*source/*.rb', File.dirname(__FILE__))].each do |file|
   require file
 end
 
 module Danger
   # @return [String] The path to the local gem directory
   def self.gem_path
-    gem_name = "danger"
+    gem_name = 'danger'
     unless Gem::Specification.find_all_by_name(gem_name).any?
       raise "Couldn't find gem directory for 'danger'"
     end

--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -19,16 +19,16 @@ module Danger
   #
   class Buildkite < CI
     def self.validates_as_ci?(env)
-      env.key? "BUILDKITE"
+      env.key? 'BUILDKITE'
     end
 
     def self.validates_as_pr?(env)
-      ["BUILDKITE_PULL_REQUEST_REPO", "BUILDKITE_PULL_REQUEST"].all? { |x| env[x] }
+      ['BUILDKITE_PULL_REQUEST_REPO', 'BUILDKITE_PULL_REQUEST'].all? { |x| env[x] }
     end
 
     def initialize(env)
-      self.repo_url = env["BUILDKITE_PULL_REQUEST_REPO"]
-      self.pull_request_id = env["BUILDKITE_PULL_REQUEST"]
+      self.repo_url = env['BUILDKITE_PULL_REQUEST_REPO']
+      self.pull_request_id = env['BUILDKITE_PULL_REQUEST']
 
       repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
       self.repo_slug = repo_matches[2] unless repo_matches.nil?

--- a/lib/danger/ci_source/ci_source.rb
+++ b/lib/danger/ci_source/ci_source.rb
@@ -1,4 +1,4 @@
-require "set"
+require 'set'
 
 module Danger
   # "abstract" CI class
@@ -15,7 +15,7 @@ module Danger
     end
 
     def supported_request_sources
-      raise "CISource subclass must specify the supported request sources"
+      raise 'CISource subclass must specify the supported request sources'
     end
 
     def supports?(request_source)
@@ -31,7 +31,7 @@ module Danger
     end
 
     def initialize(_env)
-      raise "Subclass and overwrite initialize"
+      raise 'Subclass and overwrite initialize'
     end
   end
 end

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -1,6 +1,6 @@
 # https://circleci.com/docs/environment-variables
-require "uri"
-require "danger/ci_source/circle_api"
+require 'uri'
+require 'danger/ci_source/circle_api'
 
 module Danger
   # ### CI Setup
@@ -24,14 +24,14 @@ module Danger
   #
   class CircleCI < CI
     def self.validates_as_ci?(env)
-      env.key? "CIRCLE_BUILD_NUM"
+      env.key? 'CIRCLE_BUILD_NUM'
     end
 
     def self.validates_as_pr?(env)
-      return true if env["CI_PULL_REQUEST"]
+      return true if env['CI_PULL_REQUEST']
 
       # Uses the Circle API to determine if it's a PR otherwose
-      @circle_token = env["CIRCLE_CI_API_TOKEN"]
+      @circle_token = env['CIRCLE_CI_API_TOKEN']
       !pull_request_url(env).nil?
     end
 
@@ -49,11 +49,11 @@ module Danger
     end
 
     def pull_request_url(env)
-      url = env["CI_PULL_REQUEST"]
+      url = env['CI_PULL_REQUEST']
 
-      if url.nil? && !env["CIRCLE_PROJECT_USERNAME"].nil? && !env["CIRCLE_PROJECT_REPONAME"].nil?
-        repo_slug = env["CIRCLE_PROJECT_USERNAME"] + "/" + env["CIRCLE_PROJECT_REPONAME"]
-        url = fetch_pull_request_url(repo_slug, env["CIRCLE_BUILD_NUM"])
+      if url.nil? && !env['CIRCLE_PROJECT_USERNAME'].nil? && !env['CIRCLE_PROJECT_REPONAME'].nil?
+        repo_slug = env['CIRCLE_PROJECT_USERNAME'] + '/' + env['CIRCLE_PROJECT_REPONAME']
+        url = fetch_pull_request_url(repo_slug, env['CIRCLE_BUILD_NUM'])
       end
 
       url
@@ -62,13 +62,13 @@ module Danger
     def initialize(env)
       self.repo_url = GitRepo.new.origins # CircleCI doesn't provide a repo url env variable :/
 
-      @circle_token = env["CIRCLE_CI_API_TOKEN"]
+      @circle_token = env['CIRCLE_CI_API_TOKEN']
       url = pull_request_url(env)
 
-      if URI.parse(url).path.split("/").count == 5
-        paths = URI.parse(url).path.split("/")
+      if URI.parse(url).path.split('/').count == 5
+        paths = URI.parse(url).path.split('/')
         # The first one is an extra slash, ignore it
-        self.repo_slug = paths[1] + "/" + paths[2]
+        self.repo_slug = paths[1] + '/' + paths[2]
         self.pull_request_id = paths[4]
       end
     end

--- a/lib/danger/ci_source/circle_api.rb
+++ b/lib/danger/ci_source/circle_api.rb
@@ -1,4 +1,4 @@
-require "faraday"
+require 'faraday'
 
 module Danger
   class CircleAPI
@@ -9,13 +9,13 @@ module Danger
     end
 
     def client
-      @client ||= Faraday.new(url: "https://circleci.com/api/v1")
+      @client ||= Faraday.new(url: 'https://circleci.com/api/v1')
     end
 
     def fetch_build(repo_slug, build_number)
       url = "project/#{repo_slug}/#{build_number}"
-      params = { "circle-token" => circle_token }
-      response = client.get url, params, accept: "application/json"
+      params = { 'circle-token' => circle_token }
+      response = client.get url, params, accept: 'application/json'
       json = JSON.parse(response.body, symbolize_names: true)
       json
     end

--- a/lib/danger/ci_source/drone.rb
+++ b/lib/danger/ci_source/drone.rb
@@ -21,11 +21,11 @@ module Danger
   #
   class Drone < CI
     def self.validates_as_ci?(env)
-      env.key? "DRONE_REPO"
+      env.key? 'DRONE_REPO'
     end
 
     def self.validates_as_pr?(env)
-      env["DRONE_PULL_REQUEST"].to_i > 0
+      env['DRONE_PULL_REQUEST'].to_i > 0
     end
 
     def supported_request_sources
@@ -33,8 +33,8 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_slug = env["DRONE_REPO"]
-      self.pull_request_id = env["DRONE_PULL_REQUEST"]
+      self.repo_slug = env['DRONE_REPO']
+      self.pull_request_id = env['DRONE_PULL_REQUEST']
       self.repo_url = GitRepo.new.origins # Drone doesn't provide a repo url env variable :/
     end
   end

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -18,11 +18,11 @@ module Danger
   #
   class Jenkins < CI
     def self.validates_as_ci?(env)
-      env.key? "JENKINS_URL"
+      env.key? 'JENKINS_URL'
     end
 
     def self.validates_as_pr?(env)
-      ["ghprbPullId"].all? { |x| env[x] }
+      ['ghprbPullId'].all? { |x| env[x] }
     end
 
     def supported_request_sources
@@ -30,8 +30,8 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_url = env["GIT_URL"]
-      self.pull_request_id = env["ghprbPullId"]
+      self.repo_url = env['GIT_URL']
+      self.pull_request_id = env['ghprbPullId']
 
       repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
       self.repo_slug = repo_matches[2] unless repo_matches.nil?

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -1,7 +1,7 @@
 # For more info see: https://github.com/schacon/ruby-git
 
-require "git"
-require "uri"
+require 'git'
+require 'uri'
 
 module Danger
   # ignore
@@ -9,7 +9,7 @@ module Danger
     attr_accessor :base_commit, :head_commit
 
     def self.validates_as_ci?(env)
-      env.key? "DANGER_USE_LOCAL_GIT"
+      env.key? 'DANGER_USE_LOCAL_GIT'
     end
 
     def git
@@ -25,37 +25,37 @@ module Danger
     end
 
     def initialize(env = {})
-      github_host = env["DANGER_GITHUB_HOST"] || "github.com"
+      github_host = env['DANGER_GITHUB_HOST'] || 'github.com'
 
       # get the remote URL
-      remote = run_git("remote show origin -n").lines.grep(/Fetch URL/)[0].split(": ", 2)[1]
+      remote = run_git('remote show origin -n').lines.grep(/Fetch URL/)[0].split(': ', 2)[1]
       if remote
         remote_url_matches = remote.match(%r{#{Regexp.escape github_host}(:|/)(?<repo_slug>.+/.+?)(?:\.git)?$})
-        if !remote_url_matches.nil? and remote_url_matches["repo_slug"]
-          self.repo_slug = remote_url_matches["repo_slug"]
+        if !remote_url_matches.nil? and remote_url_matches['repo_slug']
+          self.repo_slug = remote_url_matches['repo_slug']
         else
-          puts "Danger local requires a repository hosted on GitHub.com or GitHub Enterprise."
+          puts 'Danger local requires a repository hosted on GitHub.com or GitHub Enterprise.'
         end
       end
 
-      specific_pr = env["LOCAL_GIT_PR_ID"]
-      pr_ref = specific_pr ? "##{specific_pr}" : ""
-      pr_command = "log --merges --oneline"
+      specific_pr = env['LOCAL_GIT_PR_ID']
+      pr_ref = specific_pr ? "##{specific_pr}" : ''
+      pr_command = 'log --merges --oneline'
 
       # get the most recent PR merge
-      pr_merge = run_git(pr_command.strip).lines.grep(Regexp.new("Merge pull request " + pr_ref))[0]
+      pr_merge = run_git(pr_command.strip).lines.grep(Regexp.new('Merge pull request ' + pr_ref))[0]
 
       if pr_merge.to_s.empty?
         if specific_pr
           raise "Could not find the pull request (#{specific_pr}) inside the git history for this repo."
         else
-          raise "No recent pull requests found for this repo, danger requires at least one PR for the local mode."
+          raise 'No recent pull requests found for this repo, danger requires at least one PR for the local mode.'
         end
       end
 
-      self.pull_request_id = pr_merge.match("#([0-9]+)")[1]
-      sha = pr_merge.split(" ")[0]
-      parents = run_git("rev-list --parents -n 1 #{sha}").strip.split(" ")
+      self.pull_request_id = pr_merge.match('#([0-9]+)')[1]
+      sha = pr_merge.split(' ')[0]
+      parents = run_git("rev-list --parents -n 1 #{sha}").strip.split(' ')
       self.base_commit = parents[0]
       self.head_commit = parents[1]
     end

--- a/lib/danger/ci_source/semaphore.rb
+++ b/lib/danger/ci_source/semaphore.rb
@@ -12,11 +12,11 @@ module Danger
   #
   class Semaphore < CI
     def self.validates_as_ci?(env)
-      env.key? "SEMAPHORE"
+      env.key? 'SEMAPHORE'
     end
 
     def self.validates_as_pr?(env)
-      ["SEMAPHORE_REPO_SLUG", "PULL_REQUEST_NUMBER"].all? { |x| env[x] }
+      ['SEMAPHORE_REPO_SLUG', 'PULL_REQUEST_NUMBER'].all? { |x| env[x] }
     end
 
     def supported_request_sources
@@ -24,8 +24,8 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_slug = env["SEMAPHORE_REPO_SLUG"]
-      self.pull_request_id = env["PULL_REQUEST_NUMBER"]
+      self.repo_slug = env['SEMAPHORE_REPO_SLUG']
+      self.pull_request_id = env['PULL_REQUEST_NUMBER']
       self.repo_url = GitRepo.new.origins # Semaphore doesn't provide a repo url env variable :/
     end
   end

--- a/lib/danger/ci_source/surf.rb
+++ b/lib/danger/ci_source/surf.rb
@@ -13,7 +13,7 @@ module Danger
   #
   class Surf < CI
     def self.validates_as_ci?(env)
-      return ["SURF_REPO", "SURF_NWO"].all? { |x| env[x] }
+      return ['SURF_REPO', 'SURF_NWO'].all? { |x| env[x] }
     end
 
     def self.validates_as_pr?(_)
@@ -25,12 +25,12 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_slug = env["SURF_NWO"]
-      if env["SURF_PR_NUM"].to_i > 0
-        self.pull_request_id = env["SURF_PR_NUM"]
+      self.repo_slug = env['SURF_NWO']
+      if env['SURF_PR_NUM'].to_i > 0
+        self.pull_request_id = env['SURF_PR_NUM']
       end
 
-      self.repo_url = env["SURF_REPO"]
+      self.repo_url = env['SURF_REPO']
     end
   end
 end

--- a/lib/danger/ci_source/teamcity.rb
+++ b/lib/danger/ci_source/teamcity.rb
@@ -19,11 +19,11 @@ module Danger
   #
   class TeamCity < CI
     def self.validates_as_ci?(env)
-      env.key? "TEAMCITY_VERSION"
+      env.key? 'TEAMCITY_VERSION'
     end
 
     def self.validates_as_pr?(env)
-      ["GITHUB_PULL_REQUEST_ID", "GITHUB_REPO_URL", "GITHUB_REPO_SLUG"].all? { |x| env[x] }
+      ['GITHUB_PULL_REQUEST_ID', 'GITHUB_REPO_URL', 'GITHUB_REPO_SLUG'].all? { |x| env[x] }
     end
 
     def supported_request_sources
@@ -34,9 +34,9 @@ module Danger
       # NB: Unfortunately TeamCity doesn't provide these variables
       # automatically so you have to add these variables manually to your
       # project or build configuration
-      self.repo_slug       = env["GITHUB_REPO_SLUG"]
-      self.pull_request_id = env["GITHUB_PULL_REQUEST_ID"].to_i
-      self.repo_url        = env["GITHUB_REPO_URL"]
+      self.repo_slug       = env['GITHUB_REPO_SLUG']
+      self.pull_request_id = env['GITHUB_PULL_REQUEST_ID'].to_i
+      self.repo_url        = env['GITHUB_REPO_URL']
     end
   end
 end

--- a/lib/danger/ci_source/travis.rb
+++ b/lib/danger/ci_source/travis.rb
@@ -27,12 +27,12 @@ module Danger
   #
   class Travis < CI
     def self.validates_as_ci?(env)
-      env.key? "HAS_JOSH_K_SEAL_OF_APPROVAL"
+      env.key? 'HAS_JOSH_K_SEAL_OF_APPROVAL'
     end
 
     def self.validates_as_pr?(env)
-      exists = ["TRAVIS_PULL_REQUEST", "TRAVIS_REPO_SLUG"].all? { |x| env[x] }
-      exists && env["TRAVIS_PULL_REQUEST"].to_i > 0
+      exists = ['TRAVIS_PULL_REQUEST', 'TRAVIS_REPO_SLUG'].all? { |x| env[x] }
+      exists && env['TRAVIS_PULL_REQUEST'].to_i > 0
     end
 
     def supported_request_sources
@@ -40,9 +40,9 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_slug = env["TRAVIS_REPO_SLUG"]
-      if env["TRAVIS_PULL_REQUEST"].to_i > 0
-        self.pull_request_id = env["TRAVIS_PULL_REQUEST"]
+      self.repo_slug = env['TRAVIS_REPO_SLUG']
+      if env['TRAVIS_PULL_REQUEST'].to_i > 0
+        self.pull_request_id = env['TRAVIS_PULL_REQUEST']
       end
       self.repo_url = GitRepo.new.origins # Travis doesn't provide a repo url env variable :/
     end

--- a/lib/danger/ci_source/xcode_server.rb
+++ b/lib/danger/ci_source/xcode_server.rb
@@ -17,11 +17,11 @@ module Danger
   #
   class XcodeServer < CI
     def self.validates_as_ci?(env)
-      env.key? "XCS_BOT_NAME"
+      env.key? 'XCS_BOT_NAME'
     end
 
     def self.validates_as_pr?(env)
-      env["XCS_BOT_NAME"].include? "BuildaBot"
+      env['XCS_BOT_NAME'].include? 'BuildaBot'
     end
 
     def supported_request_sources
@@ -29,7 +29,7 @@ module Danger
     end
 
     def initialize(env)
-      bot_name = env["XCS_BOT_NAME"]
+      bot_name = env['XCS_BOT_NAME']
       return if bot_name.nil?
 
       repo_matches = bot_name.match(/\[(.+)\]/)

--- a/lib/danger/commands/init.rb
+++ b/lib/danger/commands/init.rb
@@ -1,27 +1,27 @@
-require "danger/commands/init_helpers/interviewer"
-require "danger/ci_source/local_git_repo"
-require "yaml"
+require 'danger/commands/init_helpers/interviewer'
+require 'danger/ci_source/local_git_repo'
+require 'yaml'
 
 module Danger
   class Init < Runner
-    self.summary = "Helps you set up Danger."
-    self.command = "init"
+    self.summary = 'Helps you set up Danger.'
+    self.command = 'init'
 
     attr_accessor :ui
 
     def self.options
       [
-        ["--impatient", "'I've not got all day here. Don't add any thematic delays please.'"],
-        ["--mousey", "'Don't make me press return to continue the adventure.'"]
+        ['--impatient', "'I've not got all day here. Don't add any thematic delays please.'"],
+        ['--mousey', "'Don't make me press return to continue the adventure.'"]
       ].concat(super)
     end
 
     def initialize(argv)
-      @bot_name = File.basename(Dir.getwd).split(".").first.capitalize + "Bot"
+      @bot_name = File.basename(Dir.getwd).split('.').first.capitalize + 'Bot'
       super
       @ui = Interviewer.new(cork)
-      ui.no_delay = argv.flag?("impatient", false)
-      ui.no_waiting = argv.flag?("mousey", false)
+      ui.no_delay = argv.flag?('impatient', false)
+      ui.no_waiting = argv.flag?('mousey', false)
     end
 
     def run
@@ -43,34 +43,34 @@ module Danger
     def show_todo_state
       ui.say "We need to do the following:\n"
       ui.pause 0.6
-      ui.say " - [ ] Create a Dangerfile and add a few simple rules."
+      ui.say ' - [ ] Create a Dangerfile and add a few simple rules.'
       ui.pause 0.6
       ui.say " - [#{@account_created ? 'x' : ' '}] Create a GitHub account for Danger to use, for messaging."
       ui.pause 0.6
-      ui.say " - [ ] Set up an access token for Danger."
+      ui.say ' - [ ] Set up an access token for Danger.'
       ui.pause 0.6
       ui.say " - [ ] Set up Danger to run on your CI.\n\n"
     end
 
     def setup_dangerfile
       dir = Danger.gem_path
-      content = File.read(File.join(dir, "lib", "assets", "DangerfileTemplate"))
-      File.write("Dangerfile", content)
+      content = File.read(File.join(dir, 'lib', 'assets', 'DangerfileTemplate'))
+      File.write('Dangerfile', content)
 
-      ui.header "Step 1: Creating a starter Dangerfile"
+      ui.header 'Step 1: Creating a starter Dangerfile'
       ui.say "I've set up an example Dangerfile for you in this folder.\n"
       ui.pause 1
 
       ui.say "cat #{Dir.pwd}/Dangerfile\n".blue
       content.lines.each do |l|
-        ui.say "  " + l.chomp.green
+        ui.say '  ' + l.chomp.green
       end
-      ui.say ""
+      ui.say ''
       ui.pause 2
 
       ui.say "There's a collection of small, simple ideas in here, but Danger is about being able to easily"
-      ui.say "iterate. The power comes from you having the ability to codify fixes for some of the problems"
-      ui.say "that come up in day to day programming. It can be difficult to try and see those from day 1."
+      ui.say 'iterate. The power comes from you having the ability to codify fixes for some of the problems'
+      ui.say 'that come up in day to day programming. It can be difficult to try and see those from day 1.'
 
       ui.say "\nIf you'd like to investigate the file, and make some changes - I'll wait here,"
       ui.say "press return when you're ready to move on..."
@@ -78,7 +78,7 @@ module Danger
     end
 
     def setup_github_account
-      ui.header "Step 2: Creating a GitHub account"
+      ui.header 'Step 2: Creating a GitHub account'
 
       ui.say "In order to get the most out of Danger, I'd recommend giving her the ability to post in"
       ui.say "the code-review comment section.\n\n"
@@ -87,11 +87,11 @@ module Danger
       ui.say "IMO, it's best to do this by using the private mode of your browser. Create an account like"
       ui.say "#{@bot_name}, and don't forget a cool robot avatar.\n\n"
       ui.pause 1
-      ui.say "Here are great resources for creative commons images of robots:"
-      ui.link "https://www.flickr.com/search/?text=robot&license=2%2C3%2C4%2C5%2C6%2C9"
-      ui.link "https://www.google.com/search?q=robot&tbs=sur:fmc&tbm=isch&tbo=u&source=univ&sa=X&ved=0ahUKEwjgy8-f95jLAhWI7hoKHV_UD00QsAQIMQ&biw=1265&bih=1359"
+      ui.say 'Here are great resources for creative commons images of robots:'
+      ui.link 'https://www.flickr.com/search/?text=robot&license=2%2C3%2C4%2C5%2C6%2C9'
+      ui.link 'https://www.google.com/search?q=robot&tbs=sur:fmc&tbm=isch&tbo=u&source=univ&sa=X&ved=0ahUKEwjgy8-f95jLAhWI7hoKHV_UD00QsAQIMQ&biw=1265&bih=1359'
 
-      ui.say ""
+      ui.say ''
       note_about_clicking_links
       ui.pause 1
       ui.say "\nCool, please press return when you have your account ready (and you've verified the email...)"
@@ -99,29 +99,29 @@ module Danger
     end
 
     def setup_access_token
-      ui.header "Step 3: Configuring a GitHub Personal Access Token"
+      ui.header 'Step 3: Configuring a GitHub Personal Access Token'
 
       ui.say "Here's the link, you should open this in the private session where you just created the new GitHub account"
-      ui.link "https://github.com/settings/tokens/new"
+      ui.link 'https://github.com/settings/tokens/new'
       ui.pause 1
 
-      @is_open_source = ui.ask_with_answers("For token access rights, I need to know if this is for an Open Source or Closed Source project\n", ["Open", "Closed"])
+      @is_open_source = ui.ask_with_answers("For token access rights, I need to know if this is for an Open Source or Closed Source project\n", ['Open', 'Closed'])
 
       if considered_an_oss_repo?
         ui.say "For Open Source projects, I'd recommend giving the token the smallest scope possible."
-        ui.say "This means only providing access to " + "public_repo".yellow + " in the token.\n\n"
+        ui.say 'This means only providing access to ' + 'public_repo'.yellow + " in the token.\n\n"
         ui.pause 1
         ui.say "This token limits Danger's abilities to just writing comments on OSS projects. I recommend"
-        ui.say "this because the token can quite easily be extracted from the environment via pull requests."
+        ui.say 'this because the token can quite easily be extracted from the environment via pull requests.'
         ui.say "#{@bot_name} does not need admin access to your repo. So its ability to cause chaos is minimalized.\n"
 
         ui.say "\nIt is important that you do not store this token in your repository, as GitHub will automatically revoke it when pushed.\n"
-      elsif @is_open_source == "closed"
+      elsif @is_open_source == 'closed'
         ui.say "For Closed Source projects, I'd recommend giving the token access to the whole repo scope."
-        ui.say "This means only providing access to " + "repo".yellow + ", and its children in the token.\n\n"
+        ui.say 'This means only providing access to ' + 'repo'.yellow + ", and its children in the token.\n\n"
         ui.pause 1
-        ui.say "It's worth noting that you " + "should not".bold.white + " re-use this token for OSS repos."
-        ui.say "Make a new one for those repos with just " + "public_repo".yellow + "."
+        ui.say "It's worth noting that you " + 'should not'.bold.white + ' re-use this token for OSS repos.'
+        ui.say 'Make a new one for those repos with just ' + 'public_repo'.yellow + '.'
         ui.pause 1
         ui.say "Additionally, don't forget to add your new GitHub account as a collaborator to your Closed Source project."
       end
@@ -131,85 +131,85 @@ module Danger
     end
 
     def considered_an_oss_repo?
-      @is_open_source == "open"
+      @is_open_source == 'open'
     end
 
     def current_repo_slug
       @git = GitRepo.new
       repo_matches = @git.origins.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
-      repo_matches[2] || "[Your/Repo]"
+      repo_matches[2] || '[Your/Repo]'
     end
 
     def setup_danger_ci
-      ui.header "Step 4: Add Danger for your CI"
+      ui.header 'Step 4: Add Danger for your CI'
 
-      uses_travis if File.exist? ".travis.yml"
-      uses_circle if File.exist? "circle.yml"
-      unsure_ci unless File.exist?(".travis.yml") || File.exist?(".circle.yml")
+      uses_travis if File.exist? '.travis.yml'
+      uses_circle if File.exist? 'circle.yml'
+      unsure_ci unless File.exist?('.travis.yml') || File.exist?('.circle.yml')
 
       ui.say "\nOK, I'll give you a moment to do this..."
       ui.wait_for_return
 
-      ui.header "Final step: exposing the GitHub token as an environment build variable."
+      ui.header 'Final step: exposing the GitHub token as an environment build variable.'
       ui.pause 0.4
       if considered_an_oss_repo?
-        ui.say "As you have an Open Source repo, this token should be considered public, otherwise you cannot"
+        ui.say 'As you have an Open Source repo, this token should be considered public, otherwise you cannot'
         ui.say "run Danger on pull requests from forks, limiting its use.\n"
         ui.pause 1
       end
 
-      travis_token if File.exist? ".travis.yml"
-      circle_token if File.exist? "circle.yml"
-      unsure_token unless File.exist?(".travis.yml") || File.exist?(".circle.yml")
+      travis_token if File.exist? '.travis.yml'
+      circle_token if File.exist? 'circle.yml'
+      unsure_token unless File.exist?('.travis.yml') || File.exist?('.circle.yml')
 
       ui.pause 0.6
-      ui.say "This is the last step, I can give you a second..."
+      ui.say 'This is the last step, I can give you a second...'
       ui.wait_for_return
     end
 
     def uses_travis
-      danger = "bundle exec danger".yellow
-      config = YAML.load(File.read(".travis.yml"))
-      if config["script"]
-        ui.say "Add " + "- ".yellow + danger + " as a new step in the " + "script".yellow + " section of your .travis.yml file."
+      danger = 'bundle exec danger'.yellow
+      config = YAML.load(File.read('.travis.yml'))
+      if config['script']
+        ui.say 'Add ' + '- '.yellow + danger + ' as a new step in the ' + 'script'.yellow + ' section of your .travis.yml file.'
       else
-        ui.say "I'd recommend adding " + "script: ".yellow + danger + " to the script section of your .travis.yml file."
+        ui.say "I'd recommend adding " + 'script: '.yellow + danger + ' to the script section of your .travis.yml file.'
       end
 
       ui.pause 1
-      ui.say "You shouldn't use " + "after_success, after_failure, after_script".red + " as they cannot fail your builds."
+      ui.say "You shouldn't use " + 'after_success, after_failure, after_script'.red + ' as they cannot fail your builds.'
     end
 
     def uses_circle
-      danger = "- bundle exec danger".yellow
-      config = YAML.load(File.read("circle.yml"))
+      danger = '- bundle exec danger'.yellow
+      config = YAML.load(File.read('circle.yml'))
 
-      if config["test"]
-        if config["test"]["post"]
-          ui.say "Add " + danger + " as a new step in the " + "test:post:".yellow + " section of your circle.yml file."
+      if config['test']
+        if config['test']['post']
+          ui.say 'Add ' + danger + ' as a new step in the ' + 'test:post:'.yellow + ' section of your circle.yml file.'
         else
-          ui.say "Add " + danger + " as a new step in the " + "test:override:".yellow + " section of your circle.yml file."
+          ui.say 'Add ' + danger + ' as a new step in the ' + 'test:override:'.yellow + ' section of your circle.yml file.'
         end
       else
-        ui.say "Add this to the bottom of your circle.yml file:"
-        ui.say "test:".green
-        ui.say "  post:".green
+        ui.say 'Add this to the bottom of your circle.yml file:'
+        ui.say 'test:'.green
+        ui.say '  post:'.green
         ui.say "    #{danger}".green
       end
     end
 
     def unsure_ci
-      danger = "bundle exec danger".yellow
+      danger = 'bundle exec danger'.yellow
       ui.say "As I'm not sure what CI you want to run Danger on based on the files in your repo, I'll just offer some generic"
-      ui.say "advice. You want to run " + danger + " after your tests have finished running, it should still be during the testing"
-      ui.say "process so the build can fail."
+      ui.say 'advice. You want to run ' + danger + ' after your tests have finished running, it should still be during the testing'
+      ui.say 'process so the build can fail.'
     end
 
     def travis_token
       # https://travis-ci.org/artsy/eigen/settings
-      ui.say "In order to add an environment variable, go to:"
+      ui.say 'In order to add an environment variable, go to:'
       ui.link "https://travis-ci.org/#{current_repo_slug}/settings"
-      ui.say "\nThe name is " + "DANGER_GITHUB_API_TOKEN".yellow + " and the value is the GitHub Personal Access Token."
+      ui.say "\nThe name is " + 'DANGER_GITHUB_API_TOKEN'.yellow + ' and the value is the GitHub Personal Access Token.'
       if @is_open_source
         ui.say 'Make sure to have "Display value in build log" enabled.'
       end
@@ -219,50 +219,50 @@ module Danger
       # https://circleci.com/gh/artsy/eigen/edit#env-vars
       if considered_an_oss_repo?
         ui.say "Before we start, it's important to be up-front. CircleCI only really has one option to support running Danger"
-        ui.say "for forks on OSS repos. It is quite a drastic option, and I want to let you know the best place to understand"
+        ui.say 'for forks on OSS repos. It is quite a drastic option, and I want to let you know the best place to understand'
         ui.say "the ramifications of turning on a setting I'm about to advise.\n"
-        ui.link "https://circleci.com/docs/fork-pr-builds"
-        ui.say "TLDR: If you have anything other than Danger config settings in CircleCI, then you should not turn on the setting."
+        ui.link 'https://circleci.com/docs/fork-pr-builds'
+        ui.say 'TLDR: If you have anything other than Danger config settings in CircleCI, then you should not turn on the setting.'
         ui.say "I'll give you a minute to read it..."
         ui.wait_for_return
 
-        ui.say "On Danger/Danger we turn on " + "Permissive building of fork pull requests".yellow + " this exposes the token to Danger"
-        ui.say "You can find this setting at:"
+        ui.say 'On Danger/Danger we turn on ' + 'Permissive building of fork pull requests'.yellow + ' this exposes the token to Danger'
+        ui.say 'You can find this setting at:'
         ui.link "https://circleci.com/gh/#{current_repo_slug}/edit#advanced-settings\n"
         ui.say "I'll hold..."
         ui.wait_for_return
       end
 
-      ui.say "In order to expose an environment variable, go to:"
+      ui.say 'In order to expose an environment variable, go to:'
       ui.link "https://circleci.com/gh/#{current_repo_slug}/edit#env-vars"
-      ui.say "The name is " + "DANGER_GITHUB_API_TOKEN".yellow + " and the value is the GitHub Personal Acess Token."
+      ui.say 'The name is ' + 'DANGER_GITHUB_API_TOKEN'.yellow + ' and the value is the GitHub Personal Acess Token.'
     end
 
     def unsure_token
-      ui.say "You need to expose a token called " + "DANGER_GITHUB_API_TOKEN".yellow + " and the value is the GitHub Personal Acess Token."
-      ui.say "Depending on the CI system, this may need to be done on the machine ( in the " + "~/.bashprofile".yellow + ") or in a web UI somewhere."
+      ui.say 'You need to expose a token called ' + 'DANGER_GITHUB_API_TOKEN'.yellow + ' and the value is the GitHub Personal Acess Token.'
+      ui.say 'Depending on the CI system, this may need to be done on the machine ( in the ' + '~/.bashprofile'.yellow + ') or in a web UI somewhere.'
     end
 
     def note_about_clicking_links
-      modifier_key = "ctrl"
-      clicks = "clicking"
+      modifier_key = 'ctrl'
+      clicks = 'clicking'
 
-      modifier_key = "cmd ( ⌘ )" if darwin?
-      clicks = "double clicking" if darwin? && !ENV["ITERM_SESSION_ID"]
+      modifier_key = 'cmd ( ⌘ )' if darwin?
+      clicks = 'double clicking' if darwin? && !ENV['ITERM_SESSION_ID']
 
       ui.say "Note: Holding #{modifier_key} and #{clicks} a link will open it in your browser."
     end
 
     def info
-      ui.header "Useful info"
-      ui.say "- One of the best ways to test out new rules locally is via " + "bundle exec danger local".yellow + "."
+      ui.header 'Useful info'
+      ui.say '- One of the best ways to test out new rules locally is via ' + 'bundle exec danger local'.yellow + '.'
       ui.pause 0.6
-      ui.say "- You can have Danger output all of its variables to the console via the " + "--verbose".yellow + " option."
+      ui.say '- You can have Danger output all of its variables to the console via the ' + '--verbose'.yellow + ' option.'
       ui.pause 0.6
-      ui.say "- You can look at the following Dangerfiles to get some more ideas:"
+      ui.say '- You can look at the following Dangerfiles to get some more ideas:'
       ui.pause 0.6
-      ui.link "https://github.com/danger/danger/blob/master/Dangerfile"
-      ui.link "https://github.com/artsy/eigen/blob/master/Dangerfile"
+      ui.link 'https://github.com/danger/danger/blob/master/Dangerfile'
+      ui.link 'https://github.com/artsy/eigen/blob/master/Dangerfile'
       ui.pause 1
     end
 
@@ -271,12 +271,12 @@ module Danger
       ui.pause 0.6
 
       ui.say "And you're good to go. Danger is a collaboration between Orta Therox, Gem 'Danger' McShane and Felix Krause."
-      ui.say "If you like it, let others know. If you want to know more, follow " + "@orta".yellow + " and " + "@KrauseFx".yellow + " on Twitter."
+      ui.say 'If you like it, let others know. If you want to know more, follow ' + '@orta'.yellow + ' and ' + '@KrauseFx'.yellow + ' on Twitter.'
       ui.say "If you don't like it, help us improve it! xxx"
     end
 
     def darwin?
-      Gem::Platform.local.os == "darwin"
+      Gem::Platform.local.os == 'darwin'
     end
   end
 end

--- a/lib/danger/commands/init_helpers/interviewer.rb
+++ b/lib/danger/commands/init_helpers/interviewer.rb
@@ -7,19 +7,19 @@ module Danger
     end
 
     def show_prompt
-      ui.print "> ".bold.green
+      ui.print '> '.bold.green
     end
 
     def yellow_bang
-      "! ".yellow
+      '! '.yellow
     end
 
     def green_bang
-      "! ".green
+      '! '.green
     end
 
     def red_bang
-      "! ".red
+      '! '.red
     end
 
     def say(output)
@@ -28,12 +28,12 @@ module Danger
 
     def header(title)
       say title.yellow
-      say ""
+      say ''
       pause 0.6
     end
 
     def link(url)
-      say " -> " + url.underline + "\n"
+      say ' -> ' + url.underline + "\n"
     end
 
     def pause(time)
@@ -48,12 +48,12 @@ module Danger
 
     def run_command(command, output_command = nil)
       output_command ||= command
-      ui.puts "  " + output_command.magenta
+      ui.puts '  ' + output_command.magenta
       system command
     end
 
     def ask(question)
-      answer = ""
+      answer = ''
       loop do
         ui.puts "\n#{question}?"
 
@@ -73,26 +73,26 @@ module Danger
       print_info = proc do
         possible_answers.each_with_index do |answer, i|
           the_answer = i.zero? ? answer.underline : answer
-          ui.print " " + the_answer
-          ui.print(" /") if i != possible_answers.length - 1
+          ui.print ' ' + the_answer
+          ui.print(' /') if i != possible_answers.length - 1
         end
         ui.print " ]\n"
       end
       print_info.call
 
-      answer = ""
+      answer = ''
 
       loop do
         show_prompt
         answer = @no_waiting ? possible_answers[0].downcase : STDIN.gets.downcase.chomp
 
-        answer = "yes" if answer == "y"
-        answer = "no" if answer == "n"
+        answer = 'yes' if answer == 'y'
+        answer = 'no' if answer == 'n'
 
         # default to first answer
-        if answer == ""
+        if answer == ''
           answer = possible_answers[0].downcase
-          ui.puts "Using: " + answer.yellow
+          ui.puts 'Using: ' + answer.yellow
         end
 
         break if possible_answers.map(&:downcase).include? answer

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -1,17 +1,17 @@
-require "danger/commands/local_helpers/http_cache"
-require "faraday/http_cache"
-require "fileutils"
-require "octokit"
-require "tmpdir"
+require 'danger/commands/local_helpers/http_cache'
+require 'faraday/http_cache'
+require 'fileutils'
+require 'octokit'
+require 'tmpdir'
 
 module Danger
   class Local < Runner
-    self.summary = "Run the Dangerfile locally."
-    self.command = "local"
+    self.summary = 'Run the Dangerfile locally.'
+    self.command = 'local'
 
     def initialize(argv)
-      @pr_num = argv.option("use-merged-pr")
-      @clear_http_cache = argv.flag?("clear-http-cache", false)
+      @pr_num = argv.option('use-merged-pr')
+      @clear_http_cache = argv.flag?('clear-http-cache', false)
 
       super
 
@@ -19,20 +19,20 @@ module Danger
     end
 
     def should_pry?(argv)
-      argv.flag?("pry", false) && !@dangerfile_path.empty? && validate_pry_available
+      argv.flag?('pry', false) && !@dangerfile_path.empty? && validate_pry_available
     end
 
     def setup_pry
-      File.delete "_Dangerfile.tmp" if File.exist? "_Dangerfile.tmp"
-      FileUtils.cp @dangerfile_path, "_Dangerfile.tmp"
-      File.open("_Dangerfile.tmp", "a") do |f|
-        f.write("binding.pry; File.delete(\"_Dangerfile.tmp\")")
+      File.delete '_Dangerfile.tmp' if File.exist? '_Dangerfile.tmp'
+      FileUtils.cp @dangerfile_path, '_Dangerfile.tmp'
+      File.open('_Dangerfile.tmp', 'a') do |f|
+        f.write('binding.pry; File.delete("_Dangerfile.tmp")')
       end
-      @dangerfile_path = "_Dangerfile.tmp"
+      @dangerfile_path = '_Dangerfile.tmp'
     end
 
     def validate_pry_available
-      require "pry"
+      require 'pry'
     rescue LoadError
       cork.warn "Pry was not found, and is required for 'danger local --pry'."
       cork.print_warnings
@@ -41,25 +41,25 @@ module Danger
 
     def self.options
       [
-        ["--use-merged-pr=[#id]", "The ID of an already merged PR inside your history to use as a reference for the local run."],
-        ["--clear-http-cache", "Clear the local http cache before running Danger locally."],
-        ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
+        ['--use-merged-pr=[#id]', 'The ID of an already merged PR inside your history to use as a reference for the local run.'],
+        ['--clear-http-cache', 'Clear the local http cache before running Danger locally.'],
+        ['--pry', 'Drop into a Pry shell after evaluating the Dangerfile.']
       ].concat(super)
     end
 
     def validate!
       super
       unless @dangerfile_path
-        help! "Could not find a Dangerfile."
+        help! 'Could not find a Dangerfile.'
       end
     end
 
     def run
-      ENV["DANGER_USE_LOCAL_GIT"] = "YES"
-      ENV["LOCAL_GIT_PR_ID"] = @pr_num if @pr_num
+      ENV['DANGER_USE_LOCAL_GIT'] = 'YES'
+      ENV['LOCAL_GIT_PR_ID'] = @pr_num if @pr_num
 
       # setup caching for Github calls to hitting the API rate limit too quickly
-      cache_file = File.join(ENV["DANGER_TMPDIR"] || Dir.tmpdir, "danger_local_cache")
+      cache_file = File.join(ENV['DANGER_TMPDIR'] || Dir.tmpdir, 'danger_local_cache')
       cache = HTTPCache.new(cache_file, clear_cache: @clear_http_cache)
       Octokit.middleware = Faraday::RackBuilder.new do |builder|
         builder.use Faraday::HttpCache, store: cache, serializer: Marshal, shared_cache: false
@@ -73,7 +73,7 @@ module Danger
 
       source = dm.env.ci_source
       if source.nil? or source.repo_slug.empty?
-        cork.puts "danger local failed because it only works with GitHub projects at the moment. Sorry.".red
+        cork.puts 'danger local failed because it only works with GitHub projects at the moment. Sorry.'.red
         exit 0
       end
 
@@ -82,7 +82,7 @@ module Danger
       cork.puts "Running your Dangerfile against this PR - https://#{gh.host}/#{source.repo_slug}/pull/#{source.pull_request_id}"
 
       if verbose != true
-        cork.puts "Turning on --verbose"
+        cork.puts 'Turning on --verbose'
         dm.verbose = true
       end
 
@@ -95,7 +95,7 @@ module Danger
       begin
         gh.fetch_details
       rescue Octokit::NotFound
-        cork.puts "Local repository was not found on GitHub. If you're trying to test a private repository please provide a valid API token through " + "DANGER_GITHUB_API_TOKEN".yellow + " environment variable."
+        cork.puts "Local repository was not found on GitHub. If you're trying to test a private repository please provide a valid API token through " + 'DANGER_GITHUB_API_TOKEN'.yellow + ' environment variable.'
         return
       end
 
@@ -104,7 +104,7 @@ module Danger
       begin
         dm.env.fill_environment_vars
         dm.env.ensure_danger_branches_are_setup
-        dm.env.scm.diff_for_folder(".", from: Danger::EnvironmentManager.danger_base_branch, to: Danger::EnvironmentManager.danger_head_branch)
+        dm.env.scm.diff_for_folder('.', from: Danger::EnvironmentManager.danger_base_branch, to: Danger::EnvironmentManager.danger_head_branch)
 
         dm.parse(Pathname.new(@dangerfile_path))
         check_and_run_org_dangerfile(dm)
@@ -118,7 +118,7 @@ module Danger
     # Check to see if there's a Dangerfile in the organisation, and run it if so
     def check_and_run_org_dangerfile(dm)
       if dm.env.request_source.organisation && !dm.env.request_source.danger_repo? && (danger_repo = dm.env.request_source.fetch_danger_repo)
-        url = dm.env.request_source.file_url(repository: danger_repo.name, path: "Dangerfile")
+        url = dm.env.request_source.file_url(repository: danger_repo.name, path: 'Dangerfile')
         path = dm.plugin.download(url)
         dm.parse(Pathname.new(path))
       end

--- a/lib/danger/commands/local_helpers/http_cache.rb
+++ b/lib/danger/commands/local_helpers/http_cache.rb
@@ -1,4 +1,4 @@
-require "pstore"
+require 'pstore'
 
 module Danger
   class HTTPCache

--- a/lib/danger/commands/plugins/plugin_json.rb
+++ b/lib/danger/commands/plugins/plugin_json.rb
@@ -1,21 +1,21 @@
-require "danger/plugin_support/plugin_parser"
-require "danger/plugin_support/plugin_file_resolver"
+require 'danger/plugin_support/plugin_parser'
+require 'danger/plugin_support/plugin_file_resolver'
 
 module Danger
   class PluginJSON < CLAide::Command::Plugins
-    self.summary = "Prints the JSON documentation representing a plugin"
-    self.command = "json"
+    self.summary = 'Prints the JSON documentation representing a plugin'
+    self.command = 'json'
 
     attr_accessor :cork
 
     def initialize(argv)
       @refs = argv.arguments! unless argv.arguments.empty?
-      @cork = Cork::Board.new(silent: argv.option("silent", false),
-                              verbose: argv.option("verbose", false))
+      @cork = Cork::Board.new(silent: argv.option('silent', false),
+                              verbose: argv.option('verbose', false))
       super
     end
 
-    self.summary = "Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success."
+    self.summary = 'Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success.'
 
     self.description = <<-DESC
       Converts a collection of file paths of Danger plugins into a JSON format.
@@ -24,7 +24,7 @@ module Danger
     DESC
 
     self.arguments = [
-      CLAide::Argument.new("Paths, Gems or Nothing", false, true)
+      CLAide::Argument.new('Paths, Gems or Nothing', false, true)
     ]
 
     def run

--- a/lib/danger/commands/plugins/plugin_lint.rb
+++ b/lib/danger/commands/plugins/plugin_lint.rb
@@ -1,23 +1,23 @@
-require "danger/plugin_support/plugin_parser"
-require "danger/plugin_support/plugin_file_resolver"
-require "danger/plugin_support/plugin_linter"
+require 'danger/plugin_support/plugin_parser'
+require 'danger/plugin_support/plugin_file_resolver'
+require 'danger/plugin_support/plugin_linter'
 
 module Danger
   class PluginLint < CLAide::Command::Plugins
-    self.summary = "Lints a plugin"
-    self.command = "lint"
+    self.summary = 'Lints a plugin'
+    self.command = 'lint'
 
     attr_accessor :cork
 
     def initialize(argv)
-      @warnings_as_errors = argv.flag?("warnings-as-errors", false)
+      @warnings_as_errors = argv.flag?('warnings-as-errors', false)
       @refs = argv.arguments! unless argv.arguments.empty?
-      @cork = Cork::Board.new(silent: argv.option("silent", false),
-                              verbose: argv.option("verbose", false))
+      @cork = Cork::Board.new(silent: argv.option('silent', false),
+                              verbose: argv.option('verbose', false))
       super
     end
 
-    self.summary = "Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success."
+    self.summary = 'Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success.'
 
     self.description = <<-DESC
       Converts a collection of file paths of Danger plugins into a JSON format.
@@ -26,12 +26,12 @@ module Danger
     DESC
 
     self.arguments = [
-      CLAide::Argument.new("Paths, Gems or Nothing", false, true)
+      CLAide::Argument.new('Paths, Gems or Nothing', false, true)
     ]
 
     def self.options
       [
-        ["--warnings-as-errors", "Ensure strict linting."]
+        ['--warnings-as-errors', 'Ensure strict linting.']
       ].concat(super)
     end
 

--- a/lib/danger/commands/plugins/plugin_readme.rb
+++ b/lib/danger/commands/plugins/plugin_readme.rb
@@ -1,23 +1,23 @@
-require "danger/plugin_support/plugin_parser"
-require "danger/plugin_support/plugin_file_resolver"
-require "json"
-require "erb"
+require 'danger/plugin_support/plugin_parser'
+require 'danger/plugin_support/plugin_file_resolver'
+require 'json'
+require 'erb'
 
 module Danger
   class PluginReadme < CLAide::Command::Plugins
-    self.summary = "Generates a README from a set of plugins"
-    self.command = "readme"
+    self.summary = 'Generates a README from a set of plugins'
+    self.command = 'readme'
 
     attr_accessor :cork, :json
 
     def initialize(argv)
       @refs = argv.arguments! unless argv.arguments.empty?
-      @cork = Cork::Board.new(silent: argv.option("silent", false),
-                              verbose: argv.option("verbose", false))
+      @cork = Cork::Board.new(silent: argv.option('silent', false),
+                              verbose: argv.option('verbose', false))
       super
     end
 
-    self.summary = "Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success."
+    self.summary = 'Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success.'
 
     self.description = <<-DESC
       Converts a collection of file paths of Danger plugins into a format usable in a README.
@@ -25,7 +25,7 @@ module Danger
     DESC
 
     self.arguments = [
-      CLAide::Argument.new("Paths, Gems or Nothing", false, true)
+      CLAide::Argument.new('Paths, Gems or Nothing', false, true)
     ]
 
     attr_accessor :json, :markdown
@@ -39,8 +39,8 @@ module Danger
       self.markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, no_intra_emphasis: true)
       self.json = JSON.parse(parser.to_json_string)
 
-      template = File.join(Danger.gem_path, "lib/danger/plugin_support/templates/readme_table.html.erb")
-      cork.puts ERB.new(File.read(template), 0, "-").result(binding)
+      template = File.join(Danger.gem_path, 'lib/danger/plugin_support/templates/readme_table.html.erb')
+      cork.puts ERB.new(File.read(template), 0, '-').result(binding)
     end
   end
 end

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -1,54 +1,54 @@
 module Danger
   class Runner < CLAide::Command
-    require "danger/commands/init"
-    require "danger/commands/local"
-    require "danger/commands/systems"
+    require 'danger/commands/init'
+    require 'danger/commands/local'
+    require 'danger/commands/systems'
 
     # manually set claide plugins as a subcommand
-    require "claide_plugin"
+    require 'claide_plugin'
     @subcommands << CLAide::Command::Plugins
     CLAide::Plugins.config =
-      CLAide::Plugins::Configuration.new("Danger",
-                                         "danger",
-                                         "https://raw.githubusercontent.com/danger/danger.systems/master/plugins-search-generated.json",
-                                         "https://github.com/danger/danger-plugin-template")
+      CLAide::Plugins::Configuration.new('Danger',
+                                         'danger',
+                                         'https://raw.githubusercontent.com/danger/danger.systems/master/plugins-search-generated.json',
+                                         'https://github.com/danger/danger-plugin-template')
 
-    require "danger/commands/plugins/plugin_lint"
-    require "danger/commands/plugins/plugin_json"
-    require "danger/commands/plugins/plugin_readme"
+    require 'danger/commands/plugins/plugin_lint'
+    require 'danger/commands/plugins/plugin_json'
+    require 'danger/commands/plugins/plugin_readme'
 
     attr_accessor :cork
 
-    self.summary = "Run the Dangerfile."
-    self.command = "danger"
+    self.summary = 'Run the Dangerfile.'
+    self.command = 'danger'
     self.version = Danger::VERSION
 
     self.plugin_prefixes = %w(claide danger)
 
     def initialize(argv)
-      dangerfile = argv.option("dangerfile", "Dangerfile")
+      dangerfile = argv.option('dangerfile', 'Dangerfile')
       @dangerfile_path = dangerfile if File.exist? dangerfile
-      @base = argv.option("base")
-      @head = argv.option("head")
-      @danger_id = argv.option("danger_id", "danger")
-      @cork = Cork::Board.new(silent: argv.option("silent", false),
-                              verbose: argv.option("verbose", false))
+      @base = argv.option('base')
+      @head = argv.option('head')
+      @danger_id = argv.option('danger_id', 'danger')
+      @cork = Cork::Board.new(silent: argv.option('silent', false),
+                              verbose: argv.option('verbose', false))
       super
     end
 
     def validate!
       super
       if self.class == Runner && !@dangerfile_path
-        help! "Could not find a Dangerfile."
+        help! 'Could not find a Dangerfile.'
       end
     end
 
     def self.options
       [
-        ["--base=[master|dev|stable]", "A branch/tag/commit to use as the base of the diff"],
-        ["--head=[master|dev|stable]", "A branch/tag/commit to use as the head"],
-        ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"],
-        ["--danger_id=<id>", "The identifier of this Danger instance"]
+        ['--base=[master|dev|stable]', 'A branch/tag/commit to use as the base of the diff'],
+        ['--head=[master|dev|stable]', 'A branch/tag/commit to use as the head'],
+        ['--dangerfile=<path/to/dangerfile>', 'The location of your Dangerfile'],
+        ['--danger_id=<id>', 'The identifier of this Danger instance']
       ].concat(super)
     end
 

--- a/lib/danger/commands/systems.rb
+++ b/lib/danger/commands/systems.rb
@@ -1,19 +1,19 @@
 module Danger
   class Systems < Runner
     self.abstract_command = true
-    self.description = "For commands related to passing information from Danger to Danger.Systems."
-    self.summary = "Create data for Danger.Systems."
+    self.description = 'For commands related to passing information from Danger to Danger.Systems.'
+    self.summary = 'Create data for Danger.Systems.'
   end
 
   class CIDocs < Systems
-    self.command = "ci_docs"
-    self.summary = "Outputs the up-to-date CI documentation for Danger."
+    self.command = 'ci_docs'
+    self.summary = 'Outputs the up-to-date CI documentation for Danger.'
 
     def run
       here = File.dirname(__FILE__)
-      ci_source_paths = Dir.glob(here + "/../ci_source/*.rb")
+      ci_source_paths = Dir.glob(here + '/../ci_source/*.rb')
 
-      require "yard"
+      require 'yard'
       # Pull out all the Danger::CI subclasses docs
       registry = YARD::Registry.load(ci_source_paths, true)
       ci_sources = registry.all(:class)
@@ -25,11 +25,11 @@ module Danger
       cis_without_docs = ci_sources.select { |source| source.base_docstring.empty? }
       unless cis_without_docs.empty?
         cork.puts "Please add docs to: #{cis_without_docs.map(&:name).join(', ')}"
-        abort("Failed.".red)
+        abort('Failed.'.red)
       end
 
       # Output a JSON array of name and details
-      require "json"
+      require 'json'
       cork.puts ci_sources.map { |ci|
         {
           name: ci.name,

--- a/lib/danger/core_ext/string.rb
+++ b/lib/danger/core_ext/string.rb
@@ -1,6 +1,6 @@
 class String
   def danger_class
-    split("_").collect!(&:capitalize).join
+    split('_').collect!(&:capitalize).join
   end
 
   def danger_pluralize(count)
@@ -8,10 +8,10 @@ class String
   end
 
   def danger_underscore
-    self.gsub(/::/, "/").
+    self.gsub(/::/, '/').
       gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').
       gsub(/([a-z\d])([A-Z])/, '\1_\2').
-      tr("-", "_").
+      tr('-', '_').
       downcase
   end
 end

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -1,12 +1,12 @@
 # So much was ripped direct from CocoaPods-Core - thanks!
 
-require "danger/danger_core/dangerfile_dsl"
-require "danger/danger_core/standard_error"
+require 'danger/danger_core/dangerfile_dsl'
+require 'danger/danger_core/standard_error'
 
-require "danger/danger_core/plugins/dangerfile_messaging_plugin"
-require "danger/danger_core/plugins/dangerfile_import_plugin"
-require "danger/danger_core/plugins/dangerfile_git_plugin"
-require "danger/danger_core/plugins/dangerfile_github_plugin"
+require 'danger/danger_core/plugins/dangerfile_messaging_plugin'
+require 'danger/danger_core/plugins/dangerfile_import_plugin'
+require 'danger/danger_core/plugins/dangerfile_git_plugin'
+require 'danger/danger_core/plugins/dangerfile_github_plugin'
 
 module Danger
   class Dangerfile
@@ -23,7 +23,7 @@ module Danger
     #         presented to the user.
     #
     def to_s
-      "Dangerfile"
+      'Dangerfile'
     end
 
     # These are the classes that are allowed to also use method_missing
@@ -69,7 +69,7 @@ module Danger
       @env = env_manager
 
       # Triggers local plugins from the root of a project
-      Dir["./danger_plugins/*.rb"].each do |file|
+      Dir['./danger_plugins/*.rb'].each do |file|
         require File.expand_path(file)
       end
 
@@ -111,10 +111,10 @@ module Danger
         methods.map do |method|
           case method
           when :api
-            value = "Octokit::Client"
+            value = 'Octokit::Client'
 
           when :pr_json
-            value = "[Skipped]"
+            value = '[Skipped]'
 
           when :pr_body
             value = plugin.send(method)
@@ -136,20 +136,20 @@ module Danger
     def print_known_info
       rows = []
       rows += method_values_for_plugin_hashes(core_dsl_attributes)
-      rows << ["---", "---"]
+      rows << ['---', '---']
       rows += method_values_for_plugin_hashes(external_dsl_attributes)
-      rows << ["---", "---"]
-      rows << ["SCM", env.scm.class]
-      rows << ["Source", env.ci_source.class]
-      rows << ["Requests", env.request_source.class]
-      rows << ["Base Commit", env.meta_info_for_base]
-      rows << ["Head Commit", env.meta_info_for_head]
+      rows << ['---', '---']
+      rows << ['SCM', env.scm.class]
+      rows << ['Source', env.ci_source.class]
+      rows << ['Requests', env.request_source.class]
+      rows << ['Base Commit', env.meta_info_for_base]
+      rows << ['Head Commit', env.meta_info_for_head]
 
       params = {}
       params[:rows] = rows.each { |current| current[0] = current[0].yellow }
       params[:title] = "Danger v#{Danger::VERSION}\nDSL Attributes".green
 
-      ui.section("Info:") do
+      ui.section('Info:') do
         ui.puts
         ui.puts Terminal::Table.new(params)
         ui.puts
@@ -161,23 +161,23 @@ module Danger
     def parse(path, contents = nil)
       print_known_info if verbose
 
-      contents ||= File.open(path, "r:utf-8", &:read)
+      contents ||= File.open(path, 'r:utf-8', &:read)
 
       # Work around for Rubinius incomplete encoding in 1.9 mode
-      if contents.respond_to?(:encoding) && contents.encoding.name != "UTF-8"
-        contents.encode!("UTF-8")
+      if contents.respond_to?(:encoding) && contents.encoding.name != 'UTF-8'
+        contents.encode!('UTF-8')
       end
 
-      if contents.tr!("“”‘’‛", %(""'''))
+      if contents.tr!('“”‘’‛', %(""'''))
         # Changes have been made
         ui.puts "Your #{path.basename} has had smart quotes sanitised. " \
-          "To avoid issues in the future, you should not use " \
-          "TextEdit for editing it. If you are not using TextEdit, " \
-          "you should turn off smart quotes in your editor of choice.".red
+          'To avoid issues in the future, you should not use ' \
+          'TextEdit for editing it. If you are not using TextEdit, ' \
+          'you should turn off smart quotes in your editor of choice.'.red
       end
 
-      if contents.include?("puts")
-        ui.puts "You used `puts` in your Dangerfile. To print out text to GitHub use `message` instead"
+      if contents.include?('puts')
+        ui.puts 'You used `puts` in your Dangerfile. To print out text to GitHub use `message` instead'
       end
 
       self.defined_in_file = path
@@ -199,9 +199,9 @@ module Danger
       status = status_report
       return if (status[:errors] + status[:warnings] + status[:messages] + status[:markdowns]).count.zero?
 
-      ui.section("Results:") do
+      ui.section('Results:') do
         [:errors, :warnings, :messages].each do |key|
-          formatted = key.to_s.capitalize + ":"
+          formatted = key.to_s.capitalize + ':'
           title = case key
                   when :errors
                     formatted.red
@@ -215,7 +215,7 @@ module Danger
         end
 
         if status[:markdowns].count > 0
-          ui.section("Markdown:") do
+          ui.section('Markdown:') do
             status[:markdowns].each do |current_markdown|
               ui.puts current_markdown
             end

--- a/lib/danger/danger_core/dangerfile_dsl.rb
+++ b/lib/danger/danger_core/dangerfile_dsl.rb
@@ -20,7 +20,7 @@ module Danger
       end
 
       def load_default_plugins
-        Dir["./danger_plugins/*.rb"].each do |file|
+        Dir['./danger_plugins/*.rb'].each do |file|
           require File.expand_path(file)
         end
       end

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -1,5 +1,5 @@
-require "danger/ci_source/ci_source"
-require "danger/request_source/request_source"
+require 'danger/ci_source/ci_source'
+require 'danger/request_source/request_source'
 
 module Danger
   class EnvironmentManager
@@ -60,11 +60,11 @@ module Danger
     end
 
     def self.danger_head_branch
-      "danger_head"
+      'danger_head'
     end
 
     def self.danger_base_branch
-      "danger_base"
+      'danger_base'
     end
   end
 end

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -13,12 +13,12 @@ module Danger
 
       # Could we find a CI source at all?
       unless EnvironmentManager.local_ci_source(ENV)
-        abort("Could not find the type of CI for Danger to run on.".red) unless ci_klass
+        abort('Could not find the type of CI for Danger to run on.'.red) unless ci_klass
       end
 
       # Could we determine that the CI source is inside a PR?
       unless EnvironmentManager.pr?(ENV)
-        cork.puts "Not a Pull Request - skipping `danger` run".yellow
+        cork.puts 'Not a Pull Request - skipping `danger` run'.yellow
         return
       end
 
@@ -36,12 +36,12 @@ module Danger
         # Offer the chance for a user to specify a branch through the command line
         ci_base = base || EnvironmentManager.danger_base_branch
         ci_head = head || EnvironmentManager.danger_head_branch
-        dm.env.scm.diff_for_folder(".", from: ci_base, to: ci_head)
+        dm.env.scm.diff_for_folder('.', from: ci_base, to: ci_head)
 
         dm.parse(Pathname.new(dangerfile_path))
 
         if dm.env.request_source.organisation && !dm.env.request_source.danger_repo? && (danger_repo = dm.env.request_source.fetch_danger_repo)
-          url = dm.env.request_source.file_url(repository: danger_repo.name, path: "Dangerfile")
+          url = dm.env.request_source.file_url(repository: danger_repo.name, path: 'Dangerfile')
           path = dm.plugin.download(url)
           dm.parse(Pathname.new(path))
         end

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -1,5 +1,5 @@
-require "danger/plugin_support/plugin"
-require "danger/core_ext/file_list"
+require 'danger/plugin_support/plugin'
+require 'danger/core_ext/file_list'
 
 # Danger
 module Danger
@@ -41,7 +41,7 @@ module Danger
     # @return [String]
     #
     def self.instance_name
-      "git"
+      'git'
     end
 
     def initialize(dangerfile)
@@ -56,7 +56,7 @@ module Danger
     # @return [FileList<String>] an [Array] subclass
     #
     def added_files
-      Danger::FileList.new(@git.diff.select { |diff| diff.type == "new" }.map(&:path))
+      Danger::FileList.new(@git.diff.select { |diff| diff.type == 'new' }.map(&:path))
     end
 
     # @!group Git Files
@@ -64,7 +64,7 @@ module Danger
     # @return [FileList<String>] an [Array] subclass
     #
     def deleted_files
-      Danger::FileList.new(@git.diff.select { |diff| diff.type == "deleted" }.map(&:path))
+      Danger::FileList.new(@git.diff.select { |diff| diff.type == 'deleted' }.map(&:path))
     end
 
     # @!group Git Files

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -1,4 +1,4 @@
-require "danger/plugin_support/plugin"
+require 'danger/plugin_support/plugin'
 
 module Danger
   # Handles interacting with GitHub inside a Dangerfile. Provides a few functions which wrap `pr_json` and also
@@ -89,7 +89,7 @@ module Danger
     # @return [String]
     #
     def self.instance_name
-      "github"
+      'github'
     end
 
     # @!group PR Metadata
@@ -196,13 +196,13 @@ module Danger
       repo = pr_json[:head][:repo][:html_url]
 
       paths = paths.map do |path|
-        url_path = path.start_with?("/") ? path : "/#{path}"
+        url_path = path.start_with?('/') ? path : "/#{path}"
         text = full_path ? path : File.basename(path)
         create_link("#{repo}/blob/#{commit}#{url_path}", text)
       end
 
       return paths.first if paths.count < 2
-      paths.first(paths.count - 1).join(", ") + " & " + paths.last
+      paths.first(paths.count - 1).join(', ') + ' & ' + paths.last
     end
 
     private

--- a/lib/danger/danger_core/plugins/dangerfile_import_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_import_plugin.rb
@@ -1,4 +1,4 @@
-require "danger/plugin_support/plugin"
+require 'danger/plugin_support/plugin'
 
 module Danger
   # One way to support internal plugins is via `plugin.import` this gives you
@@ -28,7 +28,7 @@ module Danger
     # @return [String]
     #
     def self.instance_name
-      "plugin"
+      'plugin'
     end
 
     # @!group Plugins
@@ -40,9 +40,9 @@ module Danger
     # @return   [void]
     #
     def import(path_or_url)
-      raise "`import` requires a string" unless path_or_url.kind_of?(String)
+      raise '`import` requires a string' unless path_or_url.kind_of?(String)
 
-      if path_or_url.start_with?("http")
+      if path_or_url.start_with?('http')
         import_url(path_or_url)
       else
         import_local(path_or_url)
@@ -59,18 +59,18 @@ module Danger
     # @return [String] The path to the downloaded Ruby file
     #
     def download(path_or_url)
-      raise "`download` requires a string" unless path_or_url.kind_of?(String)
-      raise "URL is not https, for security reasons `danger` only supports encrypted requests" if URI.parse(path_or_url).scheme != "https"
+      raise '`download` requires a string' unless path_or_url.kind_of?(String)
+      raise 'URL is not https, for security reasons `danger` only supports encrypted requests' if URI.parse(path_or_url).scheme != 'https'
 
-      require "tmpdir"
-      require "faraday"
+      require 'tmpdir'
+      require 'faraday'
 
       @http_client ||= Faraday.new do |b|
         b.adapter :net_http
       end
       content = @http_client.get(path_or_url)
 
-      path = File.join(Dir.mktmpdir, "temporary_danger.rb")
+      path = File.join(Dir.mktmpdir, 'temporary_danger.rb')
       File.write(path, content.body)
       return path
     end

--- a/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
@@ -1,5 +1,5 @@
-require "danger/danger_core/violation"
-require "danger/plugin_support/plugin"
+require 'danger/danger_core/violation'
+require 'danger/plugin_support/plugin'
 
 module Danger
   # Provides the feedback mechanism for Danger. Danger can keep track of
@@ -57,7 +57,7 @@ module Danger
     # @return [String]
     #
     def self.instance_name
-      "messaging"
+      'messaging'
     end
 
     # @!group Core

--- a/lib/danger/danger_core/standard_error.rb
+++ b/lib/danger/danger_core/standard_error.rb
@@ -1,5 +1,5 @@
-require "claide"
-require "claide/informative_error"
+require 'claide'
+require 'claide/informative_error'
 
 module Danger
   # From below here - this entire file was taken verbatim for CocoaPods-Core.
@@ -73,12 +73,12 @@ module Danger
 
         trace_line = backtrace.find { |l| l.include?(dsl_path.to_s) } || trace_line
         return m unless trace_line
-        line_numer = trace_line.split(":")[1].to_i - 1
+        line_numer = trace_line.split(':')[1].to_i - 1
         return m unless line_numer
 
         lines      = contents.lines
-        indent     = " #  "
-        indicator  = indent.tr("#", ">")
+        indent     = ' #  '
+        indicator  = indent.tr('#', '>')
         first_line = line_numer.zero?
         last_line  = (line_numer == (lines.count - 1))
 
@@ -99,7 +99,7 @@ module Danger
       description = self.description
       if dsl_path && description =~ /((#{Regexp.quote File.expand_path(dsl_path)}|#{Regexp.quote dsl_path.to_s}):\d+)/
         trace_line = Regexp.last_match[1]
-        description = description.sub(/#{Regexp.quote trace_line}:\s*/, "")
+        description = description.sub(/#{Regexp.quote trace_line}:\s*/, '')
       end
       [trace_line, description]
     end

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -1,4 +1,4 @@
-require "redcarpet"
+require 'redcarpet'
 
 module Danger
   module Helpers
@@ -8,7 +8,7 @@ module Danger
       end
 
       def parse_tables_from_comment(comment)
-        comment.split("</table>")
+        comment.split('</table>')
       end
 
       def violations_from_table(table)
@@ -19,7 +19,7 @@ module Danger
       def process_markdown(violation)
         html = markdown_parser.render(violation.message)
         # Remove the outer `<p>`, the -5 represents a newline + `</p>`
-        html = html[3...-5] if html.start_with? "<p>"
+        html = html[3...-5] if html.start_with? '<p>'
         Violation.new(html, violation.sticky)
       end
 
@@ -65,29 +65,29 @@ module Danger
         end
       end
 
-      def generate_comment(warnings: [], errors: [], messages: [], markdowns: [], previous_violations: {}, danger_id: "danger", template: "github")
-        require "erb"
+      def generate_comment(warnings: [], errors: [], messages: [], markdowns: [], previous_violations: {}, danger_id: 'danger', template: 'github')
+        require 'erb'
 
         md_template = File.join(Danger.gem_path, "lib/danger/comment_generators/#{template}.md.erb")
 
         # erb: http://www.rrn.dk/rubys-erb-templating-system
         # for the extra args: http://stackoverflow.com/questions/4632879/erb-template-removing-the-trailing-line
         @tables = [
-          table("Error", "no_entry_sign", errors, previous_violations),
-          table("Warning", "warning", warnings, previous_violations),
-          table("Message", "book", messages, previous_violations)
+          table('Error', 'no_entry_sign', errors, previous_violations),
+          table('Warning', 'warning', warnings, previous_violations),
+          table('Message', 'book', messages, previous_violations)
         ]
         @markdowns = markdowns
         @danger_id = danger_id
 
-        return ERB.new(File.read(md_template), 0, "-").result(binding)
+        return ERB.new(File.read(md_template), 0, '-').result(binding)
       end
 
       def generate_description(warnings: nil, errors: nil)
         if errors.empty? && warnings.empty?
           return "All green. #{random_compliment}"
         else
-          message = "⚠ "
+          message = '⚠ '
           message += "#{'Error'.danger_pluralize(errors.count)}. " unless errors.empty?
           message += "#{'Warning'.danger_pluralize(warnings.count)}. " unless warnings.empty?
           message += "Don't worry, everything is fixable."
@@ -96,8 +96,8 @@ module Danger
       end
 
       def random_compliment
-        compliment = ["Well done.", "Congrats.", "Woo!",
-                      "Yay.", "Jolly good show.", "Good on 'ya.", "Nice work."]
+        compliment = ['Well done.', 'Congrats.', 'Woo!',
+                      'Yay.', 'Jolly good show.', "Good on 'ya.", 'Nice work.']
         compliment.sample
       end
     end

--- a/lib/danger/plugin_support/plugin.rb
+++ b/lib/danger/plugin_support/plugin.rb
@@ -5,7 +5,7 @@ module Danger
     end
 
     def self.instance_name
-      to_s.gsub("Danger", "").danger_underscore.split("/").last
+      to_s.gsub('Danger', '').danger_underscore.split('/').last
     end
 
     # Both of these methods exist on all objects

--- a/lib/danger/plugin_support/plugin_file_resolver.rb
+++ b/lib/danger/plugin_support/plugin_file_resolver.rb
@@ -1,6 +1,6 @@
-require "bundler"
-require "pathname"
-require "fileutils"
+require 'bundler'
+require 'pathname'
+require 'fileutils'
 
 module Danger
   class PluginFileResolver
@@ -24,7 +24,7 @@ module Danger
 
           Dir.chdir(dir) do
             gem_names = @refs
-            gemfile = File.new("Gemfile", "w")
+            gemfile = File.new('Gemfile', 'w')
             gemfile.write "source 'https://rubygems.org'"
 
             gem_names.each do |plugin|
@@ -41,7 +41,7 @@ module Danger
         end
       # When empty, imply you want to test the current lib folder as a plugin
       else
-        Dir.glob(File.join(".", "lib/**/*.rb")).map { |path| File.expand_path(path) }
+        Dir.glob(File.join('.', 'lib/**/*.rb')).map { |path| File.expand_path(path) }
       end
     end
   end

--- a/lib/danger/plugin_support/plugin_linter.rb
+++ b/lib/danger/plugin_support/plugin_linter.rb
@@ -13,7 +13,7 @@ module Danger
       end
 
       def object_applied_to
-        metadata[:name].to_s.bold + " (" + type + ")"
+        metadata[:name].to_s.bold + ' (' + type + ')'
       end
     end
 
@@ -32,10 +32,10 @@ module Danger
     #
     def lint
       json.each do |plugin|
-        apply_rules(plugin, "class", class_rules)
+        apply_rules(plugin, 'class', class_rules)
 
         plugin[:methods].each do |method|
-          apply_rules(method, "method", method_rules)
+          apply_rules(method, 'method', method_rules)
         end
 
         plugin[:attributes].each do |method_hash|
@@ -43,7 +43,7 @@ module Danger
           method = method_hash[method_name]
 
           value = method[:write] || method[:read]
-          apply_rules(value, "attribute", method_rules)
+          apply_rules(value, 'attribute', method_rules)
         end
       end
     end
@@ -61,29 +61,29 @@ module Danger
       if failed?
         ui.puts "\n[!] Failed\n".red
       else
-        ui.notice "Passed"
+        ui.notice 'Passed'
       end
 
       # A generic proc to handle the similarities between
       # errors and warnings.
       do_rules = proc do |name, rules|
         unless rules.empty?
-          ui.puts ""
+          ui.puts ''
           ui.section(name.bold) do
             rules.each do |rule|
               title = rule.title.bold + " - #{rule.object_applied_to}"
               subtitles = [rule.description, link(rule.ref)]
-              subtitles += [rule.metadata[:files].join(":")] if rule.metadata[:files]
+              subtitles += [rule.metadata[:files].join(':')] if rule.metadata[:files]
               ui.labeled(title, subtitles)
-              ui.puts ""
+              ui.puts ''
             end
           end
         end
       end
 
       # Run the rules
-      do_rules.call("Errors".red, errors)
-      do_rules.call("Warnings".yellow, warnings)
+      do_rules.call('Errors'.red, errors)
+      do_rules.call('Warnings'.yellow, warnings)
     end
 
     private
@@ -92,16 +92,16 @@ module Danger
     #
     def class_rules
       [
-        Rule.new(:error, 4..6, "Description Markdown", "Above your class you need documentation that covers the scope, and the usage of your plugin.", proc do |json|
+        Rule.new(:error, 4..6, 'Description Markdown', 'Above your class you need documentation that covers the scope, and the usage of your plugin.', proc do |json|
           json[:body_md] && json[:body_md].empty?
         end),
-        Rule.new(:warning, 30, "Tags", "This plugin does not include `@tags tag1, tag2` and thus will be harder to find in search.", proc do |json|
+        Rule.new(:warning, 30, 'Tags', 'This plugin does not include `@tags tag1, tag2` and thus will be harder to find in search.', proc do |json|
           json[:tags] && json[:tags].empty?
         end),
-        Rule.new(:warning, 29, "References", "Ideally, you have a reference implementation of your plugin that you can show to people, add `@see org/repo` to have the site auto link it.", proc do |json|
+        Rule.new(:warning, 29, 'References', 'Ideally, you have a reference implementation of your plugin that you can show to people, add `@see org/repo` to have the site auto link it.', proc do |json|
           json[:see] && json[:see].empty?
         end),
-        Rule.new(:error, 8..27, "Examples", "You should include some examples of common use-cases for your plugin.", proc do |json|
+        Rule.new(:error, 8..27, 'Examples', 'You should include some examples of common use-cases for your plugin.', proc do |json|
           json[:example_code] && json[:example_code].empty?
         end)
       ]
@@ -111,17 +111,17 @@ module Danger
     #
     def method_rules
       [
-        Rule.new(:error, 40..41, "Description", "You should include a description for your method.", proc do |json|
+        Rule.new(:error, 40..41, 'Description', 'You should include a description for your method.', proc do |json|
           json[:body_md] && json[:body_md].empty?
         end),
-        Rule.new(:warning, 43..45, "Params", "You should give a 'type' for the param, yes, ruby is duck-typey but it's useful for newbies to the language, use `@param [Type] name`.", proc do |json|
+        Rule.new(:warning, 43..45, 'Params', "You should give a 'type' for the param, yes, ruby is duck-typey but it's useful for newbies to the language, use `@param [Type] name`.", proc do |json|
           json[:param_couplets] && json[:param_couplets].flat_map(&:values).include?(nil)
         end),
-        Rule.new(:warning, 43..45, "Unknown Param", "You should give a 'type' for the param, yes, ruby is duck-typey but it's useful for newbies to the language, use `@param [Type] name`.", proc do |json|
-          json[:param_couplets] && json[:param_couplets].flat_map(&:values).include?("Unknown")
+        Rule.new(:warning, 43..45, 'Unknown Param', "You should give a 'type' for the param, yes, ruby is duck-typey but it's useful for newbies to the language, use `@param [Type] name`.", proc do |json|
+          json[:param_couplets] && json[:param_couplets].flat_map(&:values).include?('Unknown')
         end),
-        Rule.new(:warning, 46, "Return Type", "If the function has no useful return value, use ` @return  [void]` - this will be ignored by documentation generators.", proc do |json|
-          return_hash = json[:tags].find { |tag| tag[:name] == "return" }
+        Rule.new(:warning, 46, 'Return Type', 'If the function has no useful return value, use ` @return  [void]` - this will be ignored by documentation generators.', proc do |json|
+          return_hash = json[:tags].find { |tag| tag[:name] == 'return' }
           !(return_hash && return_hash[:types] && !return_hash[:types].first.empty?)
         end)
       ]
@@ -131,11 +131,11 @@ module Danger
     #
     def link(ref)
       if ref.kind_of? Range
-        "@see - " + "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref.min}#-L#{ref.max}".blue
+        '@see - ' + "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref.min}#-L#{ref.max}".blue
       elsif ref.kind_of? Fixnum
-        "@see - " + "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref}".blue
+        '@see - ' + "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref}".blue
       else
-        "@see - " + "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb".blue
+        '@see - ' + 'https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb'.blue
       end
     end
 

--- a/lib/danger/request_source/request_source.rb
+++ b/lib/danger/request_source/request_source.rb
@@ -1,7 +1,7 @@
 module Danger
   module RequestSources
     class RequestSource
-      DANGER_REPO_NAME = "danger".freeze
+      DANGER_REPO_NAME = 'danger'.freeze
 
       attr_accessor :ci_source, :environment, :scm, :host, :ignored_violations
 
@@ -15,7 +15,7 @@ module Danger
       end
 
       def initialize(_ci_source, _environment)
-        raise "Subclass and overwrite initialize"
+        raise 'Subclass and overwrite initialize'
       end
 
       # What does this do?
@@ -36,35 +36,35 @@ module Danger
       end
 
       def update_pull_request!(_warnings: [], _errors: [], _messages: [], _markdowns: [])
-        raise "Subclass and overwrite update_pull_request!"
+        raise 'Subclass and overwrite update_pull_request!'
       end
 
       def setup_danger_branches
-        raise "Subclass and overwrite setup_danger_branches"
+        raise 'Subclass and overwrite setup_danger_branches'
       end
 
       def fetch_details
-        raise "Subclass and overwrite initialize"
+        raise 'Subclass and overwrite initialize'
       end
 
       def organisation
-        raise "Subclass and overwrite organisation"
+        raise 'Subclass and overwrite organisation'
       end
 
       def fetch_repository(_organisation: nil, _repository: nil)
-        raise "Subclass and overwrite fetch_repository"
+        raise 'Subclass and overwrite fetch_repository'
       end
 
       def fetch_danger_repo(_organisation: nil)
-        raise "Subclass and overwrite fetch_danger_repo"
+        raise 'Subclass and overwrite fetch_danger_repo'
       end
 
       def danger_repo?(_organisation: nil, _repository: nil)
-        raise "Subclass and overwrite danger_repo?"
+        raise 'Subclass and overwrite danger_repo?'
       end
 
-      def file_url(_organisation: nil, _repository: nil, _branch: "master", _path: nil)
-        raise "Subclass and overwrite file_url"
+      def file_url(_organisation: nil, _repository: nil, _branch: 'master', _path: nil)
+        raise 'Subclass and overwrite file_url'
       end
     end
   end

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -1,12 +1,12 @@
 # For more info see: https://github.com/schacon/ruby-git
 
-require "git"
+require 'git'
 
 module Danger
   class GitRepo
     attr_accessor :diff, :log
 
-    def diff_for_folder(folder, from: "master", to: "HEAD")
+    def diff_for_folder(folder, from: 'master', to: 'HEAD')
       repo = Git.open folder
       self.diff = repo.diff(from, to)
       self.log = repo.log.between(from, to)
@@ -17,11 +17,11 @@ module Danger
     end
 
     def head_commit
-      exec "rev-parse HEAD"
+      exec 'rev-parse HEAD'
     end
 
     def origins
-      exec("remote show origin -n").lines.grep(/Fetch URL/)[0].split(": ", 2)[1]
+      exec('remote show origin -n').lines.grep(/Fetch URL/)[0].split(': ', 2)[1]
     end
   end
 end

--- a/lib/danger/version.rb
+++ b/lib/danger/version.rb
@@ -1,4 +1,4 @@
 module Danger
-  VERSION = "2.1.0".freeze
-  DESCRIPTION = "Automate your PR etiquette.".freeze
+  VERSION = '2.1.0'.freeze
+  DESCRIPTION = 'Automate your PR etiquette.'.freeze
 end

--- a/spec/lib/danger/ci_sources/buildkite_spec.rb
+++ b/spec/lib/danger/ci_sources/buildkite_spec.rb
@@ -1,42 +1,42 @@
-require "danger/ci_source/buildkite"
+require 'danger/ci_source/buildkite'
 
 describe Danger::Buildkite do
-  it "validates when buildkite all env vars is found" do
-    env = { "BUILDKITE" => "true",
-            "BUILDKITE_PULL_REQUEST_REPO" => "git@github.com:KrauseFx/danger.git",
-            "BUILDKITE_PULL_REQUEST" => 1 }
+  it 'validates when buildkite all env vars is found' do
+    env = { 'BUILDKITE' => 'true',
+            'BUILDKITE_PULL_REQUEST_REPO' => 'git@github.com:KrauseFx/danger.git',
+            'BUILDKITE_PULL_REQUEST' => 1 }
     expect(Danger::Buildkite.validates_as_ci?(env)).to be true
   end
 
-  it "doesnt validate when buildkite is not found" do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true" }
+  it 'doesnt validate when buildkite is not found' do
+    env = { 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true' }
     expect(Danger::Buildkite.validates_as_ci?(env)).to be false
   end
 
-  it "gets out a repo slug from a git+ssh repo and pull request number" do
-    env = { "BUILDKITE_PULL_REQUEST_REPO" => "git@github.com:KrauseFx/danger.git",
-            "BUILDKITE_PULL_REQUEST" => "12" }
+  it 'gets out a repo slug from a git+ssh repo and pull request number' do
+    env = { 'BUILDKITE_PULL_REQUEST_REPO' => 'git@github.com:KrauseFx/danger.git',
+            'BUILDKITE_PULL_REQUEST' => '12' }
     t = Danger::Buildkite.new(env)
-    expect(t.repo_slug).to eql("KrauseFx/danger")
-    expect(t.pull_request_id).to eql("12")
+    expect(t.repo_slug).to eql('KrauseFx/danger')
+    expect(t.pull_request_id).to eql('12')
   end
 
-  it "gets out a repo slug from a https repo and pull request number" do
+  it 'gets out a repo slug from a https repo and pull request number' do
     env = {
-      "BUILDKITE_PULL_REQUEST_REPO" => "https://github.com/KrauseFx/danger.git",
-      "BUILDKITE_PULL_REQUEST" => "14",
-      "BUILDKITE_BRANCH" => "my_branch"
+      'BUILDKITE_PULL_REQUEST_REPO' => 'https://github.com/KrauseFx/danger.git',
+      'BUILDKITE_PULL_REQUEST' => '14',
+      'BUILDKITE_BRANCH' => 'my_branch'
     }
     t = Danger::Buildkite.new(env)
-    expect(t.repo_slug).to eql("KrauseFx/danger")
-    expect(t.pull_request_id).to eql("14")
+    expect(t.repo_slug).to eql('KrauseFx/danger')
+    expect(t.pull_request_id).to eql('14')
   end
 
   it "doesn't continue when the build is not a pull request" do
     env = {
-      "BUILDKITE" => "true",
-      "BUILDKITE_PULL_REQUEST_REPO" => nil,
-      "BUILDKITE_PULL_REQUEST" => "false"
+      'BUILDKITE' => 'true',
+      'BUILDKITE_PULL_REQUEST_REPO' => nil,
+      'BUILDKITE_PULL_REQUEST' => 'false'
     }
     expect(Danger::Buildkite.validates_as_ci?(env)).to be true
     expect(Danger::Buildkite.validates_as_pr?(env)).to be false

--- a/spec/lib/danger/ci_sources/ci_source.rb
+++ b/spec/lib/danger/ci_sources/ci_source.rb
@@ -1,4 +1,4 @@
-require "danger/ci_source/ci_source"
+require 'danger/ci_source/ci_source'
 
 describe Danger::Buildkite do
   before do
@@ -6,12 +6,12 @@ describe Danger::Buildkite do
     @ci_source = stub_ci
   end
 
-  it "fails if given request source is not supported" do
+  it 'fails if given request source is not supported' do
     allow(@ci_source).to receive(:supported_request_sources).and_return([])
     expect(@ci_source.supports?(@request_source)).to be false
   end
 
-  it "supports a supported request source" do
+  it 'supports a supported request source' do
     allow(@ci_source).to receive(:supported_request_sources).and_return([Danger::RequestSources::GitHub])
     expect(@ci_source.supports?(@request_source)).to be true
   end

--- a/spec/lib/danger/ci_sources/circle_api_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_api_spec.rb
@@ -1,41 +1,41 @@
-require "danger/ci_source/circle_api"
+require 'danger/ci_source/circle_api'
 
 describe Danger::CircleAPI do
-  api_path = "project/artsy/eigen/1500"
-  accept_json = { accept: "application/json" }
+  api_path = 'project/artsy/eigen/1500'
+  accept_json = { accept: 'application/json' }
 
   before do
-    build_response = fixture("circle_build_response")
+    build_response = fixture('circle_build_response')
     @mocked_response = Faraday::Response.new(body: build_response, status: 200)
     @expected_json_response = JSON.parse(build_response, symbolize_names: true)
   end
 
-  it "has a nil token as default" do
+  it 'has a nil token as default' do
     api = Danger::CircleAPI.new
     expect(api.circle_token).to be nil
   end
 
-  it "sets the token on initialize" do
-    api = Danger::CircleAPI.new("123456")
-    expect(api.circle_token).to eql("123456")
+  it 'sets the token on initialize' do
+    api = Danger::CircleAPI.new('123456')
+    expect(api.circle_token).to eql('123456')
   end
 
-  it "creates a client with the correct base url" do
+  it 'creates a client with the correct base url' do
     api = Danger::CircleAPI.new
-    expect(api.client.url_prefix.to_s).to eql("https://circleci.com/api/v1")
+    expect(api.client.url_prefix.to_s).to eql('https://circleci.com/api/v1')
   end
 
-  it "fetches the build info without token" do
+  it 'fetches the build info without token' do
     api = Danger::CircleAPI.new
-    allow(api.client).to receive(:get).with(api_path, { "circle-token" => nil }, accept_json).and_return(@mocked_response)
+    allow(api.client).to receive(:get).with(api_path, { 'circle-token' => nil }, accept_json).and_return(@mocked_response)
 
-    expect(api.fetch_build("artsy/eigen", "1500")).to eql(@expected_json_response)
+    expect(api.fetch_build('artsy/eigen', '1500')).to eql(@expected_json_response)
   end
 
-  it "fetches the build info with token" do
-    api = Danger::CircleAPI.new("123456")
-    allow(api.client).to receive(:get).with(api_path, { "circle-token" => "123456" }, accept_json).and_return(@mocked_response)
+  it 'fetches the build info with token' do
+    api = Danger::CircleAPI.new('123456')
+    allow(api.client).to receive(:get).with(api_path, { 'circle-token' => '123456' }, accept_json).and_return(@mocked_response)
 
-    expect(api.fetch_build("artsy/eigen", "1500")).to eql(@expected_json_response)
+    expect(api.fetch_build('artsy/eigen', '1500')).to eql(@expected_json_response)
   end
 end

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -1,84 +1,84 @@
-require "danger/ci_source/circle"
+require 'danger/ci_source/circle'
 
 describe Danger::CircleCI do
-  legit_pr = "https://github.com/orta/thing/pulls/45"
-  not_legit_pr = "https://github.com/orta"
+  legit_pr = 'https://github.com/orta/thing/pulls/45'
+  not_legit_pr = 'https://github.com/orta'
 
-  it "validates when circle all env vars are set" do
-    env = { "CIRCLE_BUILD_NUM" => "true",
-            "CI_PULL_REQUEST" => legit_pr,
-            "CIRCLE_PROJECT_USERNAME" => "orta",
-            "CIRCLE_PROJECT_REPONAME" => "thing" }
+  it 'validates when circle all env vars are set' do
+    env = { 'CIRCLE_BUILD_NUM' => 'true',
+            'CI_PULL_REQUEST' => legit_pr,
+            'CIRCLE_PROJECT_USERNAME' => 'orta',
+            'CIRCLE_PROJECT_REPONAME' => 'thing' }
     expect(Danger::CircleCI.validates_as_ci?(env)).to be true
   end
 
-  it "validates when circle env var is found and it has a bad PR url" do
-    env = { "CIRCLE_BUILD_NUM" => "true",
-            "CI_PULL_REQUEST" => not_legit_pr,
-            "CIRCLE_PROJECT_USERNAME" => "orta",
-            "CIRCLE_PROJECT_REPONAME" => "thing" }
+  it 'validates when circle env var is found and it has a bad PR url' do
+    env = { 'CIRCLE_BUILD_NUM' => 'true',
+            'CI_PULL_REQUEST' => not_legit_pr,
+            'CIRCLE_PROJECT_USERNAME' => 'orta',
+            'CIRCLE_PROJECT_REPONAME' => 'thing' }
     expect(Danger::CircleCI.validates_as_ci?(env)).to be true
   end
 
-  it "doesnt get a PR id when it has a bad PR url" do
-    env = { "CIRCLE_BUILD_NUM" => "true",
-            "CI_PULL_REQUEST" => not_legit_pr,
-            "CIRCLE_PROJECT_USERNAME" => "orta",
-            "CIRCLE_PROJECT_REPONAME" => "thing" }
+  it 'doesnt get a PR id when it has a bad PR url' do
+    env = { 'CIRCLE_BUILD_NUM' => 'true',
+            'CI_PULL_REQUEST' => not_legit_pr,
+            'CIRCLE_PROJECT_USERNAME' => 'orta',
+            'CIRCLE_PROJECT_REPONAME' => 'thing' }
     t = Danger::CircleCI.new(env)
     expect(t.pull_request_id).to be nil
   end
 
-  it "does validate when circle env var is found and it has no PR url" do
-    env = { "CIRCLE_BUILD_NUM" => "true",
-            "CIRCLE_PROJECT_USERNAME" => "orta",
-            "CIRCLE_PROJECT_REPONAME" => "thing" }
+  it 'does validate when circle env var is found and it has no PR url' do
+    env = { 'CIRCLE_BUILD_NUM' => 'true',
+            'CIRCLE_PROJECT_USERNAME' => 'orta',
+            'CIRCLE_PROJECT_REPONAME' => 'thing' }
     expect(Danger::CircleCI.validates_as_ci?(env)).to be true
   end
 
-  it "doesnt validate when circle ci is not found" do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true" }
+  it 'doesnt validate when circle ci is not found' do
+    env = { 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true' }
     expect(Danger::CircleCI.validates_as_ci?(env)).to be false
   end
 
-  it "gets out a repo slug and pull request number" do
+  it 'gets out a repo slug and pull request number' do
     env = {
-      "CIRCLE_BUILD_NUM" => "true",
-      "CI_PULL_REQUEST" => "https://github.com/artsy/eigen/pull/800",
-      "CIRCLE_COMPARE_URL" => "https://github.com/artsy/eigen/compare/759adcbd0d8f...13c4dc8bb61d"
+      'CIRCLE_BUILD_NUM' => 'true',
+      'CI_PULL_REQUEST' => 'https://github.com/artsy/eigen/pull/800',
+      'CIRCLE_COMPARE_URL' => 'https://github.com/artsy/eigen/compare/759adcbd0d8f...13c4dc8bb61d'
     }
     t = Danger::CircleCI.new(env)
-    expect(t.repo_slug).to eql("artsy/eigen")
-    expect(t.pull_request_id).to eql("800")
+    expect(t.repo_slug).to eql('artsy/eigen')
+    expect(t.pull_request_id).to eql('800')
   end
 
-  it "gets out a repo slug, pull request number and commit refs when PR url is not found" do
+  it 'gets out a repo slug, pull request number and commit refs when PR url is not found' do
     env = {
-      "CIRCLE_BUILD_NUM" => "1500",
-      "CIRCLE_PROJECT_USERNAME" => "artsy",
-      "CIRCLE_PROJECT_REPONAME" => "eigen",
-      "CIRCLE_COMPARE_URL" => "https://github.com/artsy/eigen/compare/759adcbd0d8f...13c4dc8bb61d"
+      'CIRCLE_BUILD_NUM' => '1500',
+      'CIRCLE_PROJECT_USERNAME' => 'artsy',
+      'CIRCLE_PROJECT_REPONAME' => 'eigen',
+      'CIRCLE_COMPARE_URL' => 'https://github.com/artsy/eigen/compare/759adcbd0d8f...13c4dc8bb61d'
     }
-    build_response = JSON.parse(fixture("circle_build_response"), symbolize_names: true)
-    allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with("artsy/eigen", "1500").and_return(build_response)
+    build_response = JSON.parse(fixture('circle_build_response'), symbolize_names: true)
+    allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with('artsy/eigen', '1500').and_return(build_response)
 
     t = Danger::CircleCI.new(env)
 
-    expect(t.repo_slug).to eql("artsy/eigen")
-    expect(t.pull_request_id).to eql("1130")
+    expect(t.repo_slug).to eql('artsy/eigen')
+    expect(t.pull_request_id).to eql('1130')
   end
 
-  it "uses Circle CI API token if available" do
+  it 'uses Circle CI API token if available' do
     env = {
-      "CIRCLE_BUILD_NUM" => "1500",
-      "CIRCLE_CI_API_TOKEN" => "token",
-      "CIRCLE_PROJECT_USERNAME" => "artsy",
-      "CIRCLE_PROJECT_REPONAME" => "eigen"
+      'CIRCLE_BUILD_NUM' => '1500',
+      'CIRCLE_CI_API_TOKEN' => 'token',
+      'CIRCLE_PROJECT_USERNAME' => 'artsy',
+      'CIRCLE_PROJECT_REPONAME' => 'eigen'
     }
-    build_response = JSON.parse(fixture("circle_build_response"), symbolize_names: true)
-    allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with("artsy/eigen", "1500").and_return(build_response)
+    build_response = JSON.parse(fixture('circle_build_response'), symbolize_names: true)
+    allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with('artsy/eigen', '1500').and_return(build_response)
 
     t = Danger::CircleCI.new(env)
-    expect(t.client.circle_token).to eql("token")
+    expect(t.client.circle_token).to eql('token')
   end
 end

--- a/spec/lib/danger/ci_sources/drone_spec.rb
+++ b/spec/lib/danger/ci_sources/drone_spec.rb
@@ -1,52 +1,52 @@
-require "danger/ci_source/drone"
+require 'danger/ci_source/drone'
 
 describe Danger::Drone do
-  it "validates when DRONE variable is set" do
-    env = { "DRONE" => "true",
-            "DRONE_REPO" => "danger/danger",
-            "DRONE_PULL_REQUEST" => 1 }
+  it 'validates when DRONE variable is set' do
+    env = { 'DRONE' => 'true',
+            'DRONE_REPO' => 'danger/danger',
+            'DRONE_PULL_REQUEST' => 1 }
     expect(Danger::Drone.validates_as_ci?(env)).to be true
   end
 
-  it "does not validate when DRONE is not set" do
-    env = { "CIRCLE" => "true" }
+  it 'does not validate when DRONE is not set' do
+    env = { 'CIRCLE' => 'true' }
     expect(Danger::Drone.validates_as_ci?(env)).to be false
   end
 
-  it "does not validate PR when DRONE_PULL_REQUEST is set to non int value" do
-    env = { "CIRCLE" => "true",
-            "DRONE_REPO" => "danger/danger",
-            "DRONE_PULL_REQUEST" => "maku" }
+  it 'does not validate PR when DRONE_PULL_REQUEST is set to non int value' do
+    env = { 'CIRCLE' => 'true',
+            'DRONE_REPO' => 'danger/danger',
+            'DRONE_PULL_REQUEST' => 'maku' }
     expect(Danger::Drone.validates_as_pr?(env)).to be false
   end
 
-  it "does not validate  PRwhen DRONE_PULL_REQUEST is set to non positive int value" do
-    env = { "CIRCLE" => "true",
-            "DRONE_REPO" => "danger/danger",
-            "DRONE_PULL_REQUEST" => -1 }
+  it 'does not validate  PRwhen DRONE_PULL_REQUEST is set to non positive int value' do
+    env = { 'CIRCLE' => 'true',
+            'DRONE_REPO' => 'danger/danger',
+            'DRONE_PULL_REQUEST' => -1 }
     expect(Danger::Drone.validates_as_pr?(env)).to be false
   end
 
-  it "gets the pull request ID" do
-    env = { "DRONE_PULL_REQUEST" => "2" }
+  it 'gets the pull request ID' do
+    env = { 'DRONE_PULL_REQUEST' => '2' }
     t = Danger::Drone.new(env)
-    expect(t.pull_request_id).to eql("2")
+    expect(t.pull_request_id).to eql('2')
   end
 
-  it "gets the repo address" do
-    env = { "DRONE_REPO" => "orta/danger" }
+  it 'gets the repo address' do
+    env = { 'DRONE_REPO' => 'orta/danger' }
     t = Danger::Drone.new(env)
-    expect(t.repo_slug).to eql("orta/danger")
+    expect(t.repo_slug).to eql('orta/danger')
   end
 
-  it "gets out a repo slug and pull request number" do
+  it 'gets out a repo slug and pull request number' do
     env = {
-      "DRONE" => "true",
-      "DRONE_PULL_REQUEST" => "800",
-      "DRONE_REPO" => "artsy/eigen"
+      'DRONE' => 'true',
+      'DRONE_PULL_REQUEST' => '800',
+      'DRONE_REPO' => 'artsy/eigen'
     }
     t = Danger::Drone.new(env)
-    expect(t.repo_slug).to eql("artsy/eigen")
-    expect(t.pull_request_id).to eql("800")
+    expect(t.repo_slug).to eql('artsy/eigen')
+    expect(t.pull_request_id).to eql('800')
   end
 end

--- a/spec/lib/danger/ci_sources/git_spec.rb
+++ b/spec/lib/danger/ci_sources/git_spec.rb
@@ -1,165 +1,165 @@
-require "danger/scm_source/git_repo"
+require 'danger/scm_source/git_repo'
 
 describe Danger::GitRepo do
-  describe "Return Types" do
+  describe 'Return Types' do
     before do
       @tmp_dir = Dir.mktmpdir
       Dir.chdir(@tmp_dir) do
         `git init`
-        File.open(@tmp_dir + "/file", "w") {}
+        File.open(@tmp_dir + '/file', 'w') {}
         `git add .`
         `git commit -m "ok"`
         `git checkout -b new`
-        File.open(@tmp_dir + "/file2", "w") {}
+        File.open(@tmp_dir + '/file2', 'w') {}
         `git add .`
         `git commit -m "another"`
       end
 
       @dm = testing_dangerfile
-      @dm.env.scm.diff_for_folder(@tmp_dir, from: "master", to: "new")
+      @dm.env.scm.diff_for_folder(@tmp_dir, from: 'master', to: 'new')
     end
 
-    it "#modified_files returns a FileList object" do
+    it '#modified_files returns a FileList object' do
       expect(@dm.git.modified_files.class).to eql(Danger::FileList)
     end
 
-    it "#added_files returns a FileList object" do
+    it '#added_files returns a FileList object' do
       expect(@dm.git.added_files.class).to eql(Danger::FileList)
     end
 
-    it "#deleted_files returns a FileList object" do
+    it '#deleted_files returns a FileList object' do
       expect(@dm.git.deleted_files.class).to eql(Danger::FileList)
     end
   end
 
-  describe "with files" do
-    it "handles adding a new file to a git repo" do
+  describe 'with files' do
+    it 'handles adding a new file to a git repo' do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
-          File.open(dir + "/file1", "w") {}
+          File.open(dir + '/file1', 'w') {}
           `git add .`
           `git commit -m "ok"`
 
           `git checkout -b new`
-          File.open(dir + "/file2", "w") {}
+          File.open(dir + '/file2', 'w') {}
           `git add .`
           `git commit -m "another"`
         end
 
         @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+        @dm.env.scm.diff_for_folder(dir, from: 'master', to: 'new')
 
-        expect(@dm.git.added_files).to eql(["file2"])
+        expect(@dm.git.added_files).to eql(['file2'])
       end
     end
 
-    it "handles file deletions as expected" do
+    it 'handles file deletions as expected' do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
-          File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
+          File.open(dir + '/file', 'w') { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`
           `git commit -m "ok"`
 
           `git checkout -b new`
-          File.delete(dir + "/file")
+          File.delete(dir + '/file')
           `git add . --all`
           `git commit -m "another"`
         end
 
         @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+        @dm.env.scm.diff_for_folder(dir, from: 'master', to: 'new')
 
-        expect(@dm.git.deleted_files).to eql(["file"])
+        expect(@dm.git.deleted_files).to eql(['file'])
       end
     end
 
-    it "handles modified as expected" do
+    it 'handles modified as expected' do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
-          File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
+          File.open(dir + '/file', 'w') { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`
           `git commit -m "ok"`
 
           `git checkout -b new`
-          File.open(dir + "/file", "a") { |file| file.write("ok\nmorestuff") }
+          File.open(dir + '/file', 'a') { |file| file.write("ok\nmorestuff") }
           `git add .`
           `git commit -m "another"`
         end
 
         @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+        @dm.env.scm.diff_for_folder(dir, from: 'master', to: 'new')
 
-        expect(@dm.git.modified_files).to eql(["file"])
+        expect(@dm.git.modified_files).to eql(['file'])
       end
     end
   end
 
-  describe "lines of code" do
-    it "handles code insertions as expected" do
+  describe 'lines of code' do
+    it 'handles code insertions as expected' do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
-          File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
+          File.open(dir + '/file', 'w') { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`
           `git commit -m "ok"`
 
           `git checkout -b new`
-          File.open(dir + "/file", "a") { |file| file.write("hi\n\najsdha") }
+          File.open(dir + '/file', 'a') { |file| file.write("hi\n\najsdha") }
           `git add .`
           `git commit -m "another"`
         end
 
         @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+        @dm.env.scm.diff_for_folder(dir, from: 'master', to: 'new')
 
         expect(@dm.git.insertions).to eql(3)
       end
     end
 
-    it "handles code deletions as expected" do
+    it 'handles code deletions as expected' do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
-          File.open(dir + "/file", "w") { |file| file.write("1\n2\n3\n4\n5\n") }
+          File.open(dir + '/file', 'w') { |file| file.write("1\n2\n3\n4\n5\n") }
           `git add .`
           `git commit -m "ok"`
 
           `git checkout -b new`
-          File.open(dir + "/file", "w") { |file| file.write("1\n2\n3\n5\n") }
+          File.open(dir + '/file', 'w') { |file| file.write("1\n2\n3\n5\n") }
           `git add .`
           `git commit -m "another"`
         end
 
         @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+        @dm.env.scm.diff_for_folder(dir, from: 'master', to: 'new')
 
         expect(@dm.git.deletions).to eql(1)
       end
     end
 
-    describe "#commits" do
-      it "returns the commits" do
+    describe '#commits' do
+      it 'returns the commits' do
         Dir.mktmpdir do |dir|
           Dir.chdir dir do
             `git init`
-            File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
+            File.open(dir + '/file', 'w') { |file| file.write("hi\n\nfb\nasdasd") }
             `git add .`
             `git commit -m "ok"`
 
             `git checkout -b new`
-            File.open(dir + "/file", "a") { |file| file.write("hi\n\najsdha") }
+            File.open(dir + '/file', 'a') { |file| file.write("hi\n\najsdha") }
             `git add .`
             `git commit -m "another"`
           end
 
           @dm = testing_dangerfile
-          @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+          @dm.env.scm.diff_for_folder(dir, from: 'master', to: 'new')
 
           messages = @dm.git.commits.map(&:message)
-          expect(messages).to eq(["another"])
+          expect(messages).to eq(['another'])
         end
       end
     end

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -1,45 +1,45 @@
-require "danger/ci_source/circle"
+require 'danger/ci_source/circle'
 
 describe Danger::Jenkins do
-  it "validates when jenkins env var is found" do
+  it 'validates when jenkins env var is found' do
     env = {
-      "JENKINS_URL" => "Hello",
-      "GIT_URL" => "https://github.com/danger/danger.git",
-      "ghprbPullId" => "1234"
+      'JENKINS_URL' => 'Hello',
+      'GIT_URL' => 'https://github.com/danger/danger.git',
+      'ghprbPullId' => '1234'
     }
     expect(Danger::Jenkins.validates_as_ci?(env)).to be true
   end
 
-  it "doesnt validate when jenkins is not found" do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true" }
+  it 'doesnt validate when jenkins is not found' do
+    env = { 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true' }
     expect(Danger::Jenkins.validates_as_ci?(env)).to be false
   end
 
-  it "gets out a repo slug from a git+ssh repo and pull request number" do
+  it 'gets out a repo slug from a git+ssh repo and pull request number' do
     env = {
-      "GIT_URL" => "git@github.com:danger/danger.git",
-      "ghprbPullId" => "12"
+      'GIT_URL' => 'git@github.com:danger/danger.git',
+      'ghprbPullId' => '12'
     }
     t = Danger::Jenkins.new(env)
-    expect(t.repo_slug).to eql("danger/danger")
-    expect(t.pull_request_id).to eql("12")
+    expect(t.repo_slug).to eql('danger/danger')
+    expect(t.pull_request_id).to eql('12')
   end
 
-  it "gets out a repo slug from a https repo and pull request number" do
+  it 'gets out a repo slug from a https repo and pull request number' do
     env = {
-      "GIT_URL" => "https://github.com/danger/danger.git",
-      "ghprbPullId" => "14"
+      'GIT_URL' => 'https://github.com/danger/danger.git',
+      'ghprbPullId' => '14'
     }
     t = Danger::Jenkins.new(env)
-    expect(t.repo_slug).to eql("danger/danger")
-    expect(t.pull_request_id).to eql("14")
+    expect(t.repo_slug).to eql('danger/danger')
+    expect(t.pull_request_id).to eql('14')
   end
 
-  it "Is classed as a PR when ghprbPullId exists" do
+  it 'Is classed as a PR when ghprbPullId exists' do
     env = {
-      "JENKINS_URL" => "Hello",
-      "GIT_URL" => "https://github.com/danger/danger.git",
-      "ghprbPullId" => "1234"
+      'JENKINS_URL' => 'Hello',
+      'GIT_URL' => 'https://github.com/danger/danger.git',
+      'ghprbPullId' => '1234'
     }
     expect(Danger::Jenkins.validates_as_pr?(env)).to be true
   end

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -1,15 +1,15 @@
-require "spec_helper"
-require "danger/ci_source/local_git_repo"
+require 'spec_helper'
+require 'danger/ci_source/local_git_repo'
 
 def run_in_repo
   Dir.mktmpdir do |dir|
     Dir.chdir dir do
       `git init`
-      File.open(dir + "/file1", "w") {}
+      File.open(dir + '/file1', 'w') {}
       `git add .`
       `git commit -m "adding file1"`
       `git checkout -b new-branch`
-      File.open(dir + "/file2", "w") {}
+      File.open(dir + '/file2', 'w') {}
       `git add .`
       `git commit -m "adding file2"`
       `git checkout master`
@@ -20,126 +20,126 @@ def run_in_repo
 end
 
 describe Danger::LocalGitRepo do
-  it "validates when run by danger local" do
-    env = { "DANGER_USE_LOCAL_GIT" => "true" }
+  it 'validates when run by danger local' do
+    env = { 'DANGER_USE_LOCAL_GIT' => 'true' }
     expect(Danger::LocalGitRepo.validates_as_ci?(env)).to be true
   end
 
-  it "doesnt validate when the local git flag is missing" do
-    env = { "HAS_ANDREW_W_K_SEAL_OF_APPROVAL" => "true" }
+  it 'doesnt validate when the local git flag is missing' do
+    env = { 'HAS_ANDREW_W_K_SEAL_OF_APPROVAL' => 'true' }
     expect(Danger::LocalGitRepo.validates_as_ci?(env)).to be false
   end
 
-  it "gets the pull request ID" do
+  it 'gets the pull request ID' do
     run_in_repo do
-      env = { "DANGER_USE_LOCAL_GIT" => "true" }
+      env = { 'DANGER_USE_LOCAL_GIT' => 'true' }
       t = Danger::LocalGitRepo.new(env)
-      expect(t.pull_request_id).to eql("1234")
+      expect(t.pull_request_id).to eql('1234')
     end
   end
 
-  describe "github repos" do
-    xit "gets the repo address when it uses https" do
+  describe 'github repos' do
+    xit 'gets the repo address when it uses https' do
       run_in_repo do
         `git remote add origin https://github.com/orta/danger.git`
-        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true' }
         t = Danger::LocalGitRepo.new(env)
-        expect(t.repo_slug).to eql("orta/danger")
+        expect(t.repo_slug).to eql('orta/danger')
       end
     end
 
-    it "gets the repo address when it uses git@" do
+    it 'gets the repo address when it uses git@' do
       run_in_repo do
         `git remote add origin git@github.com:orta/danger.git`
-        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true' }
         t = Danger::LocalGitRepo.new(env)
-        expect(t.repo_slug).to eql("orta/danger")
+        expect(t.repo_slug).to eql('orta/danger')
       end
     end
 
-    it "gets the repo address when it contains .git" do
+    it 'gets the repo address when it contains .git' do
       run_in_repo do
         `git remote add origin git@github.com:artsy/artsy.github.com.git`
-        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true' }
         t = Danger::LocalGitRepo.new(env)
-        expect(t.repo_slug).to eql("artsy/artsy.github.com")
+        expect(t.repo_slug).to eql('artsy/artsy.github.com')
       end
     end
 
-    it "gets the repo address when it starts with git://" do
+    it 'gets the repo address when it starts with git://' do
       run_in_repo do
         `git remote add origin git://github.com:orta/danger.git`
-        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true' }
         t = Danger::LocalGitRepo.new(env)
-        expect(t.repo_slug).to eql("orta/danger")
+        expect(t.repo_slug).to eql('orta/danger')
       end
     end
 
-    it "gets the repo address when it starts with git://git@" do
+    it 'gets the repo address when it starts with git://git@' do
       run_in_repo do
         `git remote add origin git://git@github.com:orta/danger.git`
-        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true' }
         t = Danger::LocalGitRepo.new(env)
-        expect(t.repo_slug).to eql("orta/danger")
+        expect(t.repo_slug).to eql('orta/danger')
       end
     end
 
-    it "does not set a repo_slug if the repo has a non-gh remote" do
+    it 'does not set a repo_slug if the repo has a non-gh remote' do
       run_in_repo do
         `git remote add origin git@git.evilcorp.com:tyrell/danger.git`
-        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true' }
         t = Danger::LocalGitRepo.new(env)
         expect(t.repo_slug).to be_nil
       end
     end
   end
 
-  describe "enterprise github repos" do
-    it "does set a repo_slug if provided with a github_host" do
+  describe 'enterprise github repos' do
+    it 'does set a repo_slug if provided with a github_host' do
       run_in_repo do
         `git remote add origin git@git.evilcorp.com:tyrell/danger.git`
-        env = { "DANGER_USE_LOCAL_GIT" => "true", "DANGER_GITHUB_HOST" => "git.evilcorp.com" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true', 'DANGER_GITHUB_HOST' => 'git.evilcorp.com' }
         t = Danger::LocalGitRepo.new(env)
-        expect(t.repo_slug).to eql("tyrell/danger")
+        expect(t.repo_slug).to eql('tyrell/danger')
       end
     end
 
-    it "does not set a repo_slug if provided with a github_host that is different from the remote" do
+    it 'does not set a repo_slug if provided with a github_host that is different from the remote' do
       run_in_repo do
         `git remote add origin git@git.evilcorp.com:tyrell/danger.git`
-        env = { "DANGER_USE_LOCAL_GIT" => "true", "DANGER_GITHUB_HOST" => "git.robot.com" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true', 'DANGER_GITHUB_HOST' => 'git.robot.com' }
         t = Danger::LocalGitRepo.new(env)
         expect(t.repo_slug).to be_nil
       end
     end
   end
 
-  describe "Support looking for a specific PR" do
+  describe 'Support looking for a specific PR' do
     def add_another_pr
       # Add a new PR merge commit
       `git checkout -b new-branch2`
-      File.open("file3", "w") {}
+      File.open('file3', 'w') {}
       `git add .`
       `git commit -m "adding file2"`
       `git checkout master`
       `git merge new-branch2 --no-ff -m "Merge pull request #1235 from new-branch"`
     end
 
-    it "handles finding the resulting PR" do
+    it 'handles finding the resulting PR' do
       run_in_repo do
         add_another_pr
 
-        env = { "DANGER_USE_LOCAL_GIT" => "true", "LOCAL_GIT_PR_ID" => "1234" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true', 'LOCAL_GIT_PR_ID' => '1234' }
         t = Danger::LocalGitRepo.new(env)
-        expect(t.pull_request_id).to eql("1234")
+        expect(t.pull_request_id).to eql('1234')
       end
     end
 
-    it "handles not finding the resulting PR" do
+    it 'handles not finding the resulting PR' do
       run_in_repo do
         add_another_pr
 
-        env = { "DANGER_USE_LOCAL_GIT" => "true", "LOCAL_GIT_PR_ID" => "1238" }
+        env = { 'DANGER_USE_LOCAL_GIT' => 'true', 'LOCAL_GIT_PR_ID' => '1238' }
 
         expect { Danger::LocalGitRepo.new(env) }.to raise_error RuntimeError
       end

--- a/spec/lib/danger/ci_sources/semaphore_spec.rb
+++ b/spec/lib/danger/ci_sources/semaphore_spec.rb
@@ -1,38 +1,38 @@
-require "danger/ci_source/travis"
+require 'danger/ci_source/travis'
 
 describe Danger::Semaphore do
-  it "validates when all semaphore variables are set" do
-    env = { "SEMAPHORE" => "true",
-            "PULL_REQUEST_NUMBER" => "800",
-            "SEMAPHORE_REPO_SLUG" => "artsy/eigen" }
+  it 'validates when all semaphore variables are set' do
+    env = { 'SEMAPHORE' => 'true',
+            'PULL_REQUEST_NUMBER' => '800',
+            'SEMAPHORE_REPO_SLUG' => 'artsy/eigen' }
     expect(Danger::Semaphore.validates_as_ci?(env)).to be true
   end
 
-  it "doesnt validate when not semaphore" do
-    env = { "CIRCLE" => "true" }
+  it 'doesnt validate when not semaphore' do
+    env = { 'CIRCLE' => 'true' }
     expect(Danger::Semaphore.validates_as_ci?(env)).to be false
   end
 
-  it "gets the pull request ID" do
-    env = { "PULL_REQUEST_NUMBER" => "2" }
+  it 'gets the pull request ID' do
+    env = { 'PULL_REQUEST_NUMBER' => '2' }
     t = Danger::Semaphore.new(env)
-    expect(t.pull_request_id).to eql("2")
+    expect(t.pull_request_id).to eql('2')
   end
 
-  it "gets the repo address" do
-    env = { "SEMAPHORE_REPO_SLUG" => "orta/danger" }
+  it 'gets the repo address' do
+    env = { 'SEMAPHORE_REPO_SLUG' => 'orta/danger' }
     t = Danger::Semaphore.new(env)
-    expect(t.repo_slug).to eql("orta/danger")
+    expect(t.repo_slug).to eql('orta/danger')
   end
 
-  it "gets out a repo slug and pull request number" do
+  it 'gets out a repo slug and pull request number' do
     env = {
-      "SEMAPHORE" => "true",
-      "PULL_REQUEST_NUMBER" => "800",
-      "SEMAPHORE_REPO_SLUG" => "artsy/eigen"
+      'SEMAPHORE' => 'true',
+      'PULL_REQUEST_NUMBER' => '800',
+      'SEMAPHORE_REPO_SLUG' => 'artsy/eigen'
     }
     t = Danger::Semaphore.new(env)
-    expect(t.repo_slug).to eql("artsy/eigen")
-    expect(t.pull_request_id).to eql("800")
+    expect(t.repo_slug).to eql('artsy/eigen')
+    expect(t.pull_request_id).to eql('800')
   end
 end

--- a/spec/lib/danger/ci_sources/surf_spec.rb
+++ b/spec/lib/danger/ci_sources/surf_spec.rb
@@ -1,38 +1,38 @@
-require "danger/ci_source/surf"
+require 'danger/ci_source/surf'
 
 describe Danger::Surf do
-  it "validates when all Surf environment vars are set" do
-    env = { "SURF_REPO" => "https://github.com/surf-build/surf",
-            "SURF_NWO" => "surf-build/surf" }
+  it 'validates when all Surf environment vars are set' do
+    env = { 'SURF_REPO' => 'https://github.com/surf-build/surf',
+            'SURF_NWO' => 'surf-build/surf' }
 
     expect(Danger::Surf.validates_as_ci?(env)).to be true
   end
 
-  it "doesnt validate when Surf aint around" do
-    env = { "CIRCLE" => "true" }
+  it 'doesnt validate when Surf aint around' do
+    env = { 'CIRCLE' => 'true' }
     expect(Danger::Surf.validates_as_ci?(env)).to be false
   end
 
-  it "gets the pull request ID" do
-    env = { "SURF_PR_NUM" => "2" }
+  it 'gets the pull request ID' do
+    env = { 'SURF_PR_NUM' => '2' }
     t = Danger::Surf.new(env)
-    expect(t.pull_request_id).to eql("2")
+    expect(t.pull_request_id).to eql('2')
   end
 
-  it "gets the repo address" do
-    env = { "SURF_NWO" => "orta/danger" }
+  it 'gets the repo address' do
+    env = { 'SURF_NWO' => 'orta/danger' }
     t = Danger::Surf.new(env)
-    expect(t.repo_slug).to eql("orta/danger")
+    expect(t.repo_slug).to eql('orta/danger')
   end
 
-  it "gets out a repo slug and pull request number" do
+  it 'gets out a repo slug and pull request number' do
     env = {
-      "SURF_PR_NUM" => "800",
-      "SURF_NWO" => "artsy/eigen",
-      "SURF_REPO" => "https://github.com/artsy/eigen"
+      'SURF_PR_NUM' => '800',
+      'SURF_NWO' => 'artsy/eigen',
+      'SURF_REPO' => 'https://github.com/artsy/eigen'
     }
     t = Danger::Surf.new(env)
-    expect(t.repo_slug).to eql("artsy/eigen")
-    expect(t.pull_request_id).to eql("800")
+    expect(t.repo_slug).to eql('artsy/eigen')
+    expect(t.pull_request_id).to eql('800')
   end
 end

--- a/spec/lib/danger/ci_sources/teamcity_spec.rb
+++ b/spec/lib/danger/ci_sources/teamcity_spec.rb
@@ -1,26 +1,26 @@
-require "danger/ci_source/teamcity"
+require 'danger/ci_source/teamcity'
 
 describe Danger::TeamCity do
-  it "detects TeamCity" do
-    env = { "TEAMCITY_VERSION" => "42" }
+  it 'detects TeamCity' do
+    env = { 'TEAMCITY_VERSION' => '42' }
     expect(Danger::TeamCity.validates_as_ci?(env)).to be true
   end
 
-  it "gets out a repo slug" do
-    env = { "GITHUB_REPO_SLUG" => "foo/bar" }
+  it 'gets out a repo slug' do
+    env = { 'GITHUB_REPO_SLUG' => 'foo/bar' }
     subject = Danger::TeamCity.new(env)
-    expect(subject.repo_slug).to eql("foo/bar")
+    expect(subject.repo_slug).to eql('foo/bar')
   end
 
-  it "gets out a pull request id" do
-    env = { "GITHUB_PULL_REQUEST_ID" => "42" }
+  it 'gets out a pull request id' do
+    env = { 'GITHUB_PULL_REQUEST_ID' => '42' }
     subject = Danger::TeamCity.new(env)
     expect(subject.pull_request_id).to eql(42)
   end
 
-  it "gets out a repo url" do
-    env = { "GITHUB_REPO_URL" => "http://example.org/" }
+  it 'gets out a repo url' do
+    env = { 'GITHUB_REPO_URL' => 'http://example.org/' }
     subject = Danger::TeamCity.new(env)
-    expect(subject.repo_url).to eql("http://example.org/")
+    expect(subject.repo_url).to eql('http://example.org/')
   end
 end

--- a/spec/lib/danger/ci_sources/travis_spec.rb
+++ b/spec/lib/danger/ci_sources/travis_spec.rb
@@ -1,51 +1,51 @@
-require "danger/ci_source/travis"
+require 'danger/ci_source/travis'
 
 describe Danger::Travis do
-  it "validates when all Travis environment vars are set and Josh K says so" do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
-            "TRAVIS_PULL_REQUEST" => "800",
-            "TRAVIS_REPO_SLUG" => "artsy/eigen" }
+  it 'validates when all Travis environment vars are set and Josh K says so' do
+    env = { 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true',
+            'TRAVIS_PULL_REQUEST' => '800',
+            'TRAVIS_REPO_SLUG' => 'artsy/eigen' }
     expect(Danger::Travis.validates_as_ci?(env)).to be true
     expect(Danger::Travis.validates_as_pr?(env)).to be true
   end
 
-  it "validates as Travis but not as a PR" do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true" }
+  it 'validates as Travis but not as a PR' do
+    env = { 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true' }
     expect(Danger::Travis.validates_as_ci?(env)).to be true
     expect(Danger::Travis.validates_as_pr?(env)).to be false
   end
 
-  it "doesnt validate when Josh K aint around" do
-    env = { "CIRCLE" => "true" }
+  it 'doesnt validate when Josh K aint around' do
+    env = { 'CIRCLE' => 'true' }
     expect(Danger::Travis.validates_as_ci?(env)).to be false
   end
 
-  it "fails the PR check when the pull request is false " do
-    env = { "TRAVIS_PULL_REQUEST" => "false" }
+  it 'fails the PR check when the pull request is false ' do
+    env = { 'TRAVIS_PULL_REQUEST' => 'false' }
     expect(Danger::Travis.validates_as_pr?(env)).to be_falsey
   end
 
-  it "gets the pull request ID" do
-    env = { "TRAVIS_PULL_REQUEST" => "2" }
+  it 'gets the pull request ID' do
+    env = { 'TRAVIS_PULL_REQUEST' => '2' }
     t = Danger::Travis.new(env)
-    expect(t.pull_request_id).to eql("2")
+    expect(t.pull_request_id).to eql('2')
   end
 
-  it "gets the repo address" do
-    env = { "TRAVIS_REPO_SLUG" => "orta/danger" }
+  it 'gets the repo address' do
+    env = { 'TRAVIS_REPO_SLUG' => 'orta/danger' }
     t = Danger::Travis.new(env)
-    expect(t.repo_slug).to eql("orta/danger")
+    expect(t.repo_slug).to eql('orta/danger')
   end
 
-  it "gets out a repo slug and pull request number" do
+  it 'gets out a repo slug and pull request number' do
     env = {
-      "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
-      "TRAVIS_PULL_REQUEST" => "800",
-      "TRAVIS_REPO_SLUG" => "artsy/eigen",
-      "TRAVIS_COMMIT_RANGE" => "759adcbd0d8f...13c4dc8bb61d"
+      'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true',
+      'TRAVIS_PULL_REQUEST' => '800',
+      'TRAVIS_REPO_SLUG' => 'artsy/eigen',
+      'TRAVIS_COMMIT_RANGE' => '759adcbd0d8f...13c4dc8bb61d'
     }
     t = Danger::Travis.new(env)
-    expect(t.repo_slug).to eql("artsy/eigen")
-    expect(t.pull_request_id).to eql("800")
+    expect(t.repo_slug).to eql('artsy/eigen')
+    expect(t.pull_request_id).to eql('800')
   end
 end

--- a/spec/lib/danger/ci_sources/xcode_server_spec.rb
+++ b/spec/lib/danger/ci_sources/xcode_server_spec.rb
@@ -1,24 +1,24 @@
-require "danger/ci_source/xcode_server"
+require 'danger/ci_source/xcode_server'
 
 describe Danger::XcodeServer do
-  it "validates when Xcode Server has XCS_BOT_NAME env var" do
+  it 'validates when Xcode Server has XCS_BOT_NAME env var' do
     env = {
-      "XCS_BOT_NAME" => "BuildaBot [danger/danger] PR #17"
+      'XCS_BOT_NAME' => 'BuildaBot [danger/danger] PR #17'
     }
     expect(Danger::XcodeServer.validates_as_ci?(env)).to be true
   end
 
-  it "doesnt validate when Xcode Server does not have XCS_BOT_NAME env var" do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true" }
+  it 'doesnt validate when Xcode Server does not have XCS_BOT_NAME env var' do
+    env = { 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true' }
     expect(Danger::XcodeServer.validates_as_ci?(env)).to be false
   end
 
-  it "gets out a repo slug and a pull request number from a bot name" do
+  it 'gets out a repo slug and a pull request number from a bot name' do
     env = {
-      "XCS_BOT_NAME" => "BuildaBot [danger/danger] PR #17"
+      'XCS_BOT_NAME' => 'BuildaBot [danger/danger] PR #17'
     }
     t = Danger::XcodeServer.new(env)
-    expect(t.repo_slug).to eql("danger/danger")
-    expect(t.pull_request_id).to eql("17")
+    expect(t.repo_slug).to eql('danger/danger')
+    expect(t.pull_request_id).to eql('17')
   end
 end

--- a/spec/lib/danger/commands/local_helpers/http_cache_spec.rb
+++ b/spec/lib/danger/commands/local_helpers/http_cache_spec.rb
@@ -1,6 +1,6 @@
-require "danger/commands/local_helpers/http_cache"
+require 'danger/commands/local_helpers/http_cache'
 
-TEST_CACHE_FILE = File.join(Dir.tmpdir, "http_cache_spec")
+TEST_CACHE_FILE = File.join(Dir.tmpdir, 'http_cache_spec')
 
 module Danger
   describe Danger::HTTPCache do
@@ -8,60 +8,60 @@ module Danger
       File.delete TEST_CACHE_FILE if File.exist? TEST_CACHE_FILE
     end
 
-    it "will default to a 300 second cache expiry" do
+    it 'will default to a 300 second cache expiry' do
       cache = HTTPCache.new(TEST_CACHE_FILE)
       expect(cache.expires_in).to eq(300)
     end
 
-    it "will allow setting a custom cache expiry" do
+    it 'will allow setting a custom cache expiry' do
       cache = HTTPCache.new(TEST_CACHE_FILE, expires_in: 1234)
       expect(cache.expires_in).to eq(1234)
     end
 
-    it "will open a previous file by default" do
+    it 'will open a previous file by default' do
       store = PStore.new(TEST_CACHE_FILE)
-      store.transaction { store["testing"] = { value: "pants", updated_at: Time.now } }
+      store.transaction { store['testing'] = { value: 'pants', updated_at: Time.now } }
       cache = HTTPCache.new(TEST_CACHE_FILE)
-      expect(cache.read("testing")).to eql("pants")
+      expect(cache.read('testing')).to eql('pants')
     end
 
-    it "will delete a previous file if told to" do
+    it 'will delete a previous file if told to' do
       store = PStore.new(TEST_CACHE_FILE)
-      store.transaction { store["testing"] = "pants" }
+      store.transaction { store['testing'] = 'pants' }
       cache = HTTPCache.new(TEST_CACHE_FILE, clear_cache: true)
-      expect(cache.read("testing")).to be_nil
+      expect(cache.read('testing')).to be_nil
     end
 
-    it "will honor the TTL when a read attempt is made" do
+    it 'will honor the TTL when a read attempt is made' do
       now = Time.now.to_i
       store = PStore.new(TEST_CACHE_FILE)
       store.transaction do
-        store["testing_valid_ttl"] = { value: "pants", updated_at: now - 280 }
-        store["testing_invalid_ttl"] = { value: "pants", updated_at: now - 301 }
+        store['testing_valid_ttl'] = { value: 'pants', updated_at: now - 280 }
+        store['testing_invalid_ttl'] = { value: 'pants', updated_at: now - 301 }
       end
 
       cache = HTTPCache.new(TEST_CACHE_FILE)
-      expect(cache.read("testing_valid_ttl")).to eql("pants")
-      expect(cache.read("testing_invalid_ttl")).to be_nil
+      expect(cache.read('testing_valid_ttl')).to eql('pants')
+      expect(cache.read('testing_invalid_ttl')).to be_nil
     end
 
-    it "will delete a key" do
+    it 'will delete a key' do
       cache = HTTPCache.new(TEST_CACHE_FILE)
 
-      cache.write("testing_delete", "pants")
-      cache.delete("testing_delete")
+      cache.write('testing_delete', 'pants')
+      cache.delete('testing_delete')
 
-      expect(cache.read("testing_delete")).to be_nil
+      expect(cache.read('testing_delete')).to be_nil
     end
 
-    it "will write a key and timestamp" do
+    it 'will write a key and timestamp' do
       cache = HTTPCache.new(TEST_CACHE_FILE)
-      cache.write("testing_write", "pants")
+      cache.write('testing_write', 'pants')
       store = PStore.new(TEST_CACHE_FILE)
       store.transaction do
-        expect(store["testing_write"]).to_not be_nil
-        expect(store["testing_write"][:value]).to eql("pants")
-        expect(store["testing_write"][:updated_at]).to be_within(1).of(Time.now.to_i)
+        expect(store['testing_write']).to_not be_nil
+        expect(store['testing_write'][:value]).to eql('pants')
+        expect(store['testing_write'][:updated_at]).to be_within(1).of(Time.now.to_i)
       end
     end
   end

--- a/spec/lib/danger/commands/plugin_lint_spec.rb
+++ b/spec/lib/danger/commands/plugin_lint_spec.rb
@@ -1,4 +1,4 @@
-require "danger/commands/plugins/plugin_json"
+require 'danger/commands/plugins/plugin_json'
 
 module Danger
   describe Danger::PluginLint do
@@ -6,9 +6,9 @@ module Danger
       Plugin.clear_external_plugins
     end
 
-    it "runs the command" do
+    it 'runs the command' do
       # allow(STDOUT).to receive(:puts) # this disables puts
-      Danger::PluginJSON.run(["spec/fixtures/plugins/example_fully_documented.rb"])
+      Danger::PluginJSON.run(['spec/fixtures/plugins/example_fully_documented.rb'])
     end
   end
 end

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -2,41 +2,41 @@ module Command
   describe Danger::Runner do
     before do
       # Danger local stuff
-      allow(ENV).to receive(:[]).with("DANGER_USE_LOCAL_GIT").and_return(nil)
-      allow(ENV).to receive(:[]).with("DANGER_GITHUB_HOST").and_return("")
-      allow(ENV).to receive(:[]).with("DANGER_GITHUB_API_TOKEN").and_return("11")
-      allow(ENV).to receive(:[]).with("DANGER_GITHUB_API_HOST").and_return(nil)
+      allow(ENV).to receive(:[]).with('DANGER_USE_LOCAL_GIT').and_return(nil)
+      allow(ENV).to receive(:[]).with('DANGER_GITHUB_HOST').and_return('')
+      allow(ENV).to receive(:[]).with('DANGER_GITHUB_API_TOKEN').and_return('11')
+      allow(ENV).to receive(:[]).with('DANGER_GITHUB_API_HOST').and_return(nil)
 
       # We'll take the first CI Source
-      allow(ENV).to receive(:[]).with("BUILDKITE").and_return("SURE")
-      allow(ENV).to receive(:[]).with("BUILDKITE_PULL_REQUEST_REPO").and_return("git@github.com:artsy/eigen.git")
-      allow(ENV).to receive(:[]).with("BUILDKITE_PULL_REQUEST").and_return("800")
+      allow(ENV).to receive(:[]).with('BUILDKITE').and_return('SURE')
+      allow(ENV).to receive(:[]).with('BUILDKITE_PULL_REQUEST_REPO').and_return('git@github.com:artsy/eigen.git')
+      allow(ENV).to receive(:[]).with('BUILDKITE_PULL_REQUEST').and_return('800')
 
       # ENV vars used under the hood
-      allow(ENV).to receive(:[]).with("http_proxy").and_return(nil)
-      allow(ENV).to receive(:[]).with("TMPDIR").and_return(nil)
-      allow(ENV).to receive(:[]).with("TMP").and_return(nil)
-      allow(ENV).to receive(:[]).with("TEMP").and_return(nil)
-      allow(ENV).to receive(:[]).with("CLAIDE_DISABLE_AUTO_WRAP").and_return(nil)
-      allow(ENV).to receive(:[]).with("GEM_REQUIREMENT_DANGER").and_return(nil)
+      allow(ENV).to receive(:[]).with('http_proxy').and_return(nil)
+      allow(ENV).to receive(:[]).with('TMPDIR').and_return(nil)
+      allow(ENV).to receive(:[]).with('TMP').and_return(nil)
+      allow(ENV).to receive(:[]).with('TEMP').and_return(nil)
+      allow(ENV).to receive(:[]).with('CLAIDE_DISABLE_AUTO_WRAP').and_return(nil)
+      allow(ENV).to receive(:[]).with('GEM_REQUIREMENT_DANGER').and_return(nil)
 
       # Mock out the octokit object with our fixtured data
       octokit_mock = Object
 
-      pr_response = JSON.parse(fixture("github_api/pr_response"), symbolize_names: true)
-      allow(octokit_mock).to receive(:pull_request).with("artsy/eigen", "800").and_return(pr_response)
-      issue_response = JSON.parse(fixture("github_api/issue_response"), symbolize_names: true)
-      allow(octokit_mock).to receive(:get).with("https://api.github.com/repos/artsy/eigen/issues/800").and_return(issue_response)
-      issue_comments_response = JSON.parse(fixture("github_api/issue_comments"), symbolize_names: true)
-      allow(octokit_mock).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issue_comments_response)
+      pr_response = JSON.parse(fixture('github_api/pr_response'), symbolize_names: true)
+      allow(octokit_mock).to receive(:pull_request).with('artsy/eigen', '800').and_return(pr_response)
+      issue_response = JSON.parse(fixture('github_api/issue_response'), symbolize_names: true)
+      allow(octokit_mock).to receive(:get).with('https://api.github.com/repos/artsy/eigen/issues/800').and_return(issue_response)
+      issue_comments_response = JSON.parse(fixture('github_api/issue_comments'), symbolize_names: true)
+      allow(octokit_mock).to receive(:issue_comments).with('artsy/eigen', '800').and_return(issue_comments_response)
 
-      issue_comment_response = JSON.parse(fixture("github_api/issue_response"), symbolize_names: true)
+      issue_comment_response = JSON.parse(fixture('github_api/issue_response'), symbolize_names: true)
       allow(octokit_mock).to receive(:add_comment).and_return(issue_comment_response)
 
       allow(Octokit::Client).to receive(:new).and_return octokit_mock
     end
 
-    xit "runtime errors when no Dangerfile found" do
+    xit 'runtime errors when no Dangerfile found' do
       allow(STDOUT).to receive(:puts) # this disables puts
 
       Dir.mktmpdir do |dir|
@@ -46,34 +46,34 @@ module Command
       end
     end
 
-    describe "Calls Executor" do
-      it "works without parameters" do
-        a = "fake"
+    describe 'Calls Executor' do
+      it 'works without parameters' do
+        a = 'fake'
         expect(Danger::Executor).to receive(:new).and_return(a)
         expect(a).to receive(:run).with({
           base: nil,
           head: nil,
-          dangerfile_path: "Dangerfile",
-          danger_id: "danger"
+          dangerfile_path: 'Dangerfile',
+          danger_id: 'danger'
         })
         Danger::Runner.run([])
       end
     end
 
-    describe "full run" do
+    describe 'full run' do
       before do
         @git_mock = Danger::GitRepo.new
         allow(Danger::GitRepo).to receive(:new).and_return @git_mock
 
         git_commands = [
-          { "rev-parse --quiet --verify danger_base" => "OK" },
-          { "rev-parse --quiet --verify danger_head" => "OK" },
-          { "rev-parse HEAD" => "561827e46167077b5e53515b4b7349b8ae04610b" },
-          { "branch danger_base 704dc55988c6996f69b6873c2424be7d1de67bbe" => "" },
-          { "branch danger_head 561827e46167077b5e53515b4b7349b8ae04610b" => "" },
-          { "remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-" => "git@github.com:artsy/eigen.git" },
-          { "branch -D danger_base" => "" },
-          { "branch -D danger_head" => "" }
+          { 'rev-parse --quiet --verify danger_base' => 'OK' },
+          { 'rev-parse --quiet --verify danger_head' => 'OK' },
+          { 'rev-parse HEAD' => '561827e46167077b5e53515b4b7349b8ae04610b' },
+          { 'branch danger_base 704dc55988c6996f69b6873c2424be7d1de67bbe' => '' },
+          { 'branch danger_head 561827e46167077b5e53515b4b7349b8ae04610b' => '' },
+          { "remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-" => 'git@github.com:artsy/eigen.git' },
+          { 'branch -D danger_base' => '' },
+          { 'branch -D danger_head' => '' }
         ]
 
         git_commands.each do |command|
@@ -81,7 +81,7 @@ module Command
         end
       end
 
-      xit "gets through the whole command" do
+      xit 'gets through the whole command' do
         Dir.mktmpdir do |dir|
           Dir.chdir dir do
             `git init`
@@ -92,7 +92,7 @@ module Command
         end
       end
 
-      xit "handles an example dangerfile well" do
+      xit 'handles an example dangerfile well' do
         allow(STDOUT).to receive(:puts) # this disables puts
 
         Dir.mktmpdir do |dir|
@@ -100,7 +100,7 @@ module Command
             `git init`
             `git remote add origin git@github.com:artsy/eigen.git`
 
-            File.write("Dangerfile", %{
+            File.write('Dangerfile', %{
               message "Hi"
               warn "OK"
               fail "Not OK"
@@ -117,7 +117,7 @@ module Command
         end
       end
 
-      xit "has the correct version" do
+      xit 'has the correct version' do
         expect(Danger::Runner.version).to eq(Danger::VERSION)
       end
     end

--- a/spec/lib/danger/core_ext/file_list_spec.rb
+++ b/spec/lib/danger/core_ext/file_list_spec.rb
@@ -1,27 +1,27 @@
-require "danger/core_ext/file_list"
+require 'danger/core_ext/file_list'
 
 describe Danger::FileList do
-  describe "#include?" do
+  describe '#include?' do
     before do
-      paths = ["path1/file_name.txt", "path1/file_name1.txt", "path2/subfolder/example.json"]
+      paths = ['path1/file_name.txt', 'path1/file_name1.txt', 'path2/subfolder/example.json']
       @filelist = Danger::FileList.new(paths)
     end
 
-    it "supports exact matches" do
-      expect(@filelist.include?("path1/file_name.txt")).to eq(true)
+    it 'supports exact matches' do
+      expect(@filelist.include?('path1/file_name.txt')).to eq(true)
     end
 
-    it "supports * for wildcards" do
-      expect(@filelist.include?("path1/*.txt")).to eq(true)
+    it 'supports * for wildcards' do
+      expect(@filelist.include?('path1/*.txt')).to eq(true)
     end
 
-    it "supports ? for single chars" do
-      expect(@filelist.include?("path1/file_name.???")).to eq(true)
-      expect(@filelist.include?("path1/file_name.?")).to eq(false)
+    it 'supports ? for single chars' do
+      expect(@filelist.include?('path1/file_name.???')).to eq(true)
+      expect(@filelist.include?('path1/file_name.?')).to eq(false)
     end
 
-    it "returns false if nothing was found" do
-      expect(@filelist.include?("notFound")).to eq(false)
+    it 'returns false if nothing was found' do
+      expect(@filelist.include?('notFound')).to eq(false)
     end
   end
 end

--- a/spec/lib/danger/core_ext/string_spec.rb
+++ b/spec/lib/danger/core_ext/string_spec.rb
@@ -1,27 +1,27 @@
 describe String do
-  describe "#danger_class" do
-    it "converts properly" do
-      expect("example_class".danger_class).to eq("ExampleClass")
+  describe '#danger_class' do
+    it 'converts properly' do
+      expect('example_class'.danger_class).to eq('ExampleClass')
     end
   end
 
-  describe "#danger_pluralize" do
+  describe '#danger_pluralize' do
     examples = [
-      { count: 0, string: "0 errors" },
-      { count: 1, string: "1 error" },
-      { count: 2, string: "2 errors" }
+      { count: 0, string: '0 errors' },
+      { count: 1, string: '1 error' },
+      { count: 2, string: '2 errors' }
     ]
 
     examples.each do |example|
       it "returns '#{example[:string]}' when count = #{example[:count]}" do
-        expect("error".danger_pluralize(example[:count])).to eq(example[:string])
+        expect('error'.danger_pluralize(example[:count])).to eq(example[:string])
       end
     end
   end
 
-  describe "#danger_underscore" do
-    it "converts properly" do
-      expect("ExampleClass".danger_underscore).to eq("example_class")
+  describe '#danger_underscore' do
+    it 'converts properly' do
+      expect('ExampleClass'.danger_underscore).to eq('example_class')
     end
   end
 end

--- a/spec/lib/danger/danger_core/danger_spec.rb
+++ b/spec/lib/danger/danger_core/danger_spec.rb
@@ -1,5 +1,5 @@
 describe Danger do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Danger::VERSION).not_to be nil
   end
 end

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -1,36 +1,36 @@
-require "pathname"
-require "tempfile"
+require 'pathname'
+require 'tempfile'
 
-require "danger/danger_core/plugins/dangerfile_messaging_plugin"
-require "danger/danger_core/plugins/dangerfile_import_plugin"
-require "danger/danger_core/plugins/dangerfile_git_plugin"
-require "danger/danger_core/plugins/dangerfile_github_plugin"
+require 'danger/danger_core/plugins/dangerfile_messaging_plugin'
+require 'danger/danger_core/plugins/dangerfile_import_plugin'
+require 'danger/danger_core/plugins/dangerfile_git_plugin'
+require 'danger/danger_core/plugins/dangerfile_github_plugin'
 
 describe Danger::Dangerfile do
-  it "keeps track of the original Dangerfile" do
-    file = make_temp_file ""
+  it 'keeps track of the original Dangerfile' do
+    file = make_temp_file ''
     dm = testing_dangerfile
     dm.parse file.path
     expect(dm.defined_in_file).to eq file.path
   end
 
-  it "runs the ruby code inside the Dangerfile" do
+  it 'runs the ruby code inside the Dangerfile' do
     dangerfile_code = "message('hi')"
-    expect_any_instance_of(Danger::DangerfileMessagingPlugin).to receive(:message).and_return("")
+    expect_any_instance_of(Danger::DangerfileMessagingPlugin).to receive(:message).and_return('')
     dm = testing_dangerfile
-    dm.parse Pathname.new(""), dangerfile_code
+    dm.parse Pathname.new(''), dangerfile_code
   end
 
-  it "raises elegantly with bad ruby code inside the Dangerfile" do
-    dangerfile_code = "asdas = asdasd + asdasddas"
+  it 'raises elegantly with bad ruby code inside the Dangerfile' do
+    dangerfile_code = 'asdas = asdasd + asdasddas'
     dm = testing_dangerfile
 
     expect do
-      dm.parse Pathname.new(""), dangerfile_code
+      dm.parse Pathname.new(''), dangerfile_code
     end.to raise_error(Danger::DSLError)
   end
 
-  it "respects ignored violations" do
+  it 'respects ignored violations' do
     code = "message 'A message'\n" \
            "warn 'An ignored warning'\n" \
            "warn 'A warning'\n" \
@@ -38,39 +38,39 @@ describe Danger::Dangerfile do
            "fail 'An error'\n"
 
     dm = testing_dangerfile
-    dm.env.request_source.ignored_violations = ["A message", "An ignored warning", "An ignored error"]
+    dm.env.request_source.ignored_violations = ['A message', 'An ignored warning', 'An ignored error']
 
-    dm.parse Pathname.new(""), code
+    dm.parse Pathname.new(''), code
 
     results = dm.status_report
-    expect(results[:messages]).to eql(["A message"])
-    expect(results[:errors]).to eql(["An error"])
-    expect(results[:warnings]).to eql(["A warning"])
+    expect(results[:messages]).to eql(['A message'])
+    expect(results[:errors]).to eql(['An error'])
+    expect(results[:warnings]).to eql(['A warning'])
   end
 
-  describe "#print_results" do
-    it "Prints out 3 lists" do
+  describe '#print_results' do
+    it 'Prints out 3 lists' do
       code = "message 'A message'\n" \
              "warn 'Another warning'\n" \
              "warn 'A warning'\n" \
              "fail 'Another error'\n" \
              "fail 'An error'\n"
       dm = testing_dangerfile
-      dm.env.request_source.ignored_violations = ["A message", "An ignored warning", "An ignored error"]
+      dm.env.request_source.ignored_violations = ['A message', 'An ignored warning', 'An ignored error']
 
-      dm.parse Pathname.new(""), code
+      dm.parse Pathname.new(''), code
 
-      expect(dm).to receive(:print_list).with("Errors:".red, ["Another error", "An error"])
-      expect(dm).to receive(:print_list).with("Warnings:".yellow, ["Another warning", "A warning"])
-      expect(dm).to receive(:print_list).with("Messages:", ["A message"])
+      expect(dm).to receive(:print_list).with('Errors:'.red, ['Another error', 'An error'])
+      expect(dm).to receive(:print_list).with('Warnings:'.yellow, ['Another warning', 'A warning'])
+      expect(dm).to receive(:print_list).with('Messages:', ['A message'])
 
       dm.print_results
     end
   end
 
-  describe "verbose" do
-    it "outputs metadata when verbose" do
-      file = make_temp_file ""
+  describe 'verbose' do
+    it 'outputs metadata when verbose' do
+      file = make_temp_file ''
       dm = testing_dangerfile
       dm.verbose = true
 
@@ -78,8 +78,8 @@ describe Danger::Dangerfile do
       dm.parse file.path
     end
 
-    it "does not print metadata by default" do
-      file = make_temp_file ""
+    it 'does not print metadata by default' do
+      file = make_temp_file ''
       dm = testing_dangerfile
 
       expect(dm).to_not receive(:print_known_info)
@@ -87,18 +87,18 @@ describe Danger::Dangerfile do
     end
   end
 
-  describe "initializing plugins" do
-    it "should add a plugin to the @plugins array" do
+  describe 'initializing plugins' do
+    it 'should add a plugin to the @plugins array' do
       class DangerTestPlugin < Danger::Plugin; end
       allow(Danger::Plugin).to receive(:all_plugins).and_return([DangerTestPlugin])
       dm = testing_dangerfile
       allow(dm).to receive(:core_dsls).and_return([])
       dm.init_plugins
 
-      expect(dm.instance_variable_get("@plugins").length).to eq(1)
+      expect(dm.instance_variable_get('@plugins').length).to eq(1)
     end
 
-    it "should add an instance variable to the dangerfile" do
+    it 'should add an instance variable to the dangerfile' do
       class DangerTestPlugin < Danger::Plugin; end
       allow(ObjectSpace).to receive(:each_object).and_return([DangerTestPlugin])
       dm = testing_dangerfile
@@ -110,8 +110,8 @@ describe Danger::Dangerfile do
     end
   end
 
-  describe "printing verbose metadata" do
-    it "exposes core attributes" do
+  describe 'printing verbose metadata' do
+    it 'exposes core attributes' do
       dm = testing_dangerfile
       methods = dm.core_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
 
@@ -121,13 +121,13 @@ describe Danger::Dangerfile do
     # NOTE: :protect_files comes from this repo, it is considered a "Danger" plugin, for
     # danger, not one that is shipped _with danger_. It is included here, because it
 
-    it "exposes no external attributes by default" do
+    it 'exposes no external attributes by default' do
       dm = testing_dangerfile
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
       expect(methods).to eq []
     end
 
-    it "exposes plugin external attributes by default" do
+    it 'exposes plugin external attributes by default' do
       class DangerCustomAttributePlugin < Danger::Plugin
         attr_reader :my_thing
       end
@@ -147,22 +147,22 @@ describe Danger::Dangerfile do
       end
     end
 
-    it "creates a table from a selection of core DSL attributes info" do
+    it 'creates a table from a selection of core DSL attributes info' do
       dm = testing_dangerfile
       dm.env.request_source.support_tokenless_auth = true
 
       # Stub out the GitHub stuff
-      pr_response = JSON.parse(fixture("github_api/pr_response"), symbolize_names: true)
-      allow(dm.env.request_source.client).to receive(:pull_request).with("artsy/eigen", "800").and_return(pr_response)
-      issue_response = JSON.parse(fixture("github_api/issue_response"), symbolize_names: true)
-      allow(dm.env.request_source.client).to receive(:get).with("https://api.github.com/repos/artsy/eigen/issues/800").and_return(issue_response)
-      diff_response = diff_fixture("pr_diff_response")
-      allow(dm.env.request_source.client).to receive(:pull_request).with("artsy/eigen", "800", accept: "application/vnd.github.v3.diff").and_return(diff_response)
+      pr_response = JSON.parse(fixture('github_api/pr_response'), symbolize_names: true)
+      allow(dm.env.request_source.client).to receive(:pull_request).with('artsy/eigen', '800').and_return(pr_response)
+      issue_response = JSON.parse(fixture('github_api/issue_response'), symbolize_names: true)
+      allow(dm.env.request_source.client).to receive(:get).with('https://api.github.com/repos/artsy/eigen/issues/800').and_return(issue_response)
+      diff_response = diff_fixture('pr_diff_response')
+      allow(dm.env.request_source.client).to receive(:pull_request).with('artsy/eigen', '800', accept: 'application/vnd.github.v3.diff').and_return(diff_response)
 
       # Use a diff from Danger's history:
       # https://github.com/danger/danger/compare/98c4f7760bb16300d1292bb791917d8e4990fd9a...9a424ecd5ad7404fa71cf2c99627d2882f0f02ce
       dm.env.fill_environment_vars
-      dm.env.scm.diff_for_folder(".", from: "9a424ecd5ad7404fa71cf2c99627d2882f0f02ce", to: "98c4f7760bb16300d1292bb791917d8e4990fd9a")
+      dm.env.scm.diff_for_folder('.', from: '9a424ecd5ad7404fa71cf2c99627d2882f0f02ce', to: '98c4f7760bb16300d1292bb791917d8e4990fd9a')
 
       # Check out the method hashes of all plugin info
       data = dm.method_values_for_plugin_hashes(dm.core_dsl_attributes)
@@ -171,15 +171,15 @@ describe Danger::Dangerfile do
       data = sort_data(data)
 
       expect(data).to eq [
-        ["status_report", { errors: [], warnings: [], messages: [], markdowns: [] }],
-        ["violation_report", { errors: [], warnings: [], messages: [] }]
+        ['status_report', { errors: [], warnings: [], messages: [], markdowns: [] }],
+        ['violation_report', { errors: [], warnings: [], messages: [] }]
       ]
     end
 
-    it "creates a table from a selection of external plugins DSL attributes info" do
+    it 'creates a table from a selection of external plugins DSL attributes info' do
       class DangerCustomAttributeTwoPlugin < Danger::Plugin
         def something
-          "value_for_something"
+          'value_for_something'
         end
       end
 
@@ -190,8 +190,8 @@ describe Danger::Dangerfile do
       data = sort_data(data)
 
       expect(data).to eq [
-        ["my_thing", nil],
-        ["something", "value_for_something"]
+        ['my_thing', nil],
+        ['something', 'value_for_something']
       ]
     end
   end

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -1,38 +1,38 @@
-require "danger/danger_core/environment_manager"
+require 'danger/danger_core/environment_manager'
 
 describe Danger::EnvironmentManager do
-  it "does not return a CI source with no ENV deets" do
-    env = { "KEY" => "VALUE" }
+  it 'does not return a CI source with no ENV deets' do
+    env = { 'KEY' => 'VALUE' }
     expect(Danger::EnvironmentManager.local_ci_source(env)).to eq nil
   end
 
-  it "stores travis in the source" do
+  it 'stores travis in the source' do
     number = 123
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true", "TRAVIS_REPO_SLUG" => "KrauseFx/fastlane", "TRAVIS_PULL_REQUEST" => number.to_s }
+    env = { 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true', 'TRAVIS_REPO_SLUG' => 'KrauseFx/fastlane', 'TRAVIS_PULL_REQUEST' => number.to_s }
     e = Danger::EnvironmentManager.new(env)
     expect(e.ci_source.pull_request_id).to eq(number.to_s)
   end
 
-  it "stores circle in the source" do
+  it 'stores circle in the source' do
     number = 800
-    env = { "CIRCLE_BUILD_NUM" => "true",
-            "CI_PULL_REQUEST" => "https://github.com/artsy/eigen/pull/#{number}",
-            "CIRCLE_PROJECT_USERNAME" => "orta",
-            "CIRCLE_PROJECT_REPONAME" => "thing" }
+    env = { 'CIRCLE_BUILD_NUM' => 'true',
+            'CI_PULL_REQUEST' => "https://github.com/artsy/eigen/pull/#{number}",
+            'CIRCLE_PROJECT_USERNAME' => 'orta',
+            'CIRCLE_PROJECT_REPONAME' => 'thing' }
     e = Danger::EnvironmentManager.new(env)
     expect(e.ci_source.pull_request_id).to eq(number.to_s)
   end
 
-  it "creates a GitHub attr" do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
-            "TRAVIS_REPO_SLUG" => "KrauseFx/fastlane",
-            "TRAVIS_PULL_REQUEST" => 123.to_s }
+  it 'creates a GitHub attr' do
+    env = { 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true',
+            'TRAVIS_REPO_SLUG' => 'KrauseFx/fastlane',
+            'TRAVIS_PULL_REQUEST' => 123.to_s }
     e = Danger::EnvironmentManager.new(env)
     expect(e.request_source).to be_truthy
   end
 
-  it "skips push runs and only runs for pull requests" do
-    env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true" }
+  it 'skips push runs and only runs for pull requests' do
+    env = { 'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true' }
     expect(Danger::EnvironmentManager.local_ci_source(env)).to be_truthy
     expect(Danger::EnvironmentManager.pr?(env)).to eq(false)
   end

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
-require "danger/helpers/comments_helper"
-require "danger/danger_core/violation"
+require 'danger/helpers/comments_helper'
+require 'danger/danger_core/violation'
 
 SINGLE_TABLE_COMMENT = <<-EOS.freeze
   Other comment content
@@ -51,91 +51,91 @@ describe Danger::Helpers::CommentsHelper do
     d
   end
 
-  describe "#markdown_parser" do
-    it "is a Redcarpet::Markdown instance" do
+  describe '#markdown_parser' do
+    it 'is a Redcarpet::Markdown instance' do
       parser = dummy.markdown_parser
       expect(parser).to be_an_instance_of(Redcarpet::Markdown)
     end
 
-    it "uses a HTML renderer" do
+    it 'uses a HTML renderer' do
       parser = dummy.markdown_parser
       expect(parser.renderer).to be_an_instance_of(Redcarpet::Render::HTML)
     end
   end
 
-  describe "#parse_tables_from_comment" do
-    it "splits a single table comment" do
+  describe '#parse_tables_from_comment' do
+    it 'splits a single table comment' do
       result = dummy.parse_tables_from_comment(SINGLE_TABLE_COMMENT)
       expect(result.size).to be(2)
-      expect(result[0]).to include("<table>")
-      expect(result[0]).to include("<thead>")
-      expect(result[0]).to include("<tbody>")
+      expect(result[0]).to include('<table>')
+      expect(result[0]).to include('<thead>')
+      expect(result[0]).to include('<tbody>')
 
-      expect(result[1]).not_to include("<table>")
-      expect(result[1]).not_to include("<thead>")
-      expect(result[1]).not_to include("<tbody>")
+      expect(result[1]).not_to include('<table>')
+      expect(result[1]).not_to include('<thead>')
+      expect(result[1]).not_to include('<tbody>')
     end
 
-    it "splits a multi table comment" do
+    it 'splits a multi table comment' do
       result = dummy.parse_tables_from_comment(MULTI_TABLE_COMMENT)
       expect(result.size).to be(3)
-      expect(result[0]).to include("<table>")
-      expect(result[0]).to include("<thead>")
-      expect(result[0]).to include("<tbody>")
-      expect(result[0]).to include("Error")
-      expect(result[0]).not_to include("Warning")
+      expect(result[0]).to include('<table>')
+      expect(result[0]).to include('<thead>')
+      expect(result[0]).to include('<tbody>')
+      expect(result[0]).to include('Error')
+      expect(result[0]).not_to include('Warning')
 
-      expect(result[1]).to include("<table>")
-      expect(result[1]).to include("<thead>")
-      expect(result[1]).to include("<tbody>")
-      expect(result[1]).not_to include("Error")
-      expect(result[1]).to include("Warning")
+      expect(result[1]).to include('<table>')
+      expect(result[1]).to include('<thead>')
+      expect(result[1]).to include('<tbody>')
+      expect(result[1]).not_to include('Error')
+      expect(result[1]).to include('Warning')
 
-      expect(result[2]).not_to include("<table>")
-      expect(result[2]).not_to include("<thead>")
-      expect(result[2]).not_to include("<tbody>")
+      expect(result[2]).not_to include('<table>')
+      expect(result[2]).not_to include('<thead>')
+      expect(result[2]).not_to include('<tbody>')
     end
   end
 
-  describe "#violations_from_table" do
-    it "finds violations" do
+  describe '#violations_from_table' do
+    it 'finds violations' do
       violations = dummy.violations_from_table(SINGLE_TABLE_COMMENT)
 
       expect(violations.size).to be(1)
-      expect(violations.first).to eq("<p>Please include a CHANGELOG entry. You can find it at <a href=\"https://github.com/danger/danger/blob/master/CHANGELOG.md\">CHANGELOG.md</a>.</p>")
+      expect(violations.first).to eq('<p>Please include a CHANGELOG entry. You can find it at <a href="https://github.com/danger/danger/blob/master/CHANGELOG.md">CHANGELOG.md</a>.</p>')
     end
   end
 
-  describe "#parse_comment" do
-    it "parse violations by kind" do
+  describe '#parse_comment' do
+    it 'parse violations by kind' do
       violations = dummy.parse_comment(MULTI_TABLE_COMMENT)
 
       expect(violations[:error].size).to be(1)
       expect(violations[:warning].size).to be(1)
       expect(violations[:message]).to be_nil
 
-      expect(violations[:error][0]).to include("Please include a CHANGELOG")
-      expect(violations[:warning][0]).to include("External contributor has edited")
+      expect(violations[:error][0]).to include('Please include a CHANGELOG')
+      expect(violations[:warning][0]).to include('External contributor has edited')
     end
   end
 
-  describe "#table" do
-    let(:violation_1) { Danger::Violation.new("**Violation 1**", false) }
+  describe '#table' do
+    let(:violation_1) { Danger::Violation.new('**Violation 1**', false) }
     let(:violation_2) do
-      Danger::Violation.new("A [link](https://example.com)", true)
+      Danger::Violation.new('A [link](https://example.com)', true)
     end
 
-    it "produces table data" do
-      table_data = dummy.table("2 Errors", "no_entry_sign", [violation_1, violation_2], {})
+    it 'produces table data' do
+      table_data = dummy.table('2 Errors', 'no_entry_sign', [violation_1, violation_2], {})
 
-      expect(table_data[:name]).to eq("2 Errors")
-      expect(table_data[:emoji]).to eq("no_entry_sign")
+      expect(table_data[:name]).to eq('2 Errors')
+      expect(table_data[:emoji]).to eq('no_entry_sign')
       expect(table_data[:content].size).to be(2)
-      expect(table_data[:content][0].message).to eq("<strong>Violation 1</strong>")
+      expect(table_data[:content][0].message).to eq('<strong>Violation 1</strong>')
       expect(table_data[:content][0].sticky).to eq(false)
 
       expect(table_data[:content][1].message).to eq(
-        "A <a href=\"https://example.com\">link</a>"
+        'A <a href="https://example.com">link</a>'
       )
       expect(table_data[:content][1].sticky).to eq(true)
       expect(table_data[:resolved]).to be_empty
@@ -143,24 +143,24 @@ describe Danger::Helpers::CommentsHelper do
     end
   end
 
-  describe "#table_kind_from_title" do
+  describe '#table_kind_from_title' do
     [
-      { title: "errors", singular: "Error", plural: "Errors", expected: :error },
-      { title: "warnings", singular: "Warning", plural: "Warnings", expected: :warning },
-      { title: "messages", singular: "Message", plural: "Messages", expected: :message }
+      { title: 'errors', singular: 'Error', plural: 'Errors', expected: :error },
+      { title: 'warnings', singular: 'Warning', plural: 'Warnings', expected: :warning },
+      { title: 'messages', singular: 'Message', plural: 'Messages', expected: :message }
     ].each do |option|
       describe option[:title] do
-        it "handles singular" do
+        it 'handles singular' do
           kind = dummy.table_kind_from_title("1 #{option[:singular]}")
           expect(kind).to eq(option[:expected])
         end
 
-        it "handles plural" do
+        it 'handles plural' do
           kind = dummy.table_kind_from_title("42 #{option[:plural]}")
           expect(kind).to eq(option[:expected])
         end
 
-        it "handles lowercase" do
+        it 'handles lowercase' do
           kind = dummy.table_kind_from_title("42 #{option[:plural].downcase}")
           expect(kind).to eq(option[:expected])
         end
@@ -168,69 +168,69 @@ describe Danger::Helpers::CommentsHelper do
     end
   end
 
-  describe "#generate_comment" do
-    it "produces the expected comment" do
+  describe '#generate_comment' do
+    it 'produces the expected comment' do
       comment = dummy.generate_comment(
-        warnings: [Danger::Violation.new("This is a warning", false)],
-        errors: [Danger::Violation.new("This is an error", true)],
-        messages: [Danger::Violation.new("This is a message", false)],
-        markdowns: ["*Raw markdown*"],
-        danger_id: "my_danger_id",
-        template: "github"
+        warnings: [Danger::Violation.new('This is a warning', false)],
+        errors: [Danger::Violation.new('This is an error', true)],
+        messages: [Danger::Violation.new('This is a message', false)],
+        markdowns: ['*Raw markdown*'],
+        danger_id: 'my_danger_id',
+        template: 'github'
       )
 
       expect(comment).to include('data-meta="generated_by_my_danger_id"')
 
       expect(comment).to include('<td data-sticky="true">This is an error</td>')
-      expect(comment).to include("<td>:no_entry_sign:</td>")
+      expect(comment).to include('<td>:no_entry_sign:</td>')
 
       expect(comment).to include('<td data-sticky="false">This is a warning</td>')
-      expect(comment).to include("<td>:warning:</td>")
+      expect(comment).to include('<td>:warning:</td>')
 
       expect(comment).to include('<td data-sticky="false">This is a message</td>')
-      expect(comment).to include("<td>:warning:</td>")
+      expect(comment).to include('<td>:warning:</td>')
 
-      expect(comment).to include("*Raw markdown*")
+      expect(comment).to include('*Raw markdown*')
     end
 
-    it "produces the expected comment when there are newlines" do
+    it 'produces the expected comment when there are newlines' do
       comment = dummy.generate_comment(
         warnings: [Danger::Violation.new("This is a warning\nin two lines", false)],
         errors: [],
         messages: [],
         markdowns: [],
-        danger_id: "my_danger_id",
-        template: "github"
+        danger_id: 'my_danger_id',
+        template: 'github'
       )
 
       expect(comment).to include('data-meta="generated_by_my_danger_id"')
 
       expect(comment).to include("<td data-sticky=\"false\">This is a warning<br>\nin two lines</td>")
-      expect(comment).to include("<td>:warning:</td>")
+      expect(comment).to include('<td>:warning:</td>')
     end
   end
 
-  describe "#generate_description" do
-    it "Handles no errors or warnings" do
+  describe '#generate_description' do
+    it 'Handles no errors or warnings' do
       message = dummy.generate_description(warnings: [], errors: [])
-      expect(message).to include("All green.")
+      expect(message).to include('All green.')
     end
 
-    it "handles a single error and a single warning" do
+    it 'handles a single error and a single warning' do
       message = dummy.generate_description(warnings: [1], errors: [1])
 
-      expect(message).to include("⚠ ")
-      expect(message).to include("Error")
-      expect(message).to include("Warning")
+      expect(message).to include('⚠ ')
+      expect(message).to include('Error')
+      expect(message).to include('Warning')
       expect(message).to include("Don't worry, everything is fixable.")
     end
 
-    it "handles multiple errors and warning with pluralisation" do
+    it 'handles multiple errors and warning with pluralisation' do
       message = dummy.generate_description(warnings: [1, 2], errors: [1, 2])
 
-      expect(message).to include("⚠ ")
-      expect(message).to include("Errors")
-      expect(message).to include("Warnings")
+      expect(message).to include('⚠ ')
+      expect(message).to include('Errors')
+      expect(message).to include('Warnings')
       expect(message).to include("Don't worry, everything is fixable.")
     end
   end

--- a/spec/lib/danger/plugin_support/plugin_linter_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_linter_spec.rb
@@ -1,5 +1,5 @@
-require "danger/plugin_support/plugin_parser"
-require "danger/plugin_support/plugin_linter"
+require 'danger/plugin_support/plugin_parser'
+require 'danger/plugin_support/plugin_linter'
 
 def json_doc_for_path(path)
   parser = Danger::PluginParser.new path
@@ -9,24 +9,24 @@ end
 
 module Danger
   describe PluginParser do
-    it "creates a set of errors for fixtured plugins" do
-      json = json_doc_for_path("spec/fixtures/plugins/plugin_many_methods.rb")
+    it 'creates a set of errors for fixtured plugins' do
+      json = json_doc_for_path('spec/fixtures/plugins/plugin_many_methods.rb')
       linter = PluginLinter.new(json)
       linter.lint
-      titles = ["Description Markdown", "Examples", "Description", "Description"]
+      titles = ['Description Markdown', 'Examples', 'Description', 'Description']
       expect(linter.errors.map(&:title)).to eq(titles)
     end
 
-    it "creates a set of warnings for fixtured plugins" do
-      json = json_doc_for_path("spec/fixtures/plugins/plugin_many_methods.rb")
+    it 'creates a set of warnings for fixtured plugins' do
+      json = json_doc_for_path('spec/fixtures/plugins/plugin_many_methods.rb')
       linter = PluginLinter.new(json)
       linter.lint
 
-      titles = ["Tags", "References", "Return Type", "Return Type", "Return Type", "Unknown Param", "Return Type"]
+      titles = ['Tags', 'References', 'Return Type', 'Return Type', 'Return Type', 'Unknown Param', 'Return Type']
       expect(linter.warnings.map(&:title)).to eq(titles)
     end
 
-    it "fails when there are errors" do
+    it 'fails when there are errors' do
       linter = PluginLinter.new({})
       expect(linter.failed?).to eq(false)
 
@@ -37,12 +37,12 @@ module Danger
       expect(linter.failed?).to eq(true)
     end
 
-    it "handles outputting a warning" do
+    it 'handles outputting a warning' do
       ui = testing_ui
       linter = PluginLinter.new({})
-      warning = PluginLinter::Rule.new(:warning, 30, "Example Title", "Example Description", nil)
-      warning.metadata = { name: "NameOfExample" }
-      warning.type = "TypeOfThing"
+      warning = PluginLinter::Rule.new(:warning, 30, 'Example Title', 'Example Description', nil)
+      warning.metadata = { name: 'NameOfExample' }
+      warning.type = 'TypeOfThing'
 
       linter.warnings << warning
 

--- a/spec/lib/danger/plugin_support/plugin_parser_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_parser_spec.rb
@@ -1,17 +1,17 @@
-require "danger/plugin_support/plugin_parser"
+require 'danger/plugin_support/plugin_parser'
 
 module Danger
   describe PluginParser do
-    it "includes an example plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_broken.rb"
+    it 'includes an example plugin' do
+      parser = PluginParser.new 'spec/fixtures/plugins/example_broken.rb'
       parser.parse
 
-      plugin_docs = parser.registry.at("Danger::Dangerfile::ExampleBroken")
+      plugin_docs = parser.registry.at('Danger::Dangerfile::ExampleBroken')
       expect(plugin_docs).to be_truthy
     end
 
-    it "finds classes from inside the file" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_broken.rb"
+    it 'finds classes from inside the file' do
+      parser = PluginParser.new 'spec/fixtures/plugins/example_broken.rb'
       parser.parse
 
       classes = parser.classes_in_file
@@ -20,8 +20,8 @@ module Danger
       expect(class_syms).to eq [:Dangerfile, :ExampleBroken]
     end
 
-    it "skips non-subclasses of Danger::Plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_broken.rb"
+    it 'skips non-subclasses of Danger::Plugin' do
+      parser = PluginParser.new 'spec/fixtures/plugins/example_broken.rb'
       parser.parse
 
       plugins = parser.plugins_from_classes(parser.classes_in_file)
@@ -30,8 +30,8 @@ module Danger
       expect(class_syms).to eq []
     end
 
-    it "find subclasses of Danger::Plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_remote.rb"
+    it 'find subclasses of Danger::Plugin' do
+      parser = PluginParser.new 'spec/fixtures/plugins/example_remote.rb'
       parser.parse
 
       plugins = parser.plugins_from_classes(parser.classes_in_file)
@@ -40,15 +40,15 @@ module Danger
       expect(class_syms).to eq [:ExampleRemote]
     end
 
-    it "outputs JSON for badly documented subclasses of Danger::Plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_remote.rb"
+    it 'outputs JSON for badly documented subclasses of Danger::Plugin' do
+      parser = PluginParser.new 'spec/fixtures/plugins/example_remote.rb'
       parser.parse
 
       plugins = parser.plugins_from_classes(parser.classes_in_file)
       json = parser.to_h(plugins)
-      sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, "")
+      sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, '')
 
-      fixture = "spec/fixtures/plugin_json/example_remote.json"
+      fixture = 'spec/fixtures/plugin_json/example_remote.json'
       # File.write(fixture, sanitized_json)
 
       # Skipping this test for windows, pathing gets complex, and no-one
@@ -60,15 +60,15 @@ module Danger
       end
     end
 
-    it "outputs JSON for well documented subclasses of Danger::Plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_fully_documented.rb"
+    it 'outputs JSON for well documented subclasses of Danger::Plugin' do
+      parser = PluginParser.new 'spec/fixtures/plugins/example_fully_documented.rb'
       parser.parse
 
       plugins = parser.plugins_from_classes(parser.classes_in_file)
       json = parser.to_h(plugins)
-      sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, "")
+      sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, '')
 
-      fixture = "spec/fixtures/plugin_json/example_fully_doc.json"
+      fixture = 'spec/fixtures/plugin_json/example_fully_doc.json'
       # File.write(fixture, sanitized_json)
 
       # Skipping this test for windows, pathing gets complex, and no-one
@@ -80,8 +80,8 @@ module Danger
       end
     end
 
-    it "creates method descriptions that make sense" do
-      parser = PluginParser.new "spec/fixtures/plugins/plugin_many_methods.rb"
+    it 'creates method descriptions that make sense' do
+      parser = PluginParser.new 'spec/fixtures/plugins/plugin_many_methods.rb'
       parser.parse
 
       plugins = parser.plugins_from_classes(parser.classes_in_file)
@@ -89,13 +89,13 @@ module Danger
       method_one_liners = json.first[:methods].map { |m| m[:one_liner] }
 
       expect(method_one_liners).to eq([
-                                        "one",
-                                        "two",
-                                        "two_point_five",
-                                        "three(param1=nil: String)",
-                                        "four(param1=nil: Number, param2: String) -> String",
-                                        "five(param1=[]: Array<String>, param2: Filepath, param3: Unknown) -> String",
-                                        "six? -> Bool"
+                                        'one',
+                                        'two',
+                                        'two_point_five',
+                                        'three(param1=nil: String)',
+                                        'four(param1=nil: Number, param2: String) -> String',
+                                        'five(param1=[]: Array<String>, param2: Filepath, param3: Unknown) -> String',
+                                        'six? -> Bool'
                                       ])
     end
   end

--- a/spec/lib/danger/plugin_support/plugin_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_spec.rb
@@ -1,10 +1,10 @@
 describe Danger::Plugin do
-  it "creates an instance name based on the class name" do
+  it 'creates an instance name based on the class name' do
     class DangerTestPlugin < Danger::Plugin; end
-    expect(DangerTestPlugin.instance_name).to eq("test_plugin")
+    expect(DangerTestPlugin.instance_name).to eq('test_plugin')
   end
 
-  it "should forward unknown method calls to the dangerfile" do
+  it 'should forward unknown method calls to the dangerfile' do
     class DangerTestPlugin < Danger::Plugin; end
     class DangerFileMock; attr_accessor :pants; end
     plugin = DangerTestPlugin.new(DangerFileMock.new)

--- a/spec/lib/danger/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/plugins/dangerfile_git_plugin_spec.rb
@@ -1,17 +1,17 @@
-require "ostruct"
+require 'ostruct'
 
 def run_in_repo_with_diff
   Dir.mktmpdir do |dir|
     Dir.chdir dir do
       `git init`
-      File.open(dir + "/file1", "w") { |f| f.write "More buritto please." }
+      File.open(dir + '/file1', 'w') { |f| f.write 'More buritto please.' }
       `git add .`
       `git commit -m "adding file1"`
       `git checkout -b new-branch`
-      File.open(dir + "/file2", "w") { |f| f.write "Pants!" }
+      File.open(dir + '/file2', 'w') { |f| f.write 'Pants!' }
       `git add .`
       `git commit -m "adding file2"`
-      g = Git.open(".")
+      g = Git.open('.')
       yield g
     end
   end
@@ -25,77 +25,77 @@ module Danger
       expect { DangerfileGitPlugin.new dm }.to raise_error RuntimeError
     end
 
-    describe "dsl" do
+    describe 'dsl' do
       before do
         dm = testing_dangerfile
         @dsl = DangerfileGitPlugin.new dm
         @repo = dm.env.scm
       end
 
-      it "gets added_files " do
-        diff = [OpenStruct.new(type: "new", path: "added")]
+      it 'gets added_files ' do
+        diff = [OpenStruct.new(type: 'new', path: 'added')]
         allow(@repo).to receive(:diff).and_return(diff)
 
-        expect(@dsl.added_files).to eq(["added"])
+        expect(@dsl.added_files).to eq(['added'])
       end
 
-      it "gets deleted_files " do
-        diff = [OpenStruct.new(type: "deleted", path: "deleted")]
+      it 'gets deleted_files ' do
+        diff = [OpenStruct.new(type: 'deleted', path: 'deleted')]
         allow(@repo).to receive(:diff).and_return(diff)
 
-        expect(@dsl.deleted_files).to eq(["deleted"])
+        expect(@dsl.deleted_files).to eq(['deleted'])
       end
 
-      it "gets modified_files " do
-        stats = { files: { "my/path/file_name" => "thing" } }
+      it 'gets modified_files ' do
+        stats = { files: { 'my/path/file_name' => 'thing' } }
         diff = OpenStruct.new(stats: stats)
         allow(@repo).to receive(:diff).and_return(diff)
 
-        expect(@dsl.modified_files).to eq(["my/path/file_name"])
+        expect(@dsl.modified_files).to eq(['my/path/file_name'])
       end
 
-      it "gets lines_of_code" do
+      it 'gets lines_of_code' do
         diff = OpenStruct.new(lines: 2)
         allow(@repo).to receive(:diff).and_return(diff)
 
         expect(@dsl.lines_of_code).to eq(2)
       end
 
-      it "gets deletions" do
+      it 'gets deletions' do
         diff = OpenStruct.new(deletions: 4)
         allow(@repo).to receive(:diff).and_return(diff)
 
         expect(@dsl.deletions).to eq(4)
       end
 
-      it "gets insertions" do
+      it 'gets insertions' do
         diff = OpenStruct.new(insertions: 6)
         allow(@repo).to receive(:diff).and_return(diff)
 
         expect(@dsl.insertions).to eq(6)
       end
 
-      it "gets commits" do
-        log = ["hi"]
+      it 'gets commits' do
+        log = ['hi']
         allow(@repo).to receive(:log).and_return(log)
 
         expect(@dsl.commits).to eq(log)
       end
 
-      describe "getting diff for a specific file" do
-        it "returns nil when a specific diff does not exist" do
+      describe 'getting diff for a specific file' do
+        it 'returns nil when a specific diff does not exist' do
           run_in_repo_with_diff do |git|
-            diff = git.diff("master")
+            diff = git.diff('master')
             allow(@repo).to receive(:diff).and_return(diff)
-            expect(@dsl.diff_for_file("file_nope_no_way")).to be_nil
+            expect(@dsl.diff_for_file('file_nope_no_way')).to be_nil
           end
         end
 
-        it "gets a specific diff" do
+        it 'gets a specific diff' do
           run_in_repo_with_diff do |git|
-            diff = git.diff("master")
+            diff = git.diff('master')
             allow(@repo).to receive(:diff).and_return(diff)
-            expect(@dsl.diff_for_file("file2")).to_not be_nil
+            expect(@dsl.diff_for_file('file2')).to_not be_nil
           end
         end
       end

--- a/spec/lib/danger/plugins/dangerfile_github_plugin_spec.rb
+++ b/spec/lib/danger/plugins/dangerfile_github_plugin_spec.rb
@@ -1,32 +1,32 @@
 module Danger
   describe DangerfileGitHubPlugin do
-    describe "dsl" do
+    describe 'dsl' do
       before do
         dm = testing_dangerfile
         @dsl = DangerfileGitHubPlugin.new dm
-        pr_response = JSON.parse(fixture("github_api/pr_response"), symbolize_names: true)
+        pr_response = JSON.parse(fixture('github_api/pr_response'), symbolize_names: true)
         allow(@dsl).to receive(:pr_json).and_return(pr_response)
       end
 
-      describe "html_link" do
-        it "works with a single path" do
-          link = @dsl.html_link("file.txt")
+      describe 'html_link' do
+        it 'works with a single path' do
+          link = @dsl.html_link('file.txt')
           expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>")
         end
 
-        it "can show just a path" do
-          link = @dsl.html_link("/path/file.txt", full_path: false)
+        it 'can show just a path' do
+          link = @dsl.html_link('/path/file.txt', full_path: false)
           expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/path/file.txt'>file.txt</a>")
         end
 
-        it "works with 2 paths" do
-          link = @dsl.html_link(["file.txt", "example.json"])
+        it 'works with 2 paths' do
+          link = @dsl.html_link(['file.txt', 'example.json'])
           expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a> & " \
                              "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/example.json'>example.json</a>")
         end
 
-        it "works with 3+ paths" do
-          link = @dsl.html_link(["file.txt", "example.json", "script.rb#L30"])
+        it 'works with 3+ paths' do
+          link = @dsl.html_link(['file.txt', 'example.json', 'script.rb#L30'])
           expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>, " \
                              "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/example.json'>example.json</a> & " \
                              "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/script.rb#L30'>script.rb#L30</a>")

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -1,63 +1,63 @@
 # coding: utf-8
-require "danger/request_source/request_source"
-require "danger/ci_source/circle"
-require "danger/ci_source/travis"
-require "danger/danger_core/violation"
+require 'danger/request_source/request_source'
+require 'danger/ci_source/circle'
+require 'danger/ci_source/travis'
+require 'danger/danger_core/violation'
 
 describe Danger::RequestSources::GitHub do
-  describe "the github host" do
-    it "sets a default GitHub host" do
-      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi" }
+  describe 'the github host' do
+    it 'sets a default GitHub host' do
+      gh_env = { 'DANGER_GITHUB_API_TOKEN' => 'hi' }
       g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
-      expect(g.host).to eql("github.com")
+      expect(g.host).to eql('github.com')
     end
 
-    it "allows the GitHub host to be overridden" do
-      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com" }
+    it 'allows the GitHub host to be overridden' do
+      gh_env = { 'DANGER_GITHUB_API_TOKEN' => 'hi', 'DANGER_GITHUB_HOST' => 'git.club-mateusa.com' }
       g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
-      expect(g.host).to eql("git.club-mateusa.com")
+      expect(g.host).to eql('git.club-mateusa.com')
     end
 
-    it "allows the GitHub API host to be overridden" do
-      api_endpoint = "https://git.club-mateusa.com/api/v3/"
-      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_API_HOST" => api_endpoint }
+    it 'allows the GitHub API host to be overridden' do
+      api_endpoint = 'https://git.club-mateusa.com/api/v3/'
+      gh_env = { 'DANGER_GITHUB_API_TOKEN' => 'hi', 'DANGER_GITHUB_API_HOST' => api_endpoint }
       g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
       expect(Octokit.api_endpoint).to eql(api_endpoint)
     end
   end
 
-  describe "valid server response" do
+  describe 'valid server response' do
     before do
-      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi" }
+      gh_env = { 'DANGER_GITHUB_API_TOKEN' => 'hi' }
       @g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
 
-      pr_response = JSON.parse(fixture("github_api/pr_response"), symbolize_names: true)
-      allow(@g.client).to receive(:pull_request).with("artsy/eigen", "800").and_return(pr_response)
+      pr_response = JSON.parse(fixture('github_api/pr_response'), symbolize_names: true)
+      allow(@g.client).to receive(:pull_request).with('artsy/eigen', '800').and_return(pr_response)
 
-      issue_response = JSON.parse(fixture("github_api/issue_response"), symbolize_names: true)
-      allow(@g.client).to receive(:get).with("https://api.github.com/repos/artsy/eigen/issues/800").and_return(issue_response)
+      issue_response = JSON.parse(fixture('github_api/issue_response'), symbolize_names: true)
+      allow(@g.client).to receive(:get).with('https://api.github.com/repos/artsy/eigen/issues/800').and_return(issue_response)
     end
 
-    it "sets its pr_json" do
+    it 'sets its pr_json' do
       @g.fetch_details
       expect(@g.pr_json).to be_truthy
     end
 
-    it "sets its issue_json" do
+    it 'sets its issue_json' do
       @g.fetch_details
       expect(@g.issue_json).to be_truthy
     end
 
-    it "sets the ignored violations" do
+    it 'sets the ignored violations' do
       @g.fetch_details
       expect(@g.ignored_violations).to eql(["Developer Specific file shouldn't be changed",
-                                            "Some warning"])
+                                            'Some warning'])
     end
 
-    describe "#organisation" do
-      it "valid value available" do
+    describe '#organisation' do
+      it 'valid value available' do
         @g.fetch_details
-        expect(@g.organisation).to eq("artsy")
+        expect(@g.organisation).to eq('artsy')
       end
 
       it "no valid value available doesn't crash" do
@@ -66,91 +66,91 @@ describe Danger::RequestSources::GitHub do
       end
     end
 
-    describe "#fetch_repository" do
+    describe '#fetch_repository' do
       before do
         @g.fetch_details
       end
 
-      it "works with valid data" do
-        issue_response = JSON.parse(fixture("repo_response"), symbolize_names: true)
-        expect(@g.client).to receive(:repo).with("artsy/yolo").and_return(issue_response)
+      it 'works with valid data' do
+        issue_response = JSON.parse(fixture('repo_response'), symbolize_names: true)
+        expect(@g.client).to receive(:repo).with('artsy/yolo').and_return(issue_response)
 
-        result = @g.fetch_repository(repository: "yolo")
-        expect(result[:url]).to eq("https://api.github.com/repos/Themoji/Danger")
+        result = @g.fetch_repository(repository: 'yolo')
+        expect(result[:url]).to eq('https://api.github.com/repos/Themoji/Danger')
       end
 
-      it "returns nil for no response" do
-        expect(@g.client).to receive(:repo).with("artsy/yolo").and_return(nil)
+      it 'returns nil for no response' do
+        expect(@g.client).to receive(:repo).with('artsy/yolo').and_return(nil)
 
-        expect(@g.fetch_repository(repository: "yolo")).to eq(nil)
+        expect(@g.fetch_repository(repository: 'yolo')).to eq(nil)
       end
     end
 
-    describe "#fetch_danger_repo" do
+    describe '#fetch_danger_repo' do
       before do
         @g.fetch_details
       end
 
       it "tries both 'danger' and 'Danger' as repo, 'Danger' first" do
-        issue_response = JSON.parse(fixture("repo_response"), symbolize_names: true)
-        expect(@g.client).to receive(:repo).with("artsy/danger").and_return(nil)
-        expect(@g.client).to receive(:repo).with("artsy/Danger").and_return(issue_response)
+        issue_response = JSON.parse(fixture('repo_response'), symbolize_names: true)
+        expect(@g.client).to receive(:repo).with('artsy/danger').and_return(nil)
+        expect(@g.client).to receive(:repo).with('artsy/Danger').and_return(issue_response)
 
         result = @g.fetch_danger_repo
-        expect(result[:url]).to eq("https://api.github.com/repos/Themoji/Danger")
+        expect(result[:url]).to eq('https://api.github.com/repos/Themoji/Danger')
       end
 
       it "tries both 'danger' and 'Danger' as repo, 'danger' first" do
-        issue_response = JSON.parse(fixture("repo_response"), symbolize_names: true)
-        expect(@g.client).to receive(:repo).with("artsy/danger").and_return(issue_response)
+        issue_response = JSON.parse(fixture('repo_response'), symbolize_names: true)
+        expect(@g.client).to receive(:repo).with('artsy/danger').and_return(issue_response)
 
         result = @g.fetch_danger_repo
-        expect(result[:url]).to eq("https://api.github.com/repos/Themoji/Danger")
+        expect(result[:url]).to eq('https://api.github.com/repos/Themoji/Danger')
       end
     end
 
-    describe "#danger_repo?" do
+    describe '#danger_repo?' do
       before do
         @g.fetch_details
-        @issue_response = JSON.parse(fixture("repo_response"), symbolize_names: true)
+        @issue_response = JSON.parse(fixture('repo_response'), symbolize_names: true)
       end
 
       it "returns true if the repo's name is danger" do
-        @issue_response[:name] = "Danger"
-        expect(@g.client).to receive(:repo).with("artsy/danger").and_return(@issue_response)
-        expect(@g.ci_source).to receive(:repo_slug).and_return("artsy/danger")
+        @issue_response[:name] = 'Danger'
+        expect(@g.client).to receive(:repo).with('artsy/danger').and_return(@issue_response)
+        expect(@g.ci_source).to receive(:repo_slug).and_return('artsy/danger')
         expect(@g.danger_repo?).to eq(true)
       end
 
       it "returns false if the repo's name is danger (it's eigen)" do
-        @issue_response[:name] = "eigen"
-        issue_response = JSON.parse(fixture("repo_response"), symbolize_names: true)
-        expect(@g.client).to receive(:repo).with("artsy/eigen").and_return(@issue_response)
+        @issue_response[:name] = 'eigen'
+        issue_response = JSON.parse(fixture('repo_response'), symbolize_names: true)
+        expect(@g.client).to receive(:repo).with('artsy/eigen').and_return(@issue_response)
 
         expect(@g.danger_repo?).to eq(false)
       end
     end
 
-    describe "#file_url" do
-      it "returns a valid URL with the minimum parameters" do
-        url = @g.file_url(repository: "danger",
-                                path: "path/Dangerfile")
-        expect(url).to eq("https://raw.githubusercontent.com//danger/master/path/Dangerfile")
+    describe '#file_url' do
+      it 'returns a valid URL with the minimum parameters' do
+        url = @g.file_url(repository: 'danger',
+                                path: 'path/Dangerfile')
+        expect(url).to eq('https://raw.githubusercontent.com//danger/master/path/Dangerfile')
       end
 
-      it "returns a valid URL with more parameters" do
-        url = @g.file_url(repository: "danger",
-                        organisation: "org_yo",
-                              branch: "yolo_branch",
-                                path: "path/Dangerfile")
-        expect(url).to eq("https://raw.githubusercontent.com/org_yo/danger/yolo_branch/path/Dangerfile")
+      it 'returns a valid URL with more parameters' do
+        url = @g.file_url(repository: 'danger',
+                        organisation: 'org_yo',
+                              branch: 'yolo_branch',
+                                path: 'path/Dangerfile')
+        expect(url).to eq('https://raw.githubusercontent.com/org_yo/danger/yolo_branch/path/Dangerfile')
       end
     end
 
     # TODO: Move to the plugin
     #
-    xdescribe "DSL Attributes" do
-      it "sets the right commit sha" do
+    xdescribe 'DSL Attributes' do
+      it 'sets the right commit sha' do
         @g.fetch_details
 
         expect(@g.pr_json[:base][:sha]).to eql(@g.base_commit)
@@ -158,85 +158,85 @@ describe Danger::RequestSources::GitHub do
         expect(@g.pr_json[:base][:ref]).to eql(@g.branch_for_merge)
       end
 
-      it "sets the right labels" do
+      it 'sets the right labels' do
         @g.fetch_details
-        expect(@g.pr_labels).to eql(["D:2", "Maintenance Work"])
+        expect(@g.pr_labels).to eql(['D:2', 'Maintenance Work'])
       end
     end
 
-    describe "#generate_comment" do
+    describe '#generate_comment' do
       before do
-        @date = Time.now.strftime("%Y-%m-%d")
-        @g.pr_json = { base: { sha: "" }, head: { sha: "" } }
+        @date = Time.now.strftime('%Y-%m-%d')
+        @g.pr_json = { base: { sha: '' }, head: { sha: '' } }
 
-        stub_request(:post, "https://git.club-mateusa.com/api/v3/repos/artsy/eigen/statuses/").
+        stub_request(:post, 'https://git.club-mateusa.com/api/v3/repos/artsy/eigen/statuses/').
           with(body: "{\"description\":\"All green. Good on 'ya.\",\"context\":\"danger/danger\",\"target_url\":null,\"state\":\"success\"}",
-                     headers: { "Accept" => "application/vnd.github.v3+json", "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Authorization" => "token hi", "Content-Type" => "application/json", "User-Agent" => "Octokit Ruby Gem 4.3.0" }).
-          to_return(status: 200, body: "", headers: {})
+                     headers: { 'Accept' => 'application/vnd.github.v3+json', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'token hi', 'Content-Type' => 'application/json', 'User-Agent' => 'Octokit Ruby Gem 4.3.0' }).
+          to_return(status: 200, body: '', headers: {})
       end
 
-      it "no warnings, no errors, no messages" do
+      it 'no warnings, no errors, no messages' do
         result = @g.generate_comment(warnings: [], errors: [], messages: [])
-        expect(result.gsub(/\s+/, "")).to eq(
+        expect(result.gsub(/\s+/, '')).to eq(
           '<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
         )
       end
 
-      it "supports markdown code below the summary table" do
-        result = @g.generate_comment(warnings: violations(["ups"]), markdowns: ["### h3"])
-        expect(result.gsub(/\s+/, "")).to eq(
+      it 'supports markdown code below the summary table' do
+        result = @g.generate_comment(warnings: violations(['ups']), markdowns: ['### h3'])
+        expect(result.gsub(/\s+/, '')).to eq(
           '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">ups</td></tr></tbody></table>###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
         )
       end
 
-      it "supports markdown only without a table" do
-        result = @g.generate_comment(markdowns: ["### h3"])
-        expect(result.gsub(/\s+/, "")).to eq(
+      it 'supports markdown only without a table' do
+        result = @g.generate_comment(markdowns: ['### h3'])
+        expect(result.gsub(/\s+/, '')).to eq(
           '###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
         )
       end
 
-      it "some warnings, no errors" do
-        result = @g.generate_comment(warnings: violations(["my warning", "second warning"]), errors: [], messages: [])
+      it 'some warnings, no errors' do
+        result = @g.generate_comment(warnings: violations(['my warning', 'second warning']), errors: [], messages: [])
         # rubocop:disable Metrics/LineLength
-        expect(result.gsub(/\s+/, "")).to eq(
+        expect(result.gsub(/\s+/, '')).to eq(
           '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky="false">secondwarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
         )
         # rubocop:enable Metrics/LineLength
       end
 
-      it "some warnings with markdown, no errors" do
-        warnings = violations(["a markdown [link to danger](https://github.com/danger/danger)", "second **warning**"])
+      it 'some warnings with markdown, no errors' do
+        warnings = violations(['a markdown [link to danger](https://github.com/danger/danger)', 'second **warning**'])
         result = @g.generate_comment(warnings: warnings, errors: [], messages: [])
         # rubocop:disable Metrics/LineLength
-        expect(result.gsub(/\s+/, "")).to eq(
+        expect(result.gsub(/\s+/, '')).to eq(
           '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></td></tr><tr><td>:warning:</td><tddata-sticky="false">second<strong>warning</strong></td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
         )
         # rubocop:enable Metrics/LineLength
       end
 
-      it "a multiline warning with markdown, no errors" do
+      it 'a multiline warning with markdown, no errors' do
         warnings = violations(["a markdown [link to danger](https://github.com/danger/danger)\n\n```\nsomething\n```\n\nHello"])
         result = @g.generate_comment(warnings: warnings, errors: [], messages: [])
         # rubocop:disable Metrics/LineLength
-        expect(result.gsub(/\s+/, "")).to eq(
+        expect(result.gsub(/\s+/, '')).to eq(
           '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></p><p><code><br>something<br></code></p><p>Hello</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
         )
         # rubocop:enable Metrics/LineLength
       end
 
-      it "some warnings, some errors" do
-        result = @g.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]), messages: [])
+      it 'some warnings, some errors' do
+        result = @g.generate_comment(warnings: violations(['my warning']), errors: violations(['some error']), messages: [])
         # rubocop:disable Metrics/LineLength
-        expect(result.gsub(/\s+/, "")).to eq(
+        expect(result.gsub(/\s+/, '')).to eq(
           '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">someerror</td></tr></tbody></table><table><thead><tr><thwidth="50"></th><thwidth="100%"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
         )
         # rubocop:enable Metrics/LineLength
       end
 
-      it "deduplicates previous violations" do
-        previous_violations = { error: ["an error", "an error"] }
-        allow(@g).to receive(:random_compliment).and_return("random compliment")
+      it 'deduplicates previous violations' do
+        previous_violations = { error: ['an error', 'an error'] }
+        allow(@g).to receive(:random_compliment).and_return('random compliment')
         result = @g.generate_comment(warnings: [], errors: violations([]), messages: [], previous_violations: previous_violations)
         expect(result).to eq(<<-HTML)
 <table>
@@ -262,187 +262,187 @@ describe Danger::RequestSources::GitHub do
         HTML
       end
 
-      it "crosses resolved violations and changes the title" do
-        previous_violations = { error: ["an error"] }
+      it 'crosses resolved violations and changes the title' do
+        previous_violations = { error: ['an error'] }
         result = @g.generate_comment(warnings: [], errors: [], messages: [], previous_violations: previous_violations)
-        expect(result.gsub(/\s+/, "")).to include('<thwidth="100%"data-kind="Error">:white_check_mark:')
-        expect(result.gsub(/\s+/, "")).to include('<td>:white_check_mark:</td><tddata-sticky="true"><del>anerror</del></td>')
+        expect(result.gsub(/\s+/, '')).to include('<thwidth="100%"data-kind="Error">:white_check_mark:')
+        expect(result.gsub(/\s+/, '')).to include('<td>:white_check_mark:</td><tddata-sticky="true"><del>anerror</del></td>')
       end
 
-      it "uncrosses violations that were on the list and happened again" do
-        previous_violations = { error: ["an error"] }
-        result = @g.generate_comment(warnings: [], errors: violations(["an error"]), messages: [], previous_violations: previous_violations)
-        expect(result.gsub(/\s+/, "")).to eq(
+      it 'uncrosses violations that were on the list and happened again' do
+        previous_violations = { error: ['an error'] }
+        result = @g.generate_comment(warnings: [], errors: violations(['an error']), messages: [], previous_violations: previous_violations)
+        expect(result.gsub(/\s+/, '')).to eq(
           '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">anerror</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
         )
       end
 
-      it "counts only unresolved violations on the title" do
-        previous_violations = { error: ["an error"] }
-        result = @g.generate_comment(warnings: [], errors: violations(["another error"]),
+      it 'counts only unresolved violations on the title' do
+        previous_violations = { error: ['an error'] }
+        result = @g.generate_comment(warnings: [], errors: violations(['another error']),
                                      messages: [], previous_violations: previous_violations)
-        expect(result.gsub(/\s+/, "")).to include('<thwidth="100%"data-kind="Error">1Error</th>')
+        expect(result.gsub(/\s+/, '')).to include('<thwidth="100%"data-kind="Error">1Error</th>')
       end
 
-      it "needs to include generated_by_danger" do
-        result = @g.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]), messages: [])
-        expect(result.gsub(/\s+/, "")).to include("generated_by_danger")
+      it 'needs to include generated_by_danger' do
+        result = @g.generate_comment(warnings: violations(['my warning']), errors: violations(['some error']), messages: [])
+        expect(result.gsub(/\s+/, '')).to include('generated_by_danger')
       end
 
-      it "handles a custom danger_id" do
-        result = @g.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]),
-                                     messages: [], danger_id: "another_danger")
-        expect(result.gsub(/\s+/, "")).to include("generated_by_another_danger")
+      it 'handles a custom danger_id' do
+        result = @g.generate_comment(warnings: violations(['my warning']), errors: violations(['some error']),
+                                     messages: [], danger_id: 'another_danger')
+        expect(result.gsub(/\s+/, '')).to include('generated_by_another_danger')
       end
 
-      it "sets data-sticky to true when a violation is sticky" do
-        sticky_warning = Danger::Violation.new("my warning", true)
+      it 'sets data-sticky to true when a violation is sticky' do
+        sticky_warning = Danger::Violation.new('my warning', true)
         result = @g.generate_comment(warnings: [sticky_warning], errors: [], messages: [])
-        expect(result.gsub(/\s+/, "")).to include('tddata-sticky="true"')
+        expect(result.gsub(/\s+/, '')).to include('tddata-sticky="true"')
       end
 
-      it "sets data-sticky to false when a violation is not sticky" do
-        non_sticky_warning = Danger::Violation.new("my warning", false)
+      it 'sets data-sticky to false when a violation is not sticky' do
+        non_sticky_warning = Danger::Violation.new('my warning', false)
         result = @g.generate_comment(warnings: [non_sticky_warning], errors: [], messages: [])
-        expect(result.gsub(/\s+/, "")).to include('tddata-sticky="false"')
+        expect(result.gsub(/\s+/, '')).to include('tddata-sticky="false"')
       end
     end
 
-    describe "status message" do
-      it "Shows a success message when no errors/warnings" do
+    describe 'status message' do
+      it 'Shows a success message when no errors/warnings' do
         message = @g.generate_description(warnings: [], errors: [])
-        expect(message).to start_with("All green.")
+        expect(message).to start_with('All green.')
       end
 
-      it "Shows an error messages when there are errors" do
+      it 'Shows an error messages when there are errors' do
         message = @g.generate_description(warnings: violations([1, 2, 3]), errors: [])
         expect(message).to eq("⚠ 3 Warnings. Don't worry, everything is fixable.")
       end
 
-      it "Shows an error message when errors and warnings" do
+      it 'Shows an error message when errors and warnings' do
         message = @g.generate_description(warnings: violations([1, 2]), errors: violations([1, 2, 3]))
         expect(message).to eq("⚠ 3 Errors. 2 Warnings. Don't worry, everything is fixable.")
       end
 
-      it "Deals with singualars in messages when errors and warnings" do
+      it 'Deals with singualars in messages when errors and warnings' do
         message = @g.generate_description(warnings: violations([1]), errors: violations([1]))
         expect(message).to eq("⚠ 1 Error. 1 Warning. Don't worry, everything is fixable.")
       end
     end
 
-    describe "commit status update" do
+    describe 'commit status update' do
       before do
-        stub_request(:post, "https://git.club-mateusa.com/api/v3/repos/artsy/eigen/statuses/").to_return status: 200
+        stub_request(:post, 'https://git.club-mateusa.com/api/v3/repos/artsy/eigen/statuses/').to_return status: 200
       end
 
-      it "fails when no head commit is set" do
-        @g.pr_json = { base: { sha: "" }, head: { sha: "" } }
+      it 'fails when no head commit is set' do
+        @g.pr_json = { base: { sha: '' }, head: { sha: '' } }
         expect do
           @g.submit_pull_request_status!
         end.to raise_error("Couldn't find a commit to update its status".red)
       end
     end
 
-    describe "issue creation" do
+    describe 'issue creation' do
       before do
-        @g.pr_json = { base: { sha: "" }, head: { sha: "" } }
+        @g.pr_json = { base: { sha: '' }, head: { sha: '' } }
         allow(@g).to receive(:submit_pull_request_status!).and_return(true)
       end
 
-      it "creates an issue if no danger comments exist" do
+      it 'creates an issue if no danger comments exist' do
         issues = []
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
+        allow(@g.client).to receive(:issue_comments).with('artsy/eigen', '800').and_return(issues)
 
-        body = @g.generate_comment(warnings: violations(["hi"]), errors: [], messages: [])
-        expect(@g.client).to receive(:add_comment).with("artsy/eigen", "800", body).and_return({})
+        body = @g.generate_comment(warnings: violations(['hi']), errors: [], messages: [])
+        expect(@g.client).to receive(:add_comment).with('artsy/eigen', '800', body).and_return({})
 
-        @g.update_pull_request!(warnings: violations(["hi"]), errors: [], messages: [])
+        @g.update_pull_request!(warnings: violations(['hi']), errors: [], messages: [])
       end
 
-      it "updates the issue if no danger comments exist" do
-        issues = [{ body: "generated_by_danger", id: "12" }]
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
+      it 'updates the issue if no danger comments exist' do
+        issues = [{ body: 'generated_by_danger', id: '12' }]
+        allow(@g.client).to receive(:issue_comments).with('artsy/eigen', '800').and_return(issues)
 
-        body = @g.generate_comment(warnings: violations(["hi"]), errors: [], messages: [])
-        expect(@g.client).to receive(:update_comment).with("artsy/eigen", "12", body).and_return({})
+        body = @g.generate_comment(warnings: violations(['hi']), errors: [], messages: [])
+        expect(@g.client).to receive(:update_comment).with('artsy/eigen', '12', body).and_return({})
 
-        @g.update_pull_request!(warnings: violations(["hi"]), errors: [], messages: [])
+        @g.update_pull_request!(warnings: violations(['hi']), errors: [], messages: [])
       end
 
-      it "updates the issue if no danger comments exist and a custom danger_id is provided" do
-        issues = [{ body: "generated_by_another_danger", id: "12" }]
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
+      it 'updates the issue if no danger comments exist and a custom danger_id is provided' do
+        issues = [{ body: 'generated_by_another_danger', id: '12' }]
+        allow(@g.client).to receive(:issue_comments).with('artsy/eigen', '800').and_return(issues)
 
-        body = @g.generate_comment(warnings: violations(["hi"]), errors: [], messages: [], danger_id: "another_danger")
-        expect(@g.client).to receive(:update_comment).with("artsy/eigen", "12", body).and_return({})
+        body = @g.generate_comment(warnings: violations(['hi']), errors: [], messages: [], danger_id: 'another_danger')
+        expect(@g.client).to receive(:update_comment).with('artsy/eigen', '12', body).and_return({})
 
-        @g.update_pull_request!(warnings: violations(["hi"]), errors: [], messages: [], danger_id: "another_danger")
+        @g.update_pull_request!(warnings: violations(['hi']), errors: [], messages: [], danger_id: 'another_danger')
       end
 
-      it "deletes existing issues if danger doesnt need to say anything" do
-        issues = [{ body: "generated_by_danger", id: "12" }]
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
+      it 'deletes existing issues if danger doesnt need to say anything' do
+        issues = [{ body: 'generated_by_danger', id: '12' }]
+        allow(@g.client).to receive(:issue_comments).with('artsy/eigen', '800').and_return(issues)
 
-        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", "12").and_return({})
+        expect(@g.client).to receive(:delete_comment).with('artsy/eigen', '12').and_return({})
         @g.update_pull_request!(warnings: [], errors: [], messages: [])
       end
 
-      it "deletes existing issues if danger doesnt need to say anything and a custom danger_id is provided" do
-        issues = [{ body: "generated_by_another_danger", id: "12" }]
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
+      it 'deletes existing issues if danger doesnt need to say anything and a custom danger_id is provided' do
+        issues = [{ body: 'generated_by_another_danger', id: '12' }]
+        allow(@g.client).to receive(:issue_comments).with('artsy/eigen', '800').and_return(issues)
 
-        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", "12").and_return({})
-        @g.update_pull_request!(warnings: [], errors: [], messages: [], danger_id: "another_danger")
+        expect(@g.client).to receive(:delete_comment).with('artsy/eigen', '12').and_return({})
+        @g.update_pull_request!(warnings: [], errors: [], messages: [], danger_id: 'another_danger')
       end
 
-      it "updates the issue if danger doesnt need to say anything but there are sticky violations" do
-        issues = [{ body: "generated_by_danger", id: "12" }]
-        allow(@g).to receive(:parse_comment).and_return({ errors: ["an error"] })
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
+      it 'updates the issue if danger doesnt need to say anything but there are sticky violations' do
+        issues = [{ body: 'generated_by_danger', id: '12' }]
+        allow(@g).to receive(:parse_comment).and_return({ errors: ['an error'] })
+        allow(@g.client).to receive(:issue_comments).with('artsy/eigen', '800').and_return(issues)
 
-        expect(@g.client).to receive(:update_comment).with("artsy/eigen", "12", any_args).and_return({})
+        expect(@g.client).to receive(:update_comment).with('artsy/eigen', '12', any_args).and_return({})
         @g.update_pull_request!(warnings: [], errors: [], messages: [])
       end
     end
 
-    describe "comment parsing" do
-      it "detects the warning kind" do
-        expect(@g.table_kind_from_title("1 Warning")).to eq(:warning)
-        expect(@g.table_kind_from_title("2 Warnings")).to eq(:warning)
+    describe 'comment parsing' do
+      it 'detects the warning kind' do
+        expect(@g.table_kind_from_title('1 Warning')).to eq(:warning)
+        expect(@g.table_kind_from_title('2 Warnings')).to eq(:warning)
       end
 
-      it "detects the error kind" do
-        expect(@g.table_kind_from_title("1 Error")).to eq(:error)
-        expect(@g.table_kind_from_title("2 Errors")).to eq(:error)
+      it 'detects the error kind' do
+        expect(@g.table_kind_from_title('1 Error')).to eq(:error)
+        expect(@g.table_kind_from_title('2 Errors')).to eq(:error)
       end
 
-      it "detects the warning kind" do
-        expect(@g.table_kind_from_title("1 Message")).to eq(:message)
-        expect(@g.table_kind_from_title("2 Messages")).to eq(:message)
+      it 'detects the warning kind' do
+        expect(@g.table_kind_from_title('1 Message')).to eq(:message)
+        expect(@g.table_kind_from_title('2 Messages')).to eq(:message)
       end
 
-      it "parses a comment with error" do
-        comment = comment_fixture("comment_with_error")
+      it 'parses a comment with error' do
+        comment = comment_fixture('comment_with_error')
         violations = @g.parse_comment(comment)
-        expect(violations).to eq({ error: ["Some error"] })
+        expect(violations).to eq({ error: ['Some error'] })
       end
 
-      it "parses a comment with error and warnings" do
-        comment = comment_fixture("comment_with_error_and_warnings")
+      it 'parses a comment with error and warnings' do
+        comment = comment_fixture('comment_with_error_and_warnings')
         violations = @g.parse_comment(comment)
-        expect(violations).to eq({ error: ["Some error"], warning: ["First warning", "Second warning"] })
+        expect(violations).to eq({ error: ['Some error'], warning: ['First warning', 'Second warning'] })
       end
 
-      it "ignores non-sticky violations when parsing a comment" do
-        comment = comment_fixture("comment_with_non_sticky")
+      it 'ignores non-sticky violations when parsing a comment' do
+        comment = comment_fixture('comment_with_non_sticky')
         violations = @g.parse_comment(comment)
-        expect(violations).to eq({ warning: ["First warning"] })
+        expect(violations).to eq({ warning: ['First warning'] })
       end
 
-      it "parses a comment with error and warnings removing strike tag" do
-        comment = comment_fixture("comment_with_resolved_violation")
+      it 'parses a comment with error and warnings removing strike tag' do
+        comment = comment_fixture('comment_with_resolved_violation')
         violations = @g.parse_comment(comment)
-        expect(violations).to eq({ error: ["Some error"], warning: ["First warning", "Second warning"] })
+        expect(violations).to eq({ error: ['Some error'], warning: ['First warning', 'Second warning'] })
       end
     end
   end

--- a/spec/lib/danger/request_sources/request_source_spec.rb
+++ b/spec/lib/danger/request_sources/request_source_spec.rb
@@ -1,30 +1,30 @@
-require "danger/request_source/github"
+require 'danger/request_source/github'
 
 describe Danger::RequestSources::RequestSource do
-  describe "the base request source" do
-    it "validates when passed a corresponding repository" do
+  describe 'the base request source' do
+    it 'validates when passed a corresponding repository' do
       git_mock = Danger::GitRepo.new
-      allow(git_mock).to receive(:exec).with("remote show origin -n").and_return("Fetch URL: git@github.com:artsy/eigen.git")
+      allow(git_mock).to receive(:exec).with('remote show origin -n').and_return('Fetch URL: git@github.com:artsy/eigen.git')
 
       g = stub_request_source
       g.scm = git_mock
       expect(g.validates_as_ci?).to be true
     end
 
-    it "validates when passed a corresponding repository with custom host" do
+    it 'validates when passed a corresponding repository with custom host' do
       git_mock = Danger::GitRepo.new
 
-      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com" }
+      gh_env = { 'DANGER_GITHUB_API_TOKEN' => 'hi', 'DANGER_GITHUB_HOST' => 'git.club-mateusa.com' }
       g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
       g.scm = git_mock
 
-      allow(git_mock).to receive(:exec).with("remote show origin -n").and_return("Fetch URL: git@git.club-mateusa.com:artsy/eigen.git")
+      allow(git_mock).to receive(:exec).with('remote show origin -n').and_return('Fetch URL: git@git.club-mateusa.com:artsy/eigen.git')
       expect(g.validates_as_ci?).to be true
     end
 
     it 'doesn\'t validate when passed a wrong repository' do
       git_mock = Danger::GitRepo.new
-      allow(git_mock).to receive(:exec).with("remote show origin -n").and_return("Fetch URL: git@bitbucket.org:artsy/eigen.git")
+      allow(git_mock).to receive(:exec).with('remote show origin -n').and_return('Fetch URL: git@bitbucket.org:artsy/eigen.git')
 
       g = stub_request_source
       g.scm = git_mock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,34 +1,34 @@
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-require "danger"
-require "webmock"
-require "webmock/rspec"
-require "json"
+require 'danger'
+require 'webmock'
+require 'webmock/rspec'
+require 'json'
 
 RSpec.configure do |config|
-  config.filter_gems_from_backtrace "bundler"
+  config.filter_gems_from_backtrace 'bundler'
 end
 
-WebMock.disable_net_connect!(allow: "coveralls.io")
+WebMock.disable_net_connect!(allow: 'coveralls.io')
 
 def make_temp_file(contents)
-  file = Tempfile.new("dangefile_tests")
+  file = Tempfile.new('dangefile_tests')
   file.write contents
   file
 end
 
 def stub_env
   {
-    "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
-    "TRAVIS_PULL_REQUEST" => "800",
-    "TRAVIS_REPO_SLUG" => "artsy/eigen",
-    "TRAVIS_COMMIT_RANGE" => "759adcbd0d8f...13c4dc8bb61d",
-    "DANGER_GITHUB_API_TOKEN" => "hi"
+    'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true',
+    'TRAVIS_PULL_REQUEST' => '800',
+    'TRAVIS_REPO_SLUG' => 'artsy/eigen',
+    'TRAVIS_COMMIT_RANGE' => '759adcbd0d8f...13c4dc8bb61d',
+    'DANGER_GITHUB_API_TOKEN' => 'hi'
   }
 end
 
 def stub_ci
-  env = { "CI_PULL_REQUEST" => "https://github.com/artsy/eigen/pull/800" }
+  env = { 'CI_PULL_REQUEST' => 'https://github.com/artsy/eigen/pull/800' }
   Danger::CircleCI.new(env)
 end
 
@@ -45,7 +45,7 @@ def testing_ui
 
   cork = Cork::Board.new(out: @output)
   def cork.string
-    out.string.gsub(/\e\[([;\d]+)?m/, "")
+    out.string.gsub(/\e\[([;\d]+)?m/, '')
   end
   cork
 end


### PR DESCRIPTION
This discussion can only be a step up from tabs vs. spaces, so feel free to close without merging :) This PR saves 3 lines of code in `.rubocop.yml`. Removing special handling in Rubocop rules has been a general goal that I've been trying to pursue. If this goes through I'll probably remove everything else in another PR and use `rubocop --auto-gen-config` to generate exceptions.