### PR TITLE
local_git_repo ci source must implement method #trivial

### DIFF
--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -12,6 +12,10 @@ module Danger
       env.key? "DANGER_USE_LOCAL_GIT"
     end
 
+    def self.validates_as_pr?(_env)
+      false
+    end
+
     def git
       @git ||= GitRepo.new
     end

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -6,5 +6,15 @@ describe Danger::Executor do
         .to raise_error(SystemExit)
         .and output(/Could not find the type of CI/).to_stderr
     end
+
+    it "does not run Dangerfile when in ci env but no pr was identified" do
+      env = { "DANGER_USE_LOCAL_GIT" => "true" }
+      cork = double
+
+      expect(cork).to receive(:puts)
+      expect(Danger::Dangerfile).not_to receive(:new)
+
+      Danger::Executor.new(env).run(cork: cork)
+    end
   end
 end


### PR DESCRIPTION
validates_as_pr? must be implemented by each ci source, even the local
git repo.

This fixes a possible crash when running with `DANGER_USE_LOCAL_GIT` env var. Considering as #trivial since this is not happening to anyone?