### PR TITLE
Require BUILDKITE_PULL_REQUEST_REPO to not be the empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Improve detection of Buildkite's PR context - cysp
+
 ## 2.1.2
 
 * Improvements to `danger init` - orta

--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -23,7 +23,8 @@ module Danger
     end
 
     def self.validates_as_pr?(env)
-      ["BUILDKITE_PULL_REQUEST_REPO", "BUILDKITE_PULL_REQUEST"].all? { |x| env[x] }
+      exists = ["BUILDKITE_PULL_REQUEST_REPO", "BUILDKITE_PULL_REQUEST"].all? { |x| env[x] }
+      exists && !env["BUILDKITE_PULL_REQUEST_REPO"].empty?
     end
 
     def initialize(env)

--- a/spec/lib/danger/ci_sources/buildkite_spec.rb
+++ b/spec/lib/danger/ci_sources/buildkite_spec.rb
@@ -32,10 +32,20 @@ describe Danger::Buildkite do
     expect(t.pull_request_id).to eql("14")
   end
 
-  it "doesn't continue when the build is not a pull request" do
+  it "doesn't validate_as_pr if pull_request_repo is missing" do
     env = {
       "BUILDKITE" => "true",
       "BUILDKITE_PULL_REQUEST_REPO" => nil,
+      "BUILDKITE_PULL_REQUEST" => "false"
+    }
+    expect(Danger::Buildkite.validates_as_ci?(env)).to be true
+    expect(Danger::Buildkite.validates_as_pr?(env)).to be false
+  end
+
+  it "doesn't validate_as_pr if pull_request_repo is the empty string" do
+    env = {
+      "BUILDKITE" => "true",
+      "BUILDKITE_PULL_REQUEST_REPO" => "",
       "BUILDKITE_PULL_REQUEST" => "false"
     }
     expect(Danger::Buildkite.validates_as_ci?(env)).to be true


### PR DESCRIPTION
Check that `BUILDKITE_PULL_REQUEST_REPO` is both present and not the empty string, as noted [here](https://github.com/danger/danger/issues/426#issuecomment-239886660).