### PR TITLE
Fix a typo in messaging-plugin docs #trivial

### DIFF
--- a/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
@@ -22,7 +22,7 @@ module Danger
   #
   #          fail "This build didn't pass tests"
   #
-  # @example Failing a build, but not keeping it's value around on subsequent runs
+  # @example Failing a build, but not keeping its value around on subsequent runs
   #
   #          fail("This build didn't pass tests", sticky: false)
   #


### PR DESCRIPTION
This PR fixes a minor typo in the documentation of the messaging plugin.