### PR TITLE
Incremented version for next development iteration.

### DIFF
--- a/lib/danger/version.rb
+++ b/lib/danger/version.rb
@@ -1,4 +1,4 @@
 module Danger
-  VERSION = "3.1.1".freeze
+  VERSION = "3.2.0".freeze
   DESCRIPTION = "Like Unit Tests, but for your Team Culture.".freeze
 end


### PR DESCRIPTION
Version 3.1.1 has already been released. I'd like to increment master to 3.2.0 as #504 is a major change with a backward compatible deprecation, so I can lock the minimum danger version to something in https://github.com/ruby-grape/danger/pull/5.

#trivial