### PR TITLE
Restore danger local behaviour to use Github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Crash fix for `danger local` - hanneskaeufler
+
 ## 3.0
 
 * GitLab support - k0nserv / deanpcmad / hjanuschka

--- a/lib/danger/request_source/github.rb
+++ b/lib/danger/request_source/github.rb
@@ -22,7 +22,7 @@ module Danger
       end
 
       def validates_as_api_source?
-        @token && !@token.empty?
+        (@token && !@token.empty?) || self.environment["DANGER_USE_LOCAL_GIT"]
       end
 
       def scm

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -41,4 +41,11 @@ describe Danger::EnvironmentManager do
     expect(Danger::EnvironmentManager.local_ci_source(env)).to be_truthy
     expect(Danger::EnvironmentManager.pr?(env)).to eq(false)
   end
+
+  it "uses local git repo and github when running locally" do
+    env = { "DANGER_USE_LOCAL_GIT" => "true" }
+    e = Danger::EnvironmentManager.new(env)
+    expect(e.ci_source).to be_truthy
+    expect(e.request_source).to be_truthy
+  end
 end


### PR DESCRIPTION
Previously, Github would be used for danger local runs.
Since 5f505b9 however danger local would crash because the
github ci source wouldn't "validate_as_api_source". Fixes #454