### PR TITLE
Add `markdown_link` for the Bitbucket Server plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Link to https://danger.systems/ in Bitbucket Server comments - HeEAaD
+* Add `markdown_link` for the Bitbucket Server plugin - HeEAaD
 
 ## 3.2.1
 

--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
@@ -150,6 +150,26 @@ module Danger
     # @return [String]
     #
     def html_link(paths, full_path: true)
+      create_link(paths, full_path) { |href, text| create_html_link(href, text) }
+    end
+
+    # @!group Bitbucket Server Misc
+    # Returns a list of Markdown links for a file, or files in the head repository.
+    # It returns a string of multiple links if passed an array.
+    # @param    [String or Array<String>] paths
+    #           A list of strings to convert to Markdown links
+    # @param    [Bool] full_path
+    #           Shows the full path as the link's text, defaults to `true`.
+    #
+    # @return [String]
+    #
+    def markdown_link(paths, full_path: true)
+      create_link(paths, full_path) { |href, text| create_markdown_link(href, text) }
+    end
+
+    private
+
+    def create_link(paths, full_path)
       paths = [paths] unless paths.kind_of?(Array)
       commit = head_commit
       repo = pr_json[:fromRef][:repository][:links][:self].flat_map { |l| l[:href] }.first
@@ -160,17 +180,19 @@ module Danger
         text = full_path ? path : File.basename(path)
         url_path.gsub!(" ", "%20")
         line_ref = line ? "##{line}" : ""
-        create_link("#{repo}/browse/#{url_path}?at=#{commit}#{line_ref}", text)
+        yield("#{repo}/browse/#{url_path}?at=#{commit}#{line_ref}", text)
       end
 
       return paths.first if paths.count < 2
       paths.first(paths.count - 1).join(", ") + " & " + paths.last
     end
 
-    private
-
-    def create_link(href, text)
+    def create_html_link(href, text)
       "<a href='#{href}'>#{text}</a>"
+    end
+
+    def create_markdown_link(href, text)
+      "[#{text}](#{href})"
     end
   end
 end

--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
@@ -180,7 +180,7 @@ module Danger
         text = full_path ? path : File.basename(path)
         url_path.gsub!(" ", "%20")
         line_ref = line ? "##{line}" : ""
-        yield("#{repo}/browse/#{url_path}?at=#{commit}#{line_ref}", text)
+        yield("#{repo}#{url_path}?at=#{commit}#{line_ref}", text)
       end
 
       return paths.first if paths.count < 2

--- a/spec/lib/danger/plugins/dangerfile_bitbucket_server_plugin_spec.rb
+++ b/spec/lib/danger/plugins/dangerfile_bitbucket_server_plugin_spec.rb
@@ -62,7 +62,7 @@ describe Danger::DangerfileBitbucketServerPlugin, host: :bitbucket_server do
     end
 
     describe "#html_link" do
-      it "creates a usable link" do
+      it "creates a usable html link" do
         expect(plugin.html_link("Classes/Main Categories/Feed/FeedViewController.m")).to include(
           "<a href='https://stash.example.com/projects/IOS/repos/fancyapp/browse/browse//Classes/Main%20Categories/Feed/FeedViewController.m?at=c50b3f61e90dac6a00b7d0c92e415a4348bb280a'>Classes/Main Categories/Feed/FeedViewController.m</a>"
         )
@@ -71,6 +71,14 @@ describe Danger::DangerfileBitbucketServerPlugin, host: :bitbucket_server do
       it "handles #XX line numbers in the same format a the other plugins" do
         expect(plugin.html_link("Classes/Main Categories/Feed/FeedViewController.m#100")).to include(
           "<a href='https://stash.example.com/projects/IOS/repos/fancyapp/browse/browse//Classes/Main%20Categories/Feed/FeedViewController.m?at=c50b3f61e90dac6a00b7d0c92e415a4348bb280a#100'>Classes/Main Categories/Feed/FeedViewController.m</a>"
+        )
+      end
+    end
+
+    describe "#markdown_link" do
+      it "creates a usable markdown link" do
+        expect(plugin.markdown_link("Classes/Main Categories/Feed/FeedViewController.m")).to include(
+          "[Classes/Main Categories/Feed/FeedViewController.m](https://stash.example.com/projects/IOS/repos/fancyapp/browse/browse//Classes/Main%20Categories/Feed/FeedViewController.m?at=c50b3f61e90dac6a00b7d0c92e415a4348bb280a)"
         )
       end
     end

--- a/spec/lib/danger/plugins/dangerfile_bitbucket_server_plugin_spec.rb
+++ b/spec/lib/danger/plugins/dangerfile_bitbucket_server_plugin_spec.rb
@@ -64,13 +64,13 @@ describe Danger::DangerfileBitbucketServerPlugin, host: :bitbucket_server do
     describe "#html_link" do
       it "creates a usable html link" do
         expect(plugin.html_link("Classes/Main Categories/Feed/FeedViewController.m")).to include(
-          "<a href='https://stash.example.com/projects/IOS/repos/fancyapp/browse/browse//Classes/Main%20Categories/Feed/FeedViewController.m?at=c50b3f61e90dac6a00b7d0c92e415a4348bb280a'>Classes/Main Categories/Feed/FeedViewController.m</a>"
+          "<a href='https://stash.example.com/projects/IOS/repos/fancyapp/browse/Classes/Main%20Categories/Feed/FeedViewController.m?at=c50b3f61e90dac6a00b7d0c92e415a4348bb280a'>Classes/Main Categories/Feed/FeedViewController.m</a>"
         )
       end
 
       it "handles #XX line numbers in the same format a the other plugins" do
         expect(plugin.html_link("Classes/Main Categories/Feed/FeedViewController.m#100")).to include(
-          "<a href='https://stash.example.com/projects/IOS/repos/fancyapp/browse/browse//Classes/Main%20Categories/Feed/FeedViewController.m?at=c50b3f61e90dac6a00b7d0c92e415a4348bb280a#100'>Classes/Main Categories/Feed/FeedViewController.m</a>"
+          "<a href='https://stash.example.com/projects/IOS/repos/fancyapp/browse/Classes/Main%20Categories/Feed/FeedViewController.m?at=c50b3f61e90dac6a00b7d0c92e415a4348bb280a#100'>Classes/Main Categories/Feed/FeedViewController.m</a>"
         )
       end
     end
@@ -78,7 +78,7 @@ describe Danger::DangerfileBitbucketServerPlugin, host: :bitbucket_server do
     describe "#markdown_link" do
       it "creates a usable markdown link" do
         expect(plugin.markdown_link("Classes/Main Categories/Feed/FeedViewController.m")).to include(
-          "[Classes/Main Categories/Feed/FeedViewController.m](https://stash.example.com/projects/IOS/repos/fancyapp/browse/browse//Classes/Main%20Categories/Feed/FeedViewController.m?at=c50b3f61e90dac6a00b7d0c92e415a4348bb280a)"
+          "[Classes/Main Categories/Feed/FeedViewController.m](https://stash.example.com/projects/IOS/repos/fancyapp/browse/Classes/Main%20Categories/Feed/FeedViewController.m?at=c50b3f61e90dac6a00b7d0c92e415a4348bb280a)"
         )
       end
     end


### PR DESCRIPTION
I check if Bitbucket server supports inline HTML in comments: Unfortunately not.
For that reason I added `markdown_link` for the Bitbucket Server plugin.

