### PR TITLE
[Core] Provide a way to check the active scm host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Improved the width handling for the output of the `danger local` table - orta
 * Update comment & remove unused regexp name in request_source.rb - JuanitoFatas
 * Mask password on BitbucketServerAPI object - JuanitoFatas
+* Add `scm_provider` to the DSL allowing users and plugins ot check which scm provider is being used when running danger - K0nserv
 
 ## 3.2.0
 

--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -86,6 +86,24 @@ module Danger
       end
     end
 
+    # @!group Danger
+    # Returns the name of the current SCM Provider being used.
+    # @return [Symbol] The name of the SCM Provider used for the active repository.
+    def scm_provider
+      return :unknown unless env.request_source
+
+      case env.request_source
+      when Danger::RequestSources::GitHub
+        :github
+      when Danger::RequestSources::GitLab
+        :gitlab
+      when Danger::RequestSources::BitbucketServer
+        :bitbucket_server
+      else
+        :unknown
+      end
+    end
+
     private
 
     # @!group Danger

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -127,7 +127,8 @@ describe Danger::Dangerfile, host: :github do
       dm = testing_dangerfile
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
       expect(methods).to eq [
-        :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files, :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title
+        :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files,
+        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider
       ]
     end
 
@@ -198,7 +199,7 @@ describe Danger::Dangerfile, host: :github do
           :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files, :deletions, :head_commit,
           :insertions, :lines_of_code, :modified_files,
           :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title,
-          :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title
+          :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider
         ]
       end
     end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -2,52 +2,50 @@ require "danger/danger_core/environment_manager"
 require "danger/danger_core/plugins/dangerfile_danger_plugin"
 
 describe Danger::Dangerfile::DSL, host: :github do
-  before do
-    @dm = testing_dangerfile
-  end
+  let(:dm) { testing_dangerfile }
 
   describe "#import" do
     describe "#import_local" do
       it "supports exact paths" do
-        @dm.danger.import_plugin("spec/fixtures/plugins/example_exact_path.rb")
+        dm.danger.import_plugin("spec/fixtures/plugins/example_exact_path.rb")
 
-        expect { @dm.example_exact_path }.to_not raise_error
-        expect(@dm.example_exact_path.echo).to eq("Hi there exact")
+        expect { dm.example_exact_path }.to_not raise_error
+        expect(dm.example_exact_path.echo).to eq("Hi there exact")
       end
 
       it "supports file globbing" do
-        @dm.danger.import_plugin("spec/fixtures/plugins/*globbing*.rb")
+        dm.danger.import_plugin("spec/fixtures/plugins/*globbing*.rb")
 
-        expect(@dm.example_globbing.echo).to eq("Hi there globbing")
+        expect(dm.example_globbing.echo).to eq("Hi there globbing")
       end
 
       # This is going to become a lot more complicated in the future, so I'm
       # happy to have it pending for now.
       xit "raises an error when calling a plugin that's not a subclass of Plugin" do
-        @dm.danger.import_plugin("spec/fixtures/plugins/example_broken.rb")
+        dm.danger.import_plugin("spec/fixtures/plugins/example_broken.rb")
 
         expect do
-          @dm.example_broken
+          dm.example_broken
         end.to raise_error("'example_broken' is not a valid danger plugin".red)
       end
     end
 
     describe "#import_url" do
       it "downloads a remote .rb file" do
-        expect { @dm.example_ping.echo }.to raise_error NoMethodError
+        expect { dm.example_ping.echo }.to raise_error NoMethodError
 
         url = "https://krausefx.com/example_remote.rb"
         stub_request(:get, "https://krausefx.com/example_remote.rb").
           to_return(status: 200, body: File.read("spec/fixtures/plugins/example_echo_plugin.rb"))
 
-        @dm.danger.import_plugin(url)
+        dm.danger.import_plugin(url)
 
-        expect(@dm.example_ping.echo).to eq("Hi there 🎉")
+        expect(dm.example_ping.echo).to eq("Hi there 🎉")
       end
 
       it "rejects unencrypted plugins" do
         expect do
-          @dm.danger.import_plugin("http://unencrypted.org")
+          dm.danger.import_plugin("http://unencrypted.org")
         end.to raise_error("URL is not https, for security reasons `danger` only supports encrypted requests")
       end
     end
@@ -61,9 +59,9 @@ describe Danger::Dangerfile::DSL, host: :github do
       url = "https://raw.githubusercontent.com/example/example/master/Dangerfile"
       stub_request(:get, url).to_return(status: 200, body: inner_dangerfile)
 
-      @dm.parse(Pathname.new("."), outer_dangerfile)
-      expect(@dm.status_report[:warnings]).to eq(["Use `import_dangerfile(github: 'example/example')` instead of `import_dangerfile 'example/example'`."])
-      expect(@dm.status_report[:messages]).to eq(["OK"])
+      dm.parse(Pathname.new("."), outer_dangerfile)
+      expect(dm.status_report[:warnings]).to eq(["Use `import_dangerfile(github: 'example/example')` instead of `import_dangerfile 'example/example'`."])
+      expect(dm.status_report[:messages]).to eq(["OK"])
     end
 
     it "github: 'repo/name'" do
@@ -73,8 +71,8 @@ describe Danger::Dangerfile::DSL, host: :github do
       url = "https://raw.githubusercontent.com/example/example/master/Dangerfile"
       stub_request(:get, url).to_return(status: 200, body: inner_dangerfile)
 
-      @dm.parse(Pathname.new("."), outer_dangerfile)
-      expect(@dm.status_report[:messages]).to eq(["OK"])
+      dm.parse(Pathname.new("."), outer_dangerfile)
+      expect(dm.status_report[:messages]).to eq(["OK"])
     end
 
     it "gitlab: 'repo/name'" do
@@ -84,8 +82,8 @@ describe Danger::Dangerfile::DSL, host: :github do
       url = "https://raw.githubusercontent.com/example/example/master/Dangerfile"
       stub_request(:get, url).to_return(status: 200, body: inner_dangerfile)
 
-      @dm.parse(Pathname.new("."), outer_dangerfile)
-      expect(@dm.status_report[:messages]).to eq(["OK"])
+      dm.parse(Pathname.new("."), outer_dangerfile)
+      expect(dm.status_report[:messages]).to eq(["OK"])
     end
 
     it "path: 'path'" do
@@ -93,8 +91,8 @@ describe Danger::Dangerfile::DSL, host: :github do
       inner_dangerfile = "message('OK')"
 
       expect(File).to receive(:open).with(Pathname.new("foo/bar/Dangerfile"), "r:utf-8").and_return(inner_dangerfile)
-      @dm.parse(Pathname.new("."), outer_dangerfile)
-      expect(@dm.status_report[:messages]).to eq(["OK"])
+      dm.parse(Pathname.new("."), outer_dangerfile)
+      expect(dm.status_report[:messages]).to eq(["OK"])
     end
 
     it "gem: 'name'" do
@@ -104,8 +102,34 @@ describe Danger::Dangerfile::DSL, host: :github do
       expect(File).to receive(:open).with(Pathname.new("/gems/foo/bar/Dangerfile"), "r:utf-8").and_return(inner_dangerfile)
       expect(Gem::Specification).to receive_message_chain(:find_by_name, :gem_dir).and_return("/gems/foo/bar")
 
-      @dm.parse(Pathname.new("."), outer_dangerfile)
-      expect(@dm.status_report[:messages]).to eq(["OK"])
+      dm.parse(Pathname.new("."), outer_dangerfile)
+      expect(dm.status_report[:messages]).to eq(["OK"])
+    end
+  end
+
+  describe "#scm_provider" do
+    context "GitHub", host: :github do
+      it "is `:github`" do
+        with_git_repo do
+          expect(dm.danger.scm_provider).to eq(:github)
+        end
+      end
+    end
+
+    context "GitLab", host: :gitlab do
+      it "is `:gitlab`" do
+        with_git_repo do
+          expect(dm.danger.scm_provider).to eq(:gitlab)
+        end
+      end
+    end
+
+    context "Bitbucket Server", host: :bitbucket_server do
+      it "is `:bitbucket_server`" do
+        with_git_repo do
+          expect(dm.danger.scm_provider).to eq(:bitbucket_server)
+        end
+      end
     end
   end
 end

--- a/spec/support/bitbucket_server_helper.rb
+++ b/spec/support/bitbucket_server_helper.rb
@@ -25,6 +25,25 @@ module Danger
         url = "https://stash.example.com/rest/api/1.0/projects/ios/repos/fancyapp/pull-requests/2080"
         WebMock.stub_request(:get, url).to_return(raw_file)
       end
+
+      def with_git_repo
+        Dir.mktmpdir do |dir|
+          Dir.chdir dir do
+            `git init`
+            File.open(dir + "/file1", "w") {}
+            `git add .`
+            `git commit -m "ok"`
+
+            `git checkout -b new`
+            File.open(dir + "/file2", "w") {}
+            `git add .`
+            `git commit -m "another"`
+            `git remote add origin git@stash.example.com:artsy/eigen`
+
+            yield
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Adds `scm_provider` to the DSL which will let users and plugins check
what the active scm_provider is. Example

```ruby
  if scm_provider == :gitlab do
    message("Running under gitlab")
  end
```