### PR TITLE
Remove unknown passings of nils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `git.info_for_file("some/file.txt")`: line counts and before/after file contents - tikitu
 * Remove `String#danger_class` - Juanito Fatas
+* Set defaults for file and line args of Violation#new & Markdown#new - Juanito Fatas
 
 ## 3.2.2
 

--- a/lib/danger/danger_core/messages/markdown.rb
+++ b/lib/danger/danger_core/messages/markdown.rb
@@ -2,7 +2,7 @@ module Danger
   class Markdown
     attr_accessor :message, :file, :line
 
-    def initialize(message, file, line)
+    def initialize(message, file = nil, line = nil)
       self.message = message
       self.file = file
       self.line = line
@@ -17,16 +17,17 @@ module Danger
         other.line == line
     end
 
+    # @return [Boolean] returns true if is a file or line, false otherwise
     def inline?
-      return (file.nil? && line.nil?) == false
+      file || line
     end
 
     def to_s
       extra = []
-      extra << "file: #{file}" unless file.nil?
-      extra << "line: #{line}" unless line.nil?
+      extra << "file: #{file}" unless file
+      extra << "line: #{line}" unless line
 
-      "Markdown #{message} { #{extra.join ', '} }"
+      "Markdown #{message} { #{extra.join ', '.freeze} }"
     end
   end
 end

--- a/lib/danger/danger_core/messages/violation.rb
+++ b/lib/danger/danger_core/messages/violation.rb
@@ -2,7 +2,7 @@ module Danger
   class Violation
     attr_accessor :message, :sticky, :file, :line
 
-    def initialize(message, sticky, file, line)
+    def initialize(message, sticky, file = nil, line = nil)
       self.message = message
       self.sticky = sticky
       self.file = file
@@ -19,17 +19,18 @@ module Danger
         other.line == line
     end
 
+    # @return [Boolean] returns true if is a file or line, false otherwise
     def inline?
-      return (file.nil? && line.nil?) == false
+      file || line
     end
 
     def to_s
       extra = []
       extra << "sticky: true" if sticky
-      extra << "file: #{file}" unless file.nil?
-      extra << "line: #{line}" unless line.nil?
+      extra << "file: #{file}" unless file
+      extra << "line: #{line}" unless line
 
-      "Violation #{message} { #{extra.join ', '} }"
+      "Violation #{message} { #{extra.join ', '.freeze} }"
     end
   end
 end

--- a/lib/danger/helpers/comments_parsing_helper.rb
+++ b/lib/danger/helpers/comments_parsing_helper.rb
@@ -9,7 +9,7 @@ module Danger
       #
       # @return [Violation or Markdown] the extracted message
       def parse_message_from_row(row)
-        Violation.new(row, true, nil, nil)
+        Violation.new(row, true)
       end
 
       def parse_tables_from_comment(comment)

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -364,13 +364,13 @@ describe Danger::Helpers::CommentsHelper do
     end
 
     it "sets data-sticky to true when a violation is sticky" do
-      sticky_warning = Danger::Violation.new("my warning", true, nil, nil)
+      sticky_warning = Danger::Violation.new("my warning", true)
       result = dummy.generate_comment(warnings: [sticky_warning], errors: [], messages: [])
       expect(result.gsub(/\s+/, "")).to include('tddata-sticky="true"')
     end
 
     it "sets data-sticky to false when a violation is not sticky" do
-      non_sticky_warning = Danger::Violation.new("my warning", false, nil, nil)
+      non_sticky_warning = Danger::Violation.new("my warning", false)
       result = dummy.generate_comment(warnings: [non_sticky_warning], errors: [], messages: [])
       expect(result.gsub(/\s+/, "")).to include('tddata-sticky="false"')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,7 +72,7 @@ def diff_fixture(file)
 end
 
 def violation(message, sticky: false)
-  Danger::Violation.new(message, sticky, nil, nil)
+  Danger::Violation.new(message, sticky)
 end
 
 def violations(messages, sticky: false)
@@ -80,7 +80,7 @@ def violations(messages, sticky: false)
 end
 
 def markdown(message)
-  Danger::Markdown.new(message, nil, nil)
+  Danger::Markdown.new(message)
 end
 
 def markdowns(messages)


### PR DESCRIPTION
Reading danger/danger code before goes to 😴 , pondering what these `nil`s are. So let's set nil-defaults for them and remove some calls 🔪 