### PR TITLE
Add per-file info (insertions, deletions, before/after contents)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Add `git.info_for_file("some/file.txt")`: line counts and before/after file contents - tikitu
+
 ## 3.2.2
 
 * Link to https://danger.systems/ in Bitbucket Server comments - HeEAaD

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -120,7 +120,15 @@ module Danger
     # @return [Hash] with keys `:insertions`, `:deletions` giving line counts, or nil if the file has no changes or does not exist
     #
     def info_for_file(file)
-      modified_files.include?(file) ? @git.diff.stats[:files][file] : nil
+      return nil unless modified_files.include?(file)
+      stats = @git.diff.stats[:files][file]
+      diff = @git.diff[file]
+      {
+        :insertions => stats[:insertions],
+        :deletions => stats[:deletions],
+        :before => diff.blob(:src).contents,
+        :after => diff.blob(:dst).contents
+      }
     end
   end
 end

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -119,7 +119,7 @@ module Danger
     # Statistics for a specific file in this diff
     # @return [Hash] with keys `:insertions`, `:deletions` giving line counts, or nil if the file has no changes or does not exist
     #
-    def stats_for_file(file)
+    def info_for_file(file)
       modified_files.include?(file) ? @git.diff.stats[:files][file] : nil
     end
   end

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -124,10 +124,10 @@ module Danger
       stats = @git.diff.stats[:files][file]
       diff = @git.diff[file]
       {
-        :insertions => stats[:insertions],
-        :deletions => stats[:deletions],
-        :before => diff.blob(:src).contents,
-        :after => diff.blob(:dst).contents
+        insertions: stats[:insertions],
+        deletions: stats[:deletions],
+        before: diff.blob(:src).contents,
+        after: diff.blob(:dst).contents
       }
     end
   end

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -117,7 +117,7 @@ module Danger
 
     # @!group Git Metadata
     # Statistics for a specific file in this diff
-    # @return [Hash] with keys `:insertions`, `:deletions` giving line counts, or nil if the file has no changes or does not exist
+    # @return [Hash] with keys `:insertions`, `:deletions` giving line counts, and `:before`, `:after` giving file contents, or nil if the file has no changes or does not exist
     #
     def info_for_file(file)
       return nil unless modified_files.include?(file)

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -114,5 +114,13 @@ module Danger
     def diff_for_file(file)
       modified_files.include?(file) ? @git.diff[file] : nil
     end
+
+    # @!group Git Metadata
+    # Statistics for a specific file in this diff
+    # @return {:insertions => [Fixnum], :deletions => [Fixnum]} or nil
+    #
+    def stats_for_file(file)
+      modified_files.include?(file) ? @git.diff.stats[:files][file] : nil
+    end
   end
 end

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -117,7 +117,7 @@ module Danger
 
     # @!group Git Metadata
     # Statistics for a specific file in this diff
-    # @return {:insertions => [Fixnum], :deletions => [Fixnum]} or nil
+    # @return [Hash] with keys `:insertions`, `:deletions` giving line counts, or nil if the file has no changes or does not exist
     #
     def stats_for_file(file)
       modified_files.include?(file) ? @git.diff.stats[:files][file] : nil

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -128,7 +128,7 @@ describe Danger::Dangerfile, host: :github do
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
       expect(methods).to eq [
         :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files,
-        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider
+        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider, :stats_for_file
       ]
     end
 

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -128,7 +128,7 @@ describe Danger::Dangerfile, host: :github do
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
       expect(methods).to eq [
         :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files,
-        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider, :stats_for_file
+        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider
       ]
     end
 

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -99,6 +99,27 @@ module Danger
           end
         end
       end
+
+      describe "getting stats for a specific file" do
+        it "returns nil when specific stats do not exist" do
+          run_in_repo_with_diff do |git|
+            diff = git.diff("master")
+            allow(@repo).to receive(:diff).and_return(diff)
+            expect(@dsl.stats_for_file("file_nope_no_way")).to be_nil
+          end
+        end
+
+        it "gets a specific diff" do
+          run_in_repo_with_diff do |git|
+            diff = git.diff("master")
+            allow(@repo).to receive(:diff).and_return(diff)
+            stats = @dsl.stats_for_file("file2")
+            expect(stats).to_not be_nil
+            expect(stats[:insertions]).to_not be_nil
+            expect(stats[:deletions]).to_not be_nil
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -100,12 +100,12 @@ module Danger
         end
       end
 
-      describe "getting stats for a specific file" do
-        it "returns nil when specific stats do not exist" do
+      describe "getting info for a specific file" do
+        it "returns nil when specific info does not exist" do
           run_in_repo_with_diff do |git|
             diff = git.diff("master")
             allow(@repo).to receive(:diff).and_return(diff)
-            expect(@dsl.stats_for_file("file_nope_no_way")).to be_nil
+            expect(@dsl.info_for_file("file_nope_no_way")).to be_nil
           end
         end
 
@@ -113,10 +113,10 @@ module Danger
           run_in_repo_with_diff do |git|
             diff = git.diff("master")
             allow(@repo).to receive(:diff).and_return(diff)
-            stats = @dsl.stats_for_file("file2")
-            expect(stats).to_not be_nil
-            expect(stats[:insertions]).to_not be_nil
-            expect(stats[:deletions]).to_not be_nil
+            info = @dsl.info_for_file("file2")
+            expect(info).to_not be_nil
+            expect(info[:insertions]).to_not be_nil
+            expect(info[:deletions]).to_not be_nil
           end
         end
       end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -110,42 +110,16 @@ module Danger
           end
         end
 
-        it "gets a specific diff" do
+        it "returns file info when it exists" do
           run_in_repo_with_diff do |git|
             diff = git.diff("master")
             allow(@repo).to receive(:diff).and_return(diff)
             info = @dsl.info_for_file("file2")
             expect(info).to_not be_nil
-            expect(info[:insertions]).to_not be_nil
-            expect(info[:deletions]).to_not be_nil
-            expect(info[:before]).to_not be_nil
-            expect(info[:after]).to_not be_nil
-          end
-        end
-
-        context "the info for file2" do
-          before(:each) do
-            run_in_repo_with_diff do |git|
-              diff = git.diff("master")
-              allow(@repo).to receive(:diff).and_return(diff)
-              @info = @dsl.info_for_file("file2")
-            end
-          end
-
-          it "reports :insertions" do
-            expect(@info[:insertions]).to equal(1)
-          end
-
-          it "reports :deletions" do
-            expect(@info[:deletions]).to equal(2)
-          end
-
-          it "reports :before" do
-            expect(@info[:before]).to eq("Shorts.\nShoes.")
-          end
-
-          it "reports :after" do
-            expect(@info[:after]).to eq("Pants!")
+            expect(info[:insertions]).to equal(1)
+            expect(info[:deletions]).to equal(2)
+            expect(info[:before]).to eq("Shorts.\nShoes.")
+            expect(info[:after]).to eq("Pants!")
           end
         end
       end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -5,6 +5,7 @@ def run_in_repo_with_diff
     Dir.chdir dir do
       `git init`
       File.open(dir + "/file1", "w") { |f| f.write "More buritto please." }
+      File.open(dir + "/file2", "w") { |f| f.write "Shorts.\nShoes." }
       `git add .`
       `git commit -m "adding file1"`
       `git checkout -b new-branch`
@@ -117,6 +118,34 @@ module Danger
             expect(info).to_not be_nil
             expect(info[:insertions]).to_not be_nil
             expect(info[:deletions]).to_not be_nil
+            expect(info[:before]).to_not be_nil
+            expect(info[:after]).to_not be_nil
+          end
+        end
+
+        context "the info for file2" do
+          before(:each) do
+            run_in_repo_with_diff do |git|
+              diff = git.diff("master")
+              allow(@repo).to receive(:diff).and_return(diff)
+              @info = @dsl.info_for_file("file2")
+            end
+          end
+
+          it "reports :insertions" do
+            expect(@info[:insertions]).to equal(1)
+          end
+
+          it "reports :deletions" do
+            expect(@info[:deletions]).to equal(2)
+          end
+
+          it "reports :before" do
+            expect(@info[:before]).to eq("Shorts.\nShoes.")
+          end
+
+          it "reports :after" do
+            expect(@info[:after]).to eq("Pants!")
           end
         end
       end


### PR DESCRIPTION
This is very closely modeled on the `diff_for_file` support (read: code search and copy/paste).