### PR TITLE
Mask password when inspect BitbucketServerAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Improved the width handling for the output of the `danger local` table - orta
 * Update comment & remove unused regexp name in request_source.rb - JuanitoFatas
+* Mask password on BitbucketServerAPI object - JuanitoFatas
 
 ## 3.2.0
 

--- a/lib/danger/request_source/bitbucket_server_api.rb
+++ b/lib/danger/request_source/bitbucket_server_api.rb
@@ -13,6 +13,16 @@ module Danger
         self.pr_api_endpoint = "https://#{host}/rest/api/1.0/projects/#{project}/repos/#{slug}/pull-requests/#{pull_request_id}"
       end
 
+      def inspect
+        inspected = super
+
+        if @password
+          inspected = inspected.sub! @password, "********".freeze
+        end
+
+        inspected
+      end
+
       def credentials_given?
         @username && !@username.empty? && @password && !@password.empty?
       end

--- a/spec/lib/danger/request_source/bitbucket_server_api_spec.rb
+++ b/spec/lib/danger/request_source/bitbucket_server_api_spec.rb
@@ -1,0 +1,12 @@
+describe Danger::RequestSources::BitbucketServerAPI, host: :bitbucket_server do
+  describe "#inspect" do
+    it "masks password on inspect" do
+      allow(ENV).to receive(:[]).with("ENVDANGER_BITBUCKETSERVER_PASSWORD") { "supertopsecret" }
+      api = described_class.new("danger", "danger", 1, stub_env)
+
+      inspected = api.inspect
+
+      expect(inspected).to include(%(@password="********"))
+    end
+  end
+end


### PR DESCRIPTION
I saw [octokit.rb did this](https://github.com/octokit/octokit.rb/blob/efceb79b2d1db92d908abbe62d4fb0f436240002/lib/octokit/client.rb#L122), and think this is a good feature to add 🔒, just in case someone did the `inspect`🕵.