### PR TITLE
Sticky false by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Show appropriate error message when GitHub repo was moved - KrauseFx
 * `danger plugins json [gem]` will now give gem metadata too - orta
+* Switch messaging's sticky to default to `false` - Bogren
 
 ## 3.0.3
 

--- a/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
@@ -7,7 +7,7 @@ module Danger
   #
   # The message within which Danger communicates back is amended on each run in a session.
   #
-  # Each of `message`, `warn` and `fail` have a `sticky` flag, `true` by default, which
+  # Each of `message`, `warn` and `fail` have a `sticky` flag, `false` by default, which
   # means that the message will be crossed out instead of being removed. If it's not use on
   # subsequent runs.
   #
@@ -81,7 +81,7 @@ module Danger
     #           defaults to `true`.
     # @return   [void]
     #
-    def message(message, sticky: true)
+    def message(message, sticky: false)
       @messages << Violation.new(message, sticky)
     end
 
@@ -95,7 +95,7 @@ module Danger
     #           defaults to `true`.
     # @return   [void]
     #
-    def warn(message, sticky: true)
+    def warn(message, sticky: false)
       return if should_ignore_violation(message)
       @warnings << Violation.new(message, sticky)
     end
@@ -110,7 +110,7 @@ module Danger
     #           defaults to `true`.
     # @return   [void]
     #
-    def fail(message, sticky: true)
+    def fail(message, sticky: false)
       return if should_ignore_violation(message)
       @errors << Violation.new(message, sticky)
     end


### PR DESCRIPTION
Fixes #482. I agree with the issue, most of my dangerfile entries set sticky to false. 