### PR TITLE
Gitlab test is missing an expectation #trivial

### DIFF
--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -14,6 +14,7 @@ describe Danger::RequestSources::GitLab, host: :gitlab do
 
     it "allows the GitLab host to be overidden" do
       env["DANGER_GITLAB_HOST"] = "gitlab.example.com"
+      expect(g.host).to eql("gitlab.example.com")
     end
   end
 


### PR DESCRIPTION
This test does not have an expectation. Funny how that test even works, magic of lazily evaluated rspec `let`s.