### PR TITLE
[GitLab] Update branch accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Update comment & remove unused regexp name in request_source.rb - JuanitoFatas
 * Mask password on BitbucketServerAPI object - JuanitoFatas
 * Add `scm_provider` to the DSL allowing users and plugins ot check which scm provider is being used when running danger - K0nserv
+* Deprecated `branch_for_merge` for GitLab. Use `branch_for_base` instead. - K0nserv
+* Added `branch_for_base` and `branch_for_head` for GitLab. - K0nserv
 
 ## 3.2.0
 

--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -120,10 +120,27 @@ module Danger
 
     # @!group MR Commit Metadata
     # The branch to which the MR is going to be merged into
+    # @deprecated Please use {#branch_for_base} instead
     # @return [String]
     #
     def branch_for_merge
+      branch_for_base
+    end
+
+    # @!group PR Commit Metadata
+    # The branch to which the PR is going to be merged into.
+    # @return [String]
+    #
+    def branch_for_base
       @gitlab.mr_json.target_branch
+    end
+
+    # @!group PR Commit Metadata
+    # The branch to which the PR is going to be merged from.
+    # @return [String]
+    #
+    def branch_for_head
+      @gitlab.mr_json.source_branch
     end
 
     # @!group MR Commit Metadata

--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -19,7 +19,9 @@ describe Danger::DangerfileGitLabPlugin, host: :gitlab do
     { method: :mr_body, expected_result: "The descriptions is here\r\n\r\n\u003e Danger: ignore \"Developer specific files shouldn't be changed\"\r\n\r\n\u003e Danger: ignore \"Testing\"" },
     { method: :mr_author, expected_result: "k0nserv" },
     { method: :mr_labels, expected_result: ["test-label"] },
-    { method: :branch_for_merge, expected_result: "master" }
+    { method: :branch_for_merge, expected_result: "master" },
+    { method: :branch_for_base, expected_result: "master" },
+    { method: :branch_for_head, expected_result: "mr-test" }
   ].each do |data|
     method = data[:method]
     expected = data[:expected_result]


### PR DESCRIPTION
Deprecated `branch_for_merge` in favour of `branch_for_base` and
add `branch_for_head`.