### PR TITLE
Improve docs for the core Danger plugin

### DIFF
--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -1,11 +1,8 @@
 require "danger/plugin_support/plugin"
 
 module Danger
-  # One way to support internal plugins is via `plugin.import` this gives you
-  # the chance to quickly iterate without the need for building rubygems. As such,
-  # it does not have the stringent rules around documentation expected of a public plugin.
-  # It's worth noting, that you can also have plugins inside `./danger_plugins` and they
-  # will be automatically imported into your Dangerfile at launch.
+  # A way to interact with Danger herself. Offering APIs to import plugins,
+  # and Dangerfiles from muliple sources.
   #
   # @example Import a plugin available over HTTP
   #
@@ -19,6 +16,18 @@ module Danger
   # @example Import all files inside a folder
   #
   #          danger.import_plugin("danger/plugins/*.rb")
+  #
+  # @example Run a Dangerfile from inside a sub-folder
+  #
+  #          danger.import_dangerfile(file: "danger/Dangerfile.private")
+  #
+  # @example Run a Dangerfile from inside a gem
+  #
+  #          danger.import_dangerfile(gem: "ruby-grape-danger")
+  #
+  # @example Run a Dangerfile from inside a repo
+  #
+  #          danger.import_dangerfile(gitlab: "ruby-grape/danger")
   #
   # @see  danger/danger
   # @tags core, plugins
@@ -53,7 +62,8 @@ module Danger
     # Import a Dangerfile.
     #
     # @param    [Hash] opts
-    # @option opts [String] :github Github path
+    # @option opts [String] :github GitHub repo
+    # @option opts [String] :gitlab GitLab repo
     # @option opts [String] :gem Gem name
     # @option opts [String] :path Path to Dangerfile
     # @return   [void]
@@ -62,8 +72,8 @@ module Danger
         warn "Use `import_dangerfile(github: '#{opts}')` instead of `import_dangerfile '#{opts}'`."
         import_dangerfile_from_github(opts)
       elsif opts.kind_of?(Hash)
-        if opts.key?(:github)
-          import_dangerfile_from_github(opts[:github])
+        if opts.key?(:github) || opts.key?(:gitlab)
+          import_dangerfile_from_github(opts[:github] || opts[:gitlab])
         elsif opts.key?(:path)
           import_dangerfile_from_path(opts[:path])
         elsif opts.key?(:gem)

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -77,6 +77,17 @@ describe Danger::Dangerfile::DSL, host: :github do
       expect(@dm.status_report[:messages]).to eq(["OK"])
     end
 
+    it "gitlab: 'repo/name'" do
+      outer_dangerfile = "danger.import_dangerfile(gitlab: 'example/example')"
+      inner_dangerfile = "message('OK')"
+
+      url = "https://raw.githubusercontent.com/example/example/master/Dangerfile"
+      stub_request(:get, url).to_return(status: 200, body: inner_dangerfile)
+
+      @dm.parse(Pathname.new("."), outer_dangerfile)
+      expect(@dm.status_report[:messages]).to eq(["OK"])
+    end
+
     it "path: 'path'" do
       outer_dangerfile = "danger.import_dangerfile(path: 'foo/bar')"
       inner_dangerfile = "message('OK')"


### PR DESCRIPTION
Improves the docs for the core plugin, and the import dangerfile from a repo would work in GitLab as well as Bucket via the same code.

#trivial