### PR TITLE
Hk extract comment identification #trivial

### DIFF
--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -120,7 +120,14 @@ module Danger
         return NEW_REGEX.match(table)
       end
 
-      class Comment < Struct.new(:id, :body)
+      class Comment
+        attr_reader :id, :body
+
+        def initialize(id, body)
+          @id = id
+          @body = body
+        end
+
         def self.from_github(comment)
           self.new(comment[:id], comment[:body])
         end

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -119,6 +119,20 @@ module Danger
 
         return NEW_REGEX.match(table)
       end
+
+      class Comment < Struct.new(:id, :body)
+        def self.from_github(comment)
+          self.new(comment[:id], comment[:body])
+        end
+
+        def self.from_gitlab(comment)
+          self.new(comment.id, comment.body)
+        end
+
+        def generated_by_danger?(danger_id)
+          body.include?("generated_by_#{danger_id}")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Trying to have only one source of truth for the `"generated_by#{danger_id}"`. Not 100% sure on this refactoring, feel free to close if you guys don't like this. The more pragmatic thing would be a `generated_by_danger(body, danger_id)` method on `CommentsHelper`. But I like wrapper object so much 😈 