### PR TITLE
[Buildkite] Use BUILDKITE_REPO for repo slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Show appropriate error message when GitHub repo was moved - KrauseFx
 * `danger plugins json [gem]` will now give gem metadata too - orta
 * Crash fix for `bundle exec danger` - hanneskaeufler
+* Fix Buildkite repo slug URL generation - phillfarrugia
 
 ## 3.0.3
 

--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -35,7 +35,7 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_url = env["BUILDKITE_PULL_REQUEST_REPO"]
+      self.repo_url = env["BUILDKITE_REPO"]
       self.pull_request_id = env["BUILDKITE_PULL_REQUEST"]
 
       repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})

--- a/spec/lib/danger/ci_sources/buildkite_spec.rb
+++ b/spec/lib/danger/ci_sources/buildkite_spec.rb
@@ -4,6 +4,7 @@ describe Danger::Buildkite do
   let(:valid_env) do
     {
       "BUILDKITE" => "true",
+      "BUILDKITE_REPO" => "git@github.com:Danger/danger.git",
       "BUILDKITE_PULL_REQUEST_REPO" => "git@github.com:KrauseFx/danger.git",
       "BUILDKITE_PULL_REQUEST" => "12"
     }
@@ -16,7 +17,7 @@ describe Danger::Buildkite do
   let(:source) { described_class.new(valid_env) }
 
   describe ".validates_as_ci?" do
-    it "validates when requierd env variables are set" do
+    it "validates when required env variables are set" do
       expect(described_class.validates_as_ci?(valid_env)).to be true
     end
 
@@ -54,12 +55,12 @@ describe Danger::Buildkite do
   describe "#new" do
     describe "repo slug" do
       it "gets out a repo slug from a git+ssh repo" do
-        expect(source.repo_slug).to eql("KrauseFx/danger")
+        expect(source.repo_slug).to eql("Danger/danger")
       end
 
       it "gets out a repo slug from a https repo" do
-        valid_env["BUILDKITE_PULL_REQUEST_REPO"] = "https://github.com/KrauseFx/danger.git"
-        expect(source.repo_slug).to eql("KrauseFx/danger")
+        valid_env["BUILDKITE_REPO"] = "https://github.com/Danger/danger.git"
+        expect(source.repo_slug).to eql("Danger/danger")
       end
     end
 


### PR DESCRIPTION
Fixes #473 .

#### Why
Danger would 404 when trying to run against a Pull Request on a Forked Repository with Buildkite.
It was using the PR URL to generate the Slug, instead it should be using the main repo URL.

Danger should continue to skip if the commit is not a PR as per #310 .

#### Approach
- Danger still uses the environment variable BUILDKITE_PULL_REQUEST_REPO to perform PR validation. I've just made the change so it uses BUILDKITE_REPO for generating the Slug used to grab the PR itself from Github.

- I've also tweaked the tests slightly, to ensure it gets out a correct repo slug from a git+ssh repo and a https repo.

#### Tested?
- I ran Danger pointing at my feature/buildkite-env-var version of Danger with these changes, and the PR build ran exactly as expected.
- I also ran a build on the Merge commit of my sample PR and Danger skipped the build for not being a PR, as expected.

<img width="1184" alt="screen shot 2016-08-30 at 11 22 42 am" src="https://cloud.githubusercontent.com/assets/4746329/18072889/2ee06d64-6ea5-11e6-8f63-9d2365d35738.png">
