### PR TITLE
Feature: import Dangerfile from path or gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## master
 
+* Deprecated `import_dangerfile(String)` in favor of `import_dangerfile(Hash)` - dblock
+
+  The new `import_dangerfile` method supports loading Dangerfile from Github.
+
+  ```ruby
+  danger.import_dangerfile github: 'ruby-grape/danger'
+  ```
+
+  You can package a Dangerfile in a gem, add it to Gemfile and import it.
+
+  ```ruby
+  danger.import_dangerfile gem: 'ruby-grape-danger'
+  ```
+
+  Use a local path for testing Dangerfile changes.
+
+  ```ruby
+  danger.import_dangerfile path: '/Users/me/source/ruby-grape/danger'
+  ```
+
+  See [#504](https://github.com/danger/danger/pull/504) for details.
+
 ## 3.1.1
 
 * Fixes for `danger.import_dangerfile "org/repo"` - orta re:#487
@@ -16,7 +38,7 @@
 ## 3.0.3
 
 * Add `mr_diff`/`pr_diff` for `Danger::DangerfileGitLabPlugin` - K0nserv
-* Fixes a bug where `danger` wouldn't work on Jenkins when setup with the GitHub Pull Request Builder plugin. - vittoriom
+* Fixes a bug where `danger` wouldn't work on Jenkins when setup with the GitHub Pull Request Builder plugin - vittoriom
 
 ## 3.0.2
 

--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -40,7 +40,7 @@ module Danger
     # @return   [void]
     #
     def import_plugin(path_or_url)
-      raise "`import` requires a string" unless path_or_url.kind_of?(String)
+      raise "`import_plugin` requires a string" unless path_or_url.kind_of?(String)
 
       if path_or_url.start_with?("http")
         import_url(path_or_url)
@@ -50,21 +50,76 @@ module Danger
     end
 
     # @!group Danger
+    # Import a Dangerfile.
+    #
+    # @param    [Hash] opts
+    # @option opts [String] :github Github path
+    # @option opts [String] :gem Gem name
+    # @option opts [String] :path Path to Dangerfile
+    # @return   [void]
+    def import_dangerfile(opts)
+      if opts.kind_of?(String)
+        warn "Use `import_dangerfile(github: '#{opts}')` instead of `import_dangerfile '#{opts}'`."
+        import_dangerfile_from_github(opts)
+      elsif opts.kind_of?(Hash)
+        if opts.key?(:github)
+          import_dangerfile_from_github(opts[:github])
+        elsif opts.key?(:path)
+          import_dangerfile_from_path(opts[:path])
+        elsif opts.key?(:gem)
+          import_dangerfile_from_gem(opts[:gem])
+        else
+          raise "`import` requires a Hash with either :github or :gem"
+        end
+      else
+        raise "`import` requires a Hash" unless opts.kind_of?(Hash)
+      end
+    end
+
+    private
+
+    # @!group Danger
+    # Read and execute a local Dangerfile.
+    #
+    # @param    [String] path
+    #           A path to a Dangerfile.
+    # @return   [void]
+    #
+    def import_dangerfile_from_path(path)
+      raise "`import_dangerfile_from_path` requires a string" unless path.kind_of?(String)
+      local_path = File.join(path, "Dangerfile")
+      @dangerfile.parse(Pathname.new(local_path))
+    end
+
+    # @!group Danger
+    # Read and execute a Dangerfile from a gem.
+    #
+    # @param    [String] name
+    #           The name of the gem that contains a Dangerfile.
+    # @return   [void]
+    #
+    def import_dangerfile_from_gem(name)
+      raise "`import_dangerfile_from_gem` requires a string" unless name.kind_of?(String)
+      spec = Gem::Specification.find_by_name(name)
+      import_dangerfile_from_path(spec.gem_dir)
+    rescue Gem::MissingSpecError
+      raise "`import_dangerfile_from_gem` tried to load `#{name}` and failed, did you forget to include it in your Gemfile?"
+    end
+
+    # @!group Danger
     # Download and execute a remote Dangerfile.
     #
-    # @param    [String] repo slug
+    # @param    [String] slug
     #           A slug that represents the repo where the Dangerfile is.
     # @return   [void]
     #
-    def import_dangerfile(slug)
-      raise "`import` requires a string" unless slug.kind_of?(String)
+    def import_dangerfile_from_github(slug)
+      raise "`import_dangerfile_from_github` requires a string" unless slug.kind_of?(String)
       org, repo = slug.split("/")
       download_url = env.request_source.file_url(organisation: org, repository: repo, branch: "master", path: "Dangerfile")
       local_path = download(download_url)
       @dangerfile.parse(Pathname.new(local_path))
     end
-
-    private
 
     # @!group Plugins
     # Download a local or remote plugin or Dangerfile.


### PR DESCRIPTION
### Problem

I've extracted code from https://github.com/ruby-grape/danger/blob/master/Dangerfile into the https://github.com/dblock/danger-changelog gem. If I update the https://github.com/ruby-grape/danger project's Dangerfile to use that via `changelog.check` I will break pull requests in all projects that use Danger in that org. I must update half a dozen repositories at once. For each repository I have to modify `Gemfile` to include `danger-changelog`. If I don't do that, it just breaks because the org projects don't know anything about `danger-changelog`.

Pain and suffering. Chicken and egg.

### Solution

Allow one to package Dangerfile in a versioned gem and be able to load it from another Dangerfile like this:

```ruby
import_dangerfile gem: 'ruby-grape-danger'
```

### Side Effects in this PR

The `import_dangerfile(String)` method is deprecated with a warning. It now supports `path`, `github` or `gem`. In the future it can take a lot more options, making `import_dangerfile` much more extensible and more compatible with syntax used in, say, Gemfile.

### TODO

* Potentially add `import file: ...` and `import: url: `, so we can just load a file and a `url` without having to imply `Dangerfile`, this way the Dangerfiles can be named differently.
* Support the `gem` and `github` pair, where the .gemspec is loaded from Github, a familiar Gemfile syntax. Really in this case it's the same as `github: org/repo`. 

What else?