### PR TITLE
Save Comment class out of CommentsHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Remove `String#danger_class` - Juanito Fatas
 * Set defaults for file and line args of Violation#new & Markdown#new - Juanito Fatas
 * Add docs to `String#danger_pluralize` & `String#danger_underscore` - Juanito Fatas
+* Refactor Comment class out of CommentsHelper - Juanito Fatas
 
 ## 3.2.2
 

--- a/lib/danger/helpers/comment.rb
+++ b/lib/danger/helpers/comment.rb
@@ -1,0 +1,22 @@
+module Danger
+  class Comment
+    attr_reader :id, :body
+
+    def initialize(id, body)
+      @id = id
+      @body = body
+    end
+
+    def self.from_github(comment)
+      self.new(comment[:id], comment[:body])
+    end
+
+    def self.from_gitlab(comment)
+      self.new(comment.id, comment.body)
+    end
+
+    def generated_by_danger?(danger_id)
+      body.include?("generated_by_#{danger_id}")
+    end
+  end
+end

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -180,27 +180,6 @@ module Danger
 
         return NEW_REGEX.match(table)
       end
-
-      class Comment
-        attr_reader :id, :body
-
-        def initialize(id, body)
-          @id = id
-          @body = body
-        end
-
-        def self.from_github(comment)
-          self.new(comment[:id], comment[:body])
-        end
-
-        def self.from_gitlab(comment)
-          self.new(comment.id, comment.body)
-        end
-
-        def generated_by_danger?(danger_id)
-          body.include?("generated_by_#{danger_id}")
-        end
-      end
     end
   end
 end

--- a/lib/danger/request_source/github.rb
+++ b/lib/danger/request_source/github.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 require "octokit"
 require "danger/helpers/comments_helper"
+require "danger/helpers/comment"
 
 module Danger
   module RequestSources

--- a/lib/danger/request_source/gitlab.rb
+++ b/lib/danger/request_source/gitlab.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 require "gitlab"
 require "danger/helpers/comments_helper"
+require "danger/helpers/comment"
 
 module Danger
   module RequestSources

--- a/spec/danger/helpers/comment_spec.rb
+++ b/spec/danger/helpers/comment_spec.rb
@@ -1,0 +1,38 @@
+require "danger/helpers/comment"
+
+describe Danger::Comment do
+  describe ".from_github" do
+    it "initializes with GitHub comment data structure" do
+      github_comment = { id: 42, body: "github comment" }
+
+      result = described_class.from_github(github_comment)
+
+      expect(result).to have_attributes(id: 42, body: "github comment")
+    end
+  end
+
+  describe ".from_gitlab" do
+    it "initializes with Gitlab comment data structure" do
+      GitlabComment = Struct.new(:id, :body)
+      gitlab_comment = GitlabComment.new(42, "gitlab comment")
+
+      result = described_class.from_gitlab(gitlab_comment)
+
+      expect(result).to have_attributes(id: 42, body: "gitlab comment")
+    end
+  end
+
+  describe "#generated_by_danger?" do
+    it "returns true when body contains generated_by_{identifier}" do
+      comment = described_class.new(42, "generated_by_orta")
+
+      expect(comment.generated_by_danger?("orta")).to be true
+    end
+
+    it "returns false when body NOT contains generated_by_{identifier}" do
+      comment = described_class.new(42, "generated_by_orta")
+
+      expect(comment.generated_by_danger?("artsy")).to be false
+    end
+  end
+end


### PR DESCRIPTION
This PR extracts `Comment` from `CommentsHelper`, benefits:

- Decouple from module
- More tests coverage

My future goal is to make:

- `lib/danger/request_source/github.rb`
- `lib/danger/request_source/gitlab.rb`

them be easily tested.

This is part of the work 🚧 to achieve the goal along the way 🛤.
