### PR TITLE
Circle CI checking for PR status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Improve detection of PR content on CircleCI.
+
 ## 2.1.3
 
 * Improve detection of Buildkite's PR context - cysp

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -29,7 +29,7 @@ module Danger
 
     def self.validates_as_pr?(env)
       # This will get used if it's available, instead of the API faffing.
-      return true if env["CI_PULL_REQUEST"]
+      return true if !env["CI_PULL_REQUEST"].empty?
 
       # Real-world talk, it should be worrying if none of these are in the environment
       return false unless ["CIRCLE_CI_API_TOKEN", "CIRCLE_PROJECT_USERNAME", "CIRCLE_PROJECT_REPONAME", "CIRCLE_BUILD_NUM"].all? { |x| env[x] }

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -29,7 +29,7 @@ module Danger
 
     def self.validates_as_pr?(env)
       # This will get used if it's available, instead of the API faffing.
-      return true if !env["CI_PULL_REQUEST"].empty?
+      return true unless env["CI_PULL_REQUEST"].empty?
 
       # Real-world talk, it should be worrying if none of these are in the environment
       return false unless ["CIRCLE_CI_API_TOKEN", "CIRCLE_PROJECT_USERNAME", "CIRCLE_PROJECT_REPONAME", "CIRCLE_BUILD_NUM"].all? { |x| env[x] }

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -38,7 +38,7 @@ describe Danger::CircleCI do
 
   it "doesn't validate_as_pr if ci_pull_request is empty" do
     env = { "CI_PULL_REQUEST" => "" }
-    expect(Danger::Buildkite.validates_as_pr?(env)).to be false
+    expect(Danger::CircleCI.validates_as_pr?(env)).to be false
   end
 
   it "doesnt validate when circle ci is not found" do

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -36,6 +36,11 @@ describe Danger::CircleCI do
     expect(Danger::CircleCI.validates_as_ci?(env)).to be true
   end
 
+  it "doesn't validate_as_pr if ci_pull_request is empty" do
+    env = { "CI_PULL_REQUEST" => "" }
+    expect(Danger::Buildkite.validates_as_pr?(env)).to be false
+  end
+
   it "doesnt validate when circle ci is not found" do
     env = { "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true" }
     expect(Danger::CircleCI.validates_as_ci?(env)).to be false


### PR DESCRIPTION
Circle CI should check if a PR IS a PR via the `CI_PULL_REQUEST`
environment variable. If it's empty then it's NOT a PR.