### PR TITLE
Integrate the Gem metadata with the Plugin JSON for external plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Show appropriate error message when GitHub repo was moved - KrauseFx
+* `danger plugins json [gem]` will now give gem metadata too - orta
 
 ## 3.0.3
 

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -8,7 +8,7 @@ module Danger
   # exist as of yet, however there is an
   # [MR](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/5698) fixing this.
   # If that has been merged and you are using either gitlab.com or a release
-  # with that change this CISource will wokr.
+  # with that change this CISource will work.
   #
   class GitLabCI < CI
     def self.validates_as_ci?(env)

--- a/lib/danger/commands/plugins/plugin_lint.rb
+++ b/lib/danger/commands/plugins/plugin_lint.rb
@@ -37,9 +37,9 @@ module Danger
 
     def run
       file_resolver = PluginFileResolver.new(@refs)
-      paths = file_resolver.resolve_to_paths
+      data = file_resolver.resolve
 
-      parser = PluginParser.new(paths, verbose: true)
+      parser = PluginParser.new(data[:paths], verbose: true)
       parser.parse
       json = parser.to_json
 

--- a/lib/danger/commands/plugins/plugin_readme.rb
+++ b/lib/danger/commands/plugins/plugin_readme.rb
@@ -31,9 +31,9 @@ module Danger
     attr_accessor :json, :markdown
     def run
       file_resolver = PluginFileResolver.new(@refs)
-      paths = file_resolver.resolve_to_paths
+      data = file_resolver.resolve
 
-      parser = PluginParser.new(paths)
+      parser = PluginParser.new(data[:paths])
       parser.parse
 
       self.json = JSON.parse(parser.to_json_string)

--- a/spec/lib/danger/commands/plugin_json_spec.rb
+++ b/spec/lib/danger/commands/plugin_json_spec.rb
@@ -1,0 +1,13 @@
+require "danger/commands/plugins/plugin_json"
+
+module Danger
+  describe Danger::PluginJSON do
+    after do
+      Plugin.clear_external_plugins
+    end
+
+    it "runs the command" do
+      Danger::PluginJSON.run(["spec/fixtures/plugins/example_fully_documented.rb"])
+    end
+  end
+end

--- a/spec/lib/danger/commands/plugins/plugin_lint_spec.rb
+++ b/spec/lib/danger/commands/plugins/plugin_lint_spec.rb
@@ -1,4 +1,4 @@
-require "danger/commands/plugins/plugin_json"
+require "danger/commands/plugins/plugin_lint"
 
 module Danger
   describe Danger::PluginLint do
@@ -8,7 +8,7 @@ module Danger
 
     it "runs the command" do
       # allow(STDOUT).to receive(:puts) # this disables puts
-      Danger::PluginJSON.run(["spec/fixtures/plugins/example_fully_documented.rb"])
+      Danger::PluginLint.run(["spec/fixtures/plugins/example_fully_documented.rb"])
     end
   end
 end


### PR DESCRIPTION
So, this is tricky. 

As a part of an upcoming Danger.Systems PR, I'm moving to separately running `bundler` per Danger plugin, this has the downside of being _slow_ -  I can look into vending the dependencies better, but I have to run it all twice to get the gem metadata and the plugin metadata. 

This is because if any plugin breaks danger.systems everything breaks, and more importantly - there can be conflicting dependencies in the plugins. We'd get nothing if two plugins update and have different deps.

Not gonna fly when it takes more than 10m to generate the files. Better to migrate the two types of data into one, and pass that around the system.