### PR TITLE
Add support for CIs that do gitlab

### DIFF
--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -36,7 +36,7 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab]
     end
   end
 end

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -6,9 +6,10 @@ module Danger
 
   # ### CI Setup
   #
-  # Ah Jenkins, so many memories. So, if you're using Jenkins, you're hosting your own environment. You
+  # Ah Jenkins, so many memories. So, if you're using Jenkins, you're hosting your own environment. For GitHub you
   # will want to be using the [GitHub pull request builder plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin)
-  # in order to ensure that you have the build environment set up for PR integration.
+  # in order to ensure that you have the build environment set up for PR integration. For GitLab, consult the
+  # [GitLab - Jenkins](http://docs.gitlab.com/ee/integration/jenkins.html) documentation.
   #
   # With that set up, you can edit your job to add `bundle exec danger` at the build action.
   #
@@ -26,7 +27,7 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab]
     end
 
     def initialize(env)

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -20,6 +20,7 @@ module Danger
       git.exec command
     end
 
+    # TODO: Support `danger local` for GitLab
     def supported_request_sources
       @supported_request_sources ||= [Danger::RequestSources::GitHub]
     end

--- a/lib/danger/ci_source/teamcity.rb
+++ b/lib/danger/ci_source/teamcity.rb
@@ -23,7 +23,7 @@ module Danger
     end
 
     def self.validates_as_pr?(env)
-      ["GITHUB_PULL_REQUEST_ID", "GITHUB_REPO_URL", "GITHUB_REPO_SLUG"].all? { |x| env[x] }
+      ["GITHUB_PULL_REQUEST_ID", "GITHUB_REPO_URL", "GITHUB_REPO_SLUG"].all? { |x| env[x] } || ["GITLAB_REPO_SLUG", "GITLAB_PULL_REQUEST_ID", "GITLAB_REPO_SLUG"].all? { |x| env[x] }
     end
 
     def supported_request_sources
@@ -34,9 +34,9 @@ module Danger
       # NB: Unfortunately TeamCity doesn't provide these variables
       # automatically so you have to add these variables manually to your
       # project or build configuration
-      self.repo_slug       = env["GITHUB_REPO_SLUG"]
-      self.pull_request_id = env["GITHUB_PULL_REQUEST_ID"].to_i
-      self.repo_url        = env["GITHUB_REPO_URL"]
+      self.repo_slug       = env["GITHUB_REPO_SLUG"] || env["GITLAB_REPO_SLUG"]
+      self.pull_request_id = (env["GITHUB_PULL_REQUEST_ID"] || env["GITLAB_PULL_REQUEST_ID"]).to_i
+      self.repo_url        = env["GITHUB_REPO_URL"] || env["GITLAB_REPO_SLUG"]
     end
   end
 end

--- a/spec/lib/danger/ci_sources/teamcity_spec.rb
+++ b/spec/lib/danger/ci_sources/teamcity_spec.rb
@@ -12,10 +12,22 @@ describe Danger::TeamCity do
     expect(subject.repo_slug).to eql("foo/bar")
   end
 
+  it "gets out a gitlab repo slug" do
+    env = { "GITLAB_REPO_SLUG" => "foo/bar" }
+    subject = Danger::TeamCity.new(env)
+    expect(subject.repo_slug).to eql("foo/bar")
+  end
+
   it "gets out a pull request id" do
     env = { "GITHUB_PULL_REQUEST_ID" => "42" }
     subject = Danger::TeamCity.new(env)
     expect(subject.pull_request_id).to eql(42)
+  end
+
+  it "gets out a pull request id" do
+    env = { "GITLAB_PULL_REQUEST_ID" => "41" }
+    subject = Danger::TeamCity.new(env)
+    expect(subject.pull_request_id).to eql(41)
   end
 
   it "gets out a repo url" do


### PR DESCRIPTION
Took a look through the docs:

- [x] BuildKite does it with not real changes
- [x] Jenkins requires some setup, so I sent them to the official docs
- [x] TeamCity _can_ but just with GitHub it's very much a "good luck to you"
- [x] Buildasaur ( for Xcode ) doesn't support it, so for now, it's skipped 