### PR TITLE
Update Semaphore docs #trivial

### DIFF
--- a/lib/danger/ci_source/semaphore.rb
+++ b/lib/danger/ci_source/semaphore.rb
@@ -4,7 +4,8 @@ module Danger
   # ### CI Setup
   #
   # For Semaphor you will want to go to the settings page of the project. Inside "Build Settings"
-  # you should add `bundle exec danger` to the Setup thread.
+  # you should add `bundle exec danger` to the Setup thread. Note that Semaphore only provides
+  # the build environment variables necessary for Danger on PRs across forks.
   #
   # ### Token Setup
   #


### PR DESCRIPTION
I was not seeing working builds when adding Danger, running `printenv` did not give the results that we see across forks.