### PR TITLE
Fix for markdown crashing DM - fixes #520

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 
+* Fix for markdown accidentally crashing Danger when sending a message #520 - orta 
 * Improved the width handling for the output of the `danger local` table - orta 
 * Added a check for the merge inflection point inside the diff, and will fetch it if needed - orta 
 * Improved the width handling for the output of the `danger local` table - orta

--- a/lib/danger/danger_core/messages/markdown.rb
+++ b/lib/danger/danger_core/messages/markdown.rb
@@ -17,6 +17,10 @@ module Danger
         other.line == line
     end
 
+    def inline?
+      return (file.nil? && line.nil?) == false
+    end
+
     def to_s
       extra = []
       extra << "file: #{file}" unless file.nil?

--- a/spec/lib/danger/request_source/github_spec.rb
+++ b/spec/lib/danger/request_source/github_spec.rb
@@ -267,8 +267,8 @@ describe Danger::RequestSources::GitHub, host: :github do
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_2).and_return({})
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", main_issue_id).and_return({})
 
-        v = Danger::Violation.new("Sure thing", true, "CHANGELOG.md", 4)
-        @g.update_pull_request!(warnings: [], errors: [], messages: [v])
+        m = Danger::Markdown.new("Sure thing", "CHANGELOG.md", 4)
+        @g.update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [m])
       end
 
       it "removes inline comments if they are not included" do


### PR DESCRIPTION
In my head, all message types were `Violation` but not Markdowns, they're a different class. Now they both have the same function determining if it's an inline object or not.

I made sure that existing tests cover this case, rather than adding a specific test for the crash.