### PR TITLE
fixes crash when running `bundle exec danger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Show appropriate error message when GitHub repo was moved - KrauseFx
 * `danger plugins json [gem]` will now give gem metadata too - orta
+* Crash fix for `bundle exec danger` - hanneskaeufler
 
 ## 3.0.3
 

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -53,7 +53,7 @@ module Danger
     end
 
     def run
-      Executor.new.run(base: @base,
+      Executor.new(ENV).run(base: @base,
                        head: @head,
                        dangerfile_path: @dangerfile_path,
                        danger_id: @danger_id)

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -1,5 +1,9 @@
 module Danger
   class Executor
+    def initialize(system_env)
+      @system_env = system_env
+    end
+
     def run(env: nil,
             dm: nil,
             cork: nil,
@@ -12,18 +16,18 @@ module Danger
                               verbose: false)
 
       # Could we find a CI source at all?
-      unless EnvironmentManager.local_ci_source(ENV)
+      unless EnvironmentManager.local_ci_source(@system_env)
         abort("Could not find the type of CI for Danger to run on.".red)
       end
 
       # Could we determine that the CI source is inside a PR?
-      unless EnvironmentManager.pr?(ENV)
+      unless EnvironmentManager.pr?(@system_env)
         cork.puts "Not a Pull Request - skipping `danger` run".yellow
         return
       end
 
       # OK, then we can have some
-      env ||= EnvironmentManager.new(ENV)
+      env ||= EnvironmentManager.new(@system_env)
       dm ||= Dangerfile.new(env, cork)
 
       dm.init_plugins

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -13,7 +13,7 @@ module Danger
 
       # Could we find a CI source at all?
       unless EnvironmentManager.local_ci_source(ENV)
-        abort("Could not find the type of CI for Danger to run on.".red) unless ci_klass
+        abort("Could not find the type of CI for Danger to run on.".red)
       end
 
       # Could we determine that the CI source is inside a PR?

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -1,7 +1,8 @@
 describe Danger::Executor do
   describe "#run" do
     it "aborts when not in a ci env" do
-      expect { Danger::Executor.new.run }
+      env = {}
+      expect { Danger::Executor.new(env).run }
         .to raise_error(SystemExit)
         .and output(/Could not find the type of CI/).to_stderr
     end

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -1,0 +1,9 @@
+describe Danger::Executor do
+  describe "#run" do
+    it "aborts when not in a ci env" do
+      expect { Danger::Executor.new.run }
+        .to raise_error(SystemExit)
+        .and output(/Could not find the type of CI/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
When not in a CI environment, this would previously fail because
of an undefined variable. Fixes #472 

- [x] I'm kind of guessing this will not pass CI because there actually will be CI env vars set 🔥 

Testing on these classes is not a solved story yet I think.
