### PR TITLE
Adds support for bitbucket cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Set defaults for file and line args of Violation#new & Markdown#new - Juanito Fatas
 * Add docs to `String#danger_pluralize` & `String#danger_underscore` - Juanito Fatas
 * Refactor Comment class out of CommentsHelper - Juanito Fatas
+* Add support for Bitbucket Cloud - Wolfgang Damm
 
 ## 3.2.2
 

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -38,7 +38,7 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab, Danger::RequestSources::BitbucketServer]
+      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab, Danger::RequestSources::BitbucketServer, Danger::RequestSources::BitbucketCloud]
     end
 
     def initialize(env)

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -9,6 +9,7 @@ require "danger/danger_core/plugins/dangerfile_git_plugin"
 require "danger/danger_core/plugins/dangerfile_github_plugin"
 require "danger/danger_core/plugins/dangerfile_gitlab_plugin"
 require "danger/danger_core/plugins/dangerfile_bitbucket_server_plugin"
+require "danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin"
 
 module Danger
   class Dangerfile
@@ -36,7 +37,7 @@ module Danger
 
     # The ones that everything would break without
     def self.essential_plugin_classes
-      [DangerfileMessagingPlugin, DangerfileGitPlugin, DangerfileDangerPlugin, DangerfileGitHubPlugin, DangerfileGitLabPlugin, DangerfileBitbucketServerPlugin]
+      [DangerfileMessagingPlugin, DangerfileGitPlugin, DangerfileDangerPlugin, DangerfileGitHubPlugin, DangerfileGitLabPlugin, DangerfileBitbucketServerPlugin, DangerfileBitbucketCloudPlugin]
     end
 
     # Both of these methods exist on all objects

--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
@@ -1,0 +1,198 @@
+# coding: utf-8
+require "danger/plugin_support/plugin"
+
+module Danger
+  # Handles interacting with Bitbucket Cloud inside a Dangerfile. Provides a few functions which wrap `pr_json` and also
+  # through a few standard functions to simplify your code.
+  #
+  # @example Warn when a PR is classed as work in progress
+  #
+  #          warn "PR is classed as Work in Progress" if bitbucket_cloud.pr_title.include? "[WIP]"
+  #
+  # @example Declare a PR to be simple to avoid specific Danger rules
+  #
+  #          declared_trivial = (bitbucket_cloud.pr_title + bitbucket_cloud.pr_body).include?("#trivial")
+  #
+  # @example Ensure that labels have been used on the PR
+  #
+  #          fail "Please add labels to this PR" if bitbucket_cloud.pr_labels.empty?
+  #
+  # @example Ensure there is a summary for a PR
+  #
+  #          fail "Please provide a summary in the Pull Request description" if bitbucket_cloud.pr_body.length < 5
+  #
+  # @example Only accept PRs to the develop branch
+  #
+  #          fail "Please re-submit this PR to develop, we may have already fixed your issue." if bitbucket_cloud.branch_for_base != "develop"
+  #
+  # @example Highlight when a celebrity makes a pull request
+  #
+  #          message "Welcome, Danger." if bitbucket_cloud.pr_author == "dangermcshane"
+  #
+  # @example Ensure that all PRs have an assignee
+  #
+  #          warn "This PR does not have any assignees yet." unless bitbucket_cloud.pr_json["reviewers"].length == 0
+  #
+  # @example Send a message with links to a collection of specific files
+  #
+  #          if git.modified_files.include? "config/*.js"
+  #            config_files = git.modified_files.select { |path| path.include? "config/" }
+  #            message "This PR changes #{ bitbucket_cloud.html_link(config_files) }"
+  #          end
+  #
+  # @example Highlight with a clickable link if a Package.json is changed
+  #
+  #         warn "#{bitbucket_cloud.html_link("Package.json")} was edited." if git.modified_files.include? "Package.json"
+  #
+  # @see  danger/danger
+  # @tags core, bitbucket_cloud
+  #
+  class DangerfileBitbucketCloudPlugin < Plugin
+    # So that this init can fail.
+    def self.new(dangerfile)
+      return nil if dangerfile.env.request_source.class != Danger::RequestSources::BitbucketCloud
+      super
+    end
+
+    # The instance name used in the Dangerfile
+    # @return [String]
+    #
+    def self.instance_name
+      "bitbucket_cloud"
+    end
+
+    def initialize(dangerfile)
+      super(dangerfile)
+      @bs = dangerfile.env.request_source
+    end
+
+    # @!group Bitbucket Cloud Misc
+    # The hash that represents the PR's JSON. For an example of what this looks like
+    # see the [Danger Fixture'd one](https://raw.githubusercontent.com/danger/danger/master/spec/fixtures/bitbucket_cloud_api/pr_response.json).
+    # @return [Hash]
+    def pr_json
+      @bs.pr_json
+    end
+
+    # @!group PR Metadata
+    # The title of the Pull Request.
+    # @return [String]
+    #
+    def pr_title
+      @bs.pr_json[:title].to_s
+    end
+
+    # @!group PR Metadata
+    # The body text of the Pull Request.
+    # @return [String]
+    #
+    def pr_description
+      @bs.pr_json[:description].to_s
+    end
+    alias pr_body pr_description
+
+    # @!group PR Metadata
+    # The username of the author of the Pull Request.
+    # @return [String]
+    #
+    def pr_author
+      @bs.pr_json[:author][:user][:slug].to_s
+    end
+
+    # @!group PR Commit Metadata
+    # The branch to which the PR is going to be merged into.
+    # @return [String]
+    #
+    def branch_for_base
+      @bs.pr_json[:toRef][:displayId].to_s
+    end
+
+    # @!group PR Commit Metadata
+    # A href that represents the current PR
+    # @return [String]
+    #
+    def pr_link
+      @bs.pr_json[:links][:self].flat_map { |l| l[:href] }.first.to_s
+    end
+
+    # @!group PR Commit Metadata
+    # The branch to which the PR is going to be merged from.
+    # @return [String]
+    #
+    def branch_for_head
+      @bs.pr_json[:fromRef][:displayId].to_s
+    end
+
+    # @!group PR Commit Metadata
+    # The base commit to which the PR is going to be merged as a parent.
+    # @return [String]
+    #
+    def base_commit
+      @bs.pr_json[:toRef][:latestCommit].to_s
+    end
+
+    # @!group PR Commit Metadata
+    # The head commit to which the PR is requesting to be merged from.
+    # @return [String]
+    #
+    def head_commit
+      @bs.pr_json[:fromRef][:latestCommit].to_s
+    end
+
+    # @!group Bitbucket Cloud Misc
+    # Returns a list of HTML anchors for a file, or files in the head repository.
+    # It returns a string of multiple anchors if passed an array.
+    # @param    [String or Array<String>] paths
+    #           A list of strings to convert to github anchors
+    # @param    [Bool] full_path
+    #           Shows the full path as the link's text, defaults to `true`.
+    #
+    # @return [String]
+    #
+    def html_link(paths, full_path: true)
+      create_link(paths, full_path) { |href, text| create_html_link(href, text) }
+    end
+
+    # @!group Bitbucket Cloud Misc
+    # Returns a list of Markdown links for a file, or files in the head repository.
+    # It returns a string of multiple links if passed an array.
+    # @param    [String or Array<String>] paths
+    #           A list of strings to convert to Markdown links
+    # @param    [Bool] full_path
+    #           Shows the full path as the link's text, defaults to `true`.
+    #
+    # @return [String]
+    #
+    def markdown_link(paths, full_path: true)
+      create_link(paths, full_path) { |href, text| create_markdown_link(href, text) }
+    end
+
+    private
+
+    def create_link(paths, full_path)
+      paths = [paths] unless paths.kind_of?(Array)
+      commit = head_commit
+      repo = pr_json[:fromRef][:repository][:links][:self].flat_map { |l| l[:href] }.first
+
+      paths = paths.map do |path|
+        path, line = path.split("#")
+        url_path = path.start_with?("/") ? path : "/#{path}"
+        text = full_path ? path : File.basename(path)
+        url_path.gsub!(" ", "%20")
+        line_ref = line ? "##{line}" : ""
+        yield("#{repo}#{url_path}?at=#{commit}#{line_ref}", text)
+      end
+
+      return paths.first if paths.count < 2
+      paths.first(paths.count - 1).join(", ") + " & " + paths.last
+    end
+
+    def create_html_link(href, text)
+      "<a href='#{href}'>#{text}</a>"
+    end
+
+    def create_markdown_link(href, text)
+      "[#{text}](#{href})"
+    end
+  end
+end

--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -99,6 +99,8 @@ module Danger
         :gitlab
       when Danger::RequestSources::BitbucketServer
         :bitbucket_server
+      when Danger::RequestSources::BitbucketCloud
+        :bitbucket_cloud
       else
         :unknown
       end

--- a/lib/danger/request_source/bitbucket_cloud.rb
+++ b/lib/danger/request_source/bitbucket_cloud.rb
@@ -1,0 +1,78 @@
+# coding: utf-8
+require "danger/helpers/comments_helper"
+
+module Danger
+  module RequestSources
+    class BitbucketCloud < RequestSource
+      include Danger::Helpers::CommentsHelper
+      attr_accessor :pr_json
+
+      def initialize(ci_source, environment)
+        self.ci_source = ci_source
+        self.environment = environment
+
+        project, slug = ci_source.repo_slug.split("/")
+        @api = BitbucketCloudAPI.new(project, slug, ci_source.pull_request_id, environment)
+      end
+
+      def validates_as_ci?
+        # TODO: ???
+        true
+      end
+
+      def validates_as_api_source?
+        @api.credentials_given?
+      end
+
+      def scm
+        @scm ||= GitRepo.new
+      end
+
+      def host
+        @host ||= @api.host
+      end
+
+      def fetch_details
+        self.pr_json = @api.fetch_pr_json
+      end
+
+      def setup_danger_branches
+        base_commit = self.pr_json[:destination][:commit][:hash]
+        head_commit = self.pr_json[:source][:commit][:hash]
+
+        # Next, we want to ensure that we have a version of the current branch at a known location
+        self.scm.exec "branch #{EnvironmentManager.danger_base_branch} #{base_commit}"
+
+        # OK, so we want to ensure that we have a known head branch, this will always represent
+        # the head of the PR ( e.g. the most recent commit that will be merged. )
+        self.scm.exec "branch #{EnvironmentManager.danger_head_branch} #{head_commit}"
+      end
+
+      def organisation
+        nil
+      end
+
+      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger")
+        delete_old_comments(danger_id: danger_id)
+
+        comment = generate_description(warnings: warnings, errors: errors)
+        comment += "\n\n"
+        comment += generate_comment(warnings: warnings,
+                                     errors: errors,
+                                   messages: messages,
+                                  markdowns: markdowns,
+                        previous_violations: {},
+                                  danger_id: danger_id,
+                                   template: "bitbucket_server")
+
+        @api.post_comment(comment)
+      end
+
+      def delete_old_comments(danger_id: "danger")
+        @api.fetch_last_comments.each do |c|
+          @api.delete_comment(c[:id]) if c[:content][:raw] =~ /generated_by_#{danger_id}/
+        end
+      end
+    end
+  end
+end

--- a/lib/danger/request_source/bitbucket_cloud_api.rb
+++ b/lib/danger/request_source/bitbucket_cloud_api.rb
@@ -1,0 +1,80 @@
+# coding: utf-8
+require "danger/helpers/comments_helper"
+
+module Danger
+  module RequestSources
+    class BitbucketCloudAPI
+      attr_accessor :host, :pr_api_endpoint, :pr_api_endpoint_v1
+
+      def initialize(project, slug, pull_request_id, environment)
+        @username = environment["DANGER_BITBUCKETCLOUD_USERNAME"]
+        @password = environment["DANGER_BITBUCKETCLOUD_PASSWORD"]
+        self.pr_api_endpoint = "https://api.bitbucket.org/2.0/repositories/#{project}/#{slug}/pullrequests/#{pull_request_id}"
+        self.pr_api_endpoint_v1 = "https://api.bitbucket.org/1.0/repositories/#{project}/#{slug}/pullrequests/#{pull_request_id}"
+      end
+
+      def inspect
+        inspected = super
+
+        if @password
+          inspected = inspected.sub! @password, "********".freeze
+        end
+
+        inspected
+      end
+
+      def credentials_given?
+        @username && !@username.empty? && @password && !@password.empty?
+      end
+
+      def fetch_pr_json
+        uri = URI(pr_api_endpoint)
+        fetch_json(uri)
+      end
+
+      def fetch_last_comments
+        uri = URI("#{pr_api_endpoint}/activity?limit=1000")
+        fetch_json(uri)[:values].select { |v| v[:comment] }.map { |v| v[:comment] }
+      end
+
+      def delete_comment(id)
+        uri = URI("#{pr_api_endpoint_v1}/comments/#{id}")
+        delete(uri)
+      end
+
+      def post_comment(text)
+        uri = URI("#{pr_api_endpoint_v1}/comments")
+        body = { content: text }.to_json
+        post(uri, body)
+      end
+
+      private
+
+      def fetch_json(uri)
+        req = Net::HTTP::Get.new(uri.request_uri, { "Content-Type" => "application/json" })
+        req.basic_auth @username, @password
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(req)
+        end
+        JSON.parse(res.body, symbolize_names: true)
+      end
+
+      def post(uri, body)
+        req = Net::HTTP::Post.new(uri.request_uri, { "Content-Type" => "application/json" })
+        req.basic_auth @username, @password
+        req.body = body
+        Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(req)
+        end
+      end
+
+      def delete(uri)
+        req = Net::HTTP::Delete.new(uri.request_uri, { "Content-Type" => "application/json" })
+        req.basic_auth @username, @password
+        Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(req)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/bitbucket_cloud_api/pr_response.json
+++ b/spec/fixtures/bitbucket_cloud_api/pr_response.json
@@ -1,0 +1,173 @@
+HTTP/1.1 200 OK
+
+{
+  "merge_commit": null,
+  "description": "",
+  "links": {
+    "decline": {
+      "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080/decline"
+    },
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080/commits"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080"
+    },
+    "comments": {
+      "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080/comments"
+    },
+    "merge": {
+      "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080/merge"
+    },
+    "html": {
+      "href": "https://bitbucket.org/ios/fancyapp/pull-requests/2080"
+    },
+    "activity": {
+      "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080/activity"
+    },
+    "diff": {
+      "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080/diff"
+    },
+    "approve": {
+      "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080/approve"
+    },
+    "statuses": {
+      "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080/statuses"
+    }
+  },
+  "title": "This is a danger test",
+  "close_source_branch": false,
+  "reviewers": [],
+  "destination": {
+    "commit": {
+      "hash": "9c823062cf99",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/commit/9c823062cf99"
+        }
+      }
+    },
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp"
+        },
+        "html": {
+          "href": "https://bitbucket.org/ios/fancyapp"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/ios/fancyapp/avatar/32/"
+        }
+      },
+      "type": "repository",
+      "name": "fancyapp",
+      "full_name": "ios/fancyapp",
+      "uuid": "{123456-4675-45d3-a8a0-df38734aa1ea}"
+    },
+    "branch": {
+      "name": "develop"
+    }
+  },
+  "state": "OPEN",
+  "closed_by": null,
+  "source": {
+    "commit": {
+      "hash": "b6f5656b6ac9",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/commit/b6f5656b6ac9"
+        }
+      }
+    },
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp"
+        },
+        "html": {
+          "href": "https://bitbucket.org/ios/fancyapp"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/ios/fancyapp/avatar/32/"
+        }
+      },
+      "type": "repository",
+      "name": "fancyapp",
+      "full_name": "ios/fancyapp",
+      "uuid": "{123456-4675-45d3-a8a0-df38734aa1ea}"
+    },
+    "branch": {
+      "name": "feature/test_danger"
+    }
+  },
+  "comment_count": 2,
+  "author": {
+    "username": "AName",
+    "display_name": "Name",
+    "type": "user",
+    "uuid": "{123456-b28d-43ad-be76-2185a0183d3b}",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/AName"
+      },
+      "html": {
+        "href": "https://bitbucket.org/AName/"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/AName/avatar/32/"
+      }
+    }
+  },
+  "created_on": "2016-09-16T10:11:34.994585+00:00",
+  "participants": [
+    {
+      "role": "PARTICIPANT",
+      "type": "participant",
+      "user": {
+        "username": "AName",
+        "display_name": "Name",
+        "type": "user",
+        "uuid": "{123456-3399-4f12-8609-d1332c891369}",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/"
+          },
+          "html": {
+            "href": "https://bitbucket.org/AName/"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/AName/avatar/32/"
+          }
+        }
+      },
+      "approved": false
+    },
+    {
+      "role": "PARTICIPANT",
+      "type": "participant",
+      "user": {
+        "username": "AName",
+        "display_name": "Name",
+        "type": "user",
+        "uuid": "{123456-b28d-43ad-be76-2185a0183d3b}",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/AName"
+          },
+          "html": {
+            "href": "https://bitbucket.org/AName/"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/AName/avatar/32/"
+          }
+        }
+      },
+      "approved": false
+    }
+  ],
+  "reason": "",
+  "updated_on": "2016-09-16T15:19:42.053756+00:00",
+  "type": "pullrequest",
+  "id": 2080,
+  "task_count": 0
+}

--- a/spec/lib/danger/request_source/bitbucket_cloud_api_spec.rb
+++ b/spec/lib/danger/request_source/bitbucket_cloud_api_spec.rb
@@ -1,0 +1,12 @@
+describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud do
+  describe "#inspect" do
+    it "masks password on inspect" do
+      allow(ENV).to receive(:[]).with("ENVDANGER_BITBUCKETCLOUD_PASSWORD") { "supertopsecret" }
+      api = described_class.new("danger", "danger", 1, stub_env)
+
+      inspected = api.inspect
+
+      expect(inspected).to include(%(@password="********"))
+    end
+  end
+end

--- a/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
+++ b/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
@@ -1,0 +1,36 @@
+# coding: utf-8
+require "danger/request_source/request_source"
+
+describe Danger::RequestSources::BitbucketCloud, host: :bitbucket_cloud do
+  let(:env) { stub_env }
+  let(:bs) { Danger::RequestSources::BitbucketCloud.new(stub_ci, env) }
+
+  describe "#validates_as_api_source" do
+    it "validates_as_api_source for non empty `DANGER_BITBUCKETCLOUD_USERNAME` and `DANGER_BITBUCKETCLOUD_PASSWORD`" do
+      expect(bs.validates_as_api_source?).to be true
+    end
+  end
+
+  describe "#pr_json" do
+    before do
+      stub_pull_request
+      bs.fetch_details
+    end
+
+    it "has a non empty pr_json after `fetch_details`" do
+      expect(bs.pr_json).to be_truthy
+    end
+
+    describe "#pr_json[:id]" do
+      it "has fetched the same pull request id as ci_sources's `pull_request_id`" do
+        expect(bs.pr_json[:id]).to eql(2080)
+      end
+    end
+
+    describe "#pr_json[:title]" do
+      it "has fetched the pull requests title" do
+        expect(bs.pr_json[:title]).to eql("This is a danger test")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,12 +14,14 @@ require "json"
 require "support/gitlab_helper"
 require "support/github_helper"
 require "support/bitbucket_server_helper"
+require "support/bitbucket_cloud_helper"
 
 RSpec.configure do |config|
   config.filter_gems_from_backtrace "bundler"
   config.include Danger::Support::GitLabHelper, host: :gitlab
   config.include Danger::Support::GitHubHelper, host: :github
   config.include Danger::Support::BitbucketServerHelper, host: :bitbucket_server
+  config.include Danger::Support::BitbucketCloudHelper, host: :bitbucket_cloud
   config.run_all_when_everything_filtered = true
   config.filter_run focus: true
 end

--- a/spec/support/bitbucket_cloud_helper.rb
+++ b/spec/support/bitbucket_cloud_helper.rb
@@ -1,0 +1,48 @@
+module Danger
+  module Support
+    module BitbucketCloudHelper
+      def stub_env
+        {
+          "DANGER_BITBUCKETCLOUD_USERNAME" => "a.name",
+          "DANGER_BITBUCKETCLOUD_PASSWORD" => "a_password",
+          "JENKINS_URL" => "http://jenkins.example.com/job/ios-check-pullrequest/",
+          "GIT_URL" => "ssh://git@stash.example.com:7999/ios/fancyapp.git",
+          "ghprbPullId" => "2080"
+        }
+      end
+
+      def stub_ci
+        Danger::Jenkins.new(stub_env)
+      end
+
+      def stub_request_source
+        Danger::RequestSources::GitLab.new(stub_ci, stub_env)
+      end
+
+      def stub_pull_request
+        raw_file = File.new("spec/fixtures/bitbucket_cloud_api/pr_response.json")
+        url = "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080"
+        WebMock.stub_request(:get, url).to_return(raw_file)
+      end
+
+      def with_git_repo
+        Dir.mktmpdir do |dir|
+          Dir.chdir dir do
+            `git init`
+            File.open(dir + "/file1", "w") {}
+            `git add .`
+            `git commit -m "ok"`
+
+            `git checkout -b new`
+            File.open(dir + "/file2", "w") {}
+            `git add .`
+            `git commit -m "another"`
+            `git remote add origin git@stash.example.com:artsy/eigen`
+
+            yield
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Duplicates bitbucket_server RequestSource and Plugin and adapts them for bitbucket cloud REST API.
- Dangerfile support is the same as for bitbucket_server but uses bitbucket_cloud name.
- Basic Auth via username/password is used and needs to be set via DANGER_BITBUCKETCLOUD_USERNAME and DANGER_BITBUCKETCLOUD_PASSWORD environment vars