### PR TITLE
Find the common merge commit, before looking for a diff in git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Improve detection of Buildkite's PR context - cysp
+* An attempt at fixing a misalignment with what Danger says is inside the diff range, and what people have seen #160 #316 - orta/yimingtang/jamtur01/segiddins
 
 ## 2.1.2
 

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -8,7 +8,9 @@ module Danger
 
     def diff_for_folder(folder, from: "master", to: "HEAD")
       repo = Git.open folder
-      self.diff = repo.diff(from, to)
+
+      merge_base = repo.merge_base(from, to)
+      self.diff = repo.diff(merge_base.to_s, to)
       self.log = repo.log.between(from, to)
     end
 
@@ -22,6 +24,31 @@ module Danger
 
     def origins
       exec("remote show origin -n").lines.grep(/Fetch URL/)[0].split(": ", 2)[1]
+    end
+  end
+end
+
+# For full context see:
+# https://github.com/danger/danger/issues/160
+# and https://github.com/danger/danger/issues/316
+#
+# for which the fix comes from an unmerged PR from 2012
+# https://github.com/schacon/ruby-git/pull/43
+
+module Git
+  class Base
+    def merge_base(commit1, commit2, *other_commits)
+      Git::Object.new self, self.lib.merge_base(commit1, commit2, *other_commits)
+    end
+  end
+
+  class Lib
+    def merge_base(commit1, commit2, *other_commits)
+      arr_opts = []
+      arr_opts << commit1
+      arr_opts << commit2
+      arr_opts += other_commits
+      command("merge-base", arr_opts)
     end
   end
 end


### PR DESCRIPTION
Re: #160 #316

This applies the fix in https://github.com/jamtur01/ruby-git/commit/6f0b644d24d9e061a852ba2f18a3c78c4ec1a0e4 / inline. 

Considering the amount of tests we have where we create a real repo and exec some commits, I'm happy this isn't breaking anything, what I'm not 100% sure of is whether it fixes the problem. I rarely would see it.