### PR TITLE
Fix typo in gitlab.branch_for_merge documentation #trivial

### DIFF
--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -26,7 +26,7 @@ module Danger
   #
   # @example Only accept MRs to the develop branch
   #
-  #          fail "Please re-submit this MR to develop, we may have already fixed your issue." if gitlab.branch_for_base != "develop"
+  #          fail "Please re-submit this MR to develop, we may have already fixed your issue." if gitlab.branch_for_merge != "develop"
   #
   # @example Note when MRs don't reference a milestone, which goes away when it does
   #


### PR DESCRIPTION
The examples list a `gitlab.branch_for_base` which failed for us and it should be `gitlab.branch_for_merge`.