### PR TITLE
Improve handling of tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Improved the width handling for the output of the `danger local` table - orta 
+
 ## 3.2.0
 
 * add `file` and `line` optional parameters to methods on the messaging plugin - champo

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -123,12 +123,9 @@ module Danger
           when :pr_json
             value = "[Skipped]"
 
-          when :pr_body
-            value = plugin.send(method)
-            value = value.scan(/.{,80}/).to_a.each(&:strip!).join("\n")
-
           else
             value = plugin.send(method)
+            value = value.scan(/.{,80}/).to_a.each(&:strip!).join("\n")  if value.kind_of?(String)
             # So that we either have one value per row
             # or we have [] for an empty array
             value = value.join("\n") if value.kind_of?(Array) && value.count > 0
@@ -158,7 +155,9 @@ module Danger
 
       ui.section("Info:") do
         ui.puts
-        ui.puts Terminal::Table.new(params)
+        table = Terminal::Table.new(params)
+        table.align_column(0, :right)
+        ui.puts table
         ui.puts
       end
     end

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -125,7 +125,7 @@ module Danger
 
           else
             value = plugin.send(method)
-            value = value.scan(/.{,80}/).to_a.each(&:strip!).join("\n")  if value.kind_of?(String)
+            value = value.scan(/.{,80}/).to_a.each(&:strip!).join("\n") if value.kind_of?(String)
             # So that we either have one value per row
             # or we have [] for an empty array
             value = value.join("\n") if value.kind_of?(Array) && value.count > 0

--- a/lib/danger/version.rb
+++ b/lib/danger/version.rb
@@ -1,4 +1,4 @@
 module Danger
-  VERSION = "3.2.0".freeze
+  VERSION = "3.2.1".freeze
   DESCRIPTION = "Like Unit Tests, but for your Team Culture.".freeze
 end


### PR DESCRIPTION
 #322 shows us that the tables can  be really long. 

We all talked about how keeping track of the window size can help, but these tables are built of the data. So now, when we have a string, that string is capped at 80 chars. Meaning the tables will always be this long:

![screen shot 2016-09-03 at 5 30 35 pm](https://cloud.githubusercontent.com/assets/49038/18227731/ba0f350a-71fc-11e6-825d-a5666b1ea65f.png)

I think that's a reasonable enough size to not close the issue.