### PR TITLE
Hk spec improvements #trivial

### DIFF
--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -57,7 +57,7 @@ describe Danger::Bitrise do
     end
 
     it "sets the repo_url", host: :github do
-      with_git_repo do
+      with_git_repo(origin: "git@github.com:artsy/eigen") do
         expect(source.repo_url).to eq("git@github.com:artsy/eigen")
       end
     end

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -8,11 +8,11 @@ def run_in_repo(has_pr = true)
       File.open(dir + "/file1", "w") {}
       `git add .`
       `git commit -m "adding file1"`
-      `git checkout -b new-branch`
+      `git checkout -b new-branch --quiet`
       File.open(dir + "/file2", "w") {}
       `git add .`
       `git commit -m "adding file2"`
-      `git checkout master`
+      `git checkout master --quiet`
 
       if has_pr
         `git merge new-branch --no-ff -m "Merge pull request #1234 from new-branch"`
@@ -106,11 +106,11 @@ describe Danger::LocalGitRepo do
       context "multiple PRs" do
         def add_another_pr
           # Add a new PR merge commit
-          `git checkout -b new-branch2`
+          `git checkout -b new-branch2 --quiet`
           File.open("file3", "w") {}
           `git add .`
           `git commit -m "adding file2"`
-          `git checkout master`
+          `git checkout master --quiet`
           `git merge new-branch2 --no-ff -m "Merge pull request #1235 from new-branch"`
         end
 

--- a/spec/lib/danger/ci_sources/xcode_server_spec.rb
+++ b/spec/lib/danger/ci_sources/xcode_server_spec.rb
@@ -55,7 +55,7 @@ describe Danger::XcodeServer do
     end
 
     it "sets the repo_url", host: :github do
-      with_git_repo do
+      with_git_repo(origin: "git@github.com:artsy/eigen") do
         expect(source.repo_url).to eq("git@github.com:artsy/eigen")
       end
     end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -110,7 +110,7 @@ describe Danger::Dangerfile::DSL, host: :github do
   describe "#scm_provider" do
     context "GitHub", host: :github do
       it "is `:github`" do
-        with_git_repo do
+        with_git_repo(origin: "git@github.com:artsy/eigen") do
           expect(dm.danger.scm_provider).to eq(:github)
         end
       end
@@ -118,7 +118,7 @@ describe Danger::Dangerfile::DSL, host: :github do
 
     context "GitLab", host: :gitlab do
       it "is `:gitlab`" do
-        with_git_repo do
+        with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
           expect(dm.danger.scm_provider).to eq(:gitlab)
         end
       end
@@ -126,7 +126,7 @@ describe Danger::Dangerfile::DSL, host: :github do
 
     context "Bitbucket Server", host: :bitbucket_server do
       it "is `:bitbucket_server`" do
-        with_git_repo do
+        with_git_repo(origin: "git@stash.example.com:artsy/eigen") do
           expect(dm.danger.scm_provider).to eq(:bitbucket_server)
         end
       end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -8,7 +8,7 @@ def run_in_repo_with_diff
       File.open(dir + "/file2", "w") { |f| f.write "Shorts.\nShoes." }
       `git add .`
       `git commit -m "adding file1"`
-      `git checkout -b new-branch`
+      `git checkout -b new-branch --quiet`
       File.open(dir + "/file2", "w") { |f| f.write "Pants!" }
       `git add .`
       `git commit -m "adding file2"`

--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -28,7 +28,7 @@ describe Danger::DangerfileGitLabPlugin, host: :gitlab do
 
     describe "##{method}" do
       it "sets the correct #{method}" do
-        with_git_repo do
+        with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
           dangerfile.env.request_source.fetch_details
           expect(plugin.send(method)).to eq(expected)
         end
@@ -46,7 +46,7 @@ describe Danger::DangerfileGitLabPlugin, host: :gitlab do
     end
 
     it "sets the mr_diff" do
-      with_git_repo do
+      with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
         expect(plugin.mr_diff).to include("Danger rocks!")
         expect(plugin.mr_diff).to include("Test message please ignore")
       end
@@ -55,14 +55,14 @@ describe Danger::DangerfileGitLabPlugin, host: :gitlab do
 
   describe "#mr_json" do
     it "is set" do
-      with_git_repo do
+      with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
         dangerfile.env.request_source.fetch_details
         expect(plugin.mr_json).not_to be_nil
       end
     end
 
     it "has the expected keys" do
-      with_git_repo do
+      with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
         dangerfile.env.request_source.fetch_details
 
         [
@@ -82,7 +82,7 @@ describe Danger::DangerfileGitLabPlugin, host: :gitlab do
 
   describe "#html_link" do
     it "should render a html link to the given file" do
-      with_git_repo do
+      with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
         dangerfile.env.request_source.fetch_details
         expect(plugin.html_link("CHANGELOG.md")).to eql("<a href='https://gitlab.com/k0nserv/danger-test/blob/345e74fabb2fecea93091e8925b1a7a208b48ba6/CHANGELOG.md'>CHANGELOG.md</a>")
       end

--- a/spec/lib/danger/request_source/github_spec.rb
+++ b/spec/lib/danger/request_source/github_spec.rb
@@ -22,7 +22,7 @@ describe Danger::RequestSources::GitHub, host: :github do
       it "allows the GitHub API host to be overridden with `DANGER_GITHUB_API_BASE_URL`" do
         api_endpoint = "https://git.club-mateusa.com/api/v3/"
         gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_API_BASE_URL" => api_endpoint }
-        g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
+        Danger::RequestSources::GitHub.new(stub_ci, gh_env)
         expect(Octokit.api_endpoint).to eql(api_endpoint)
       end
 
@@ -30,7 +30,7 @@ describe Danger::RequestSources::GitHub, host: :github do
       it "allows the GitHub API host to be overridden with `DANGER_GITHUB_API_HOST`" do
         api_endpoint = "https://git.club-mateusa.com/api/v3/"
         gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_API_HOST" => api_endpoint }
-        g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
+        Danger::RequestSources::GitHub.new(stub_ci, gh_env)
         expect(Octokit.api_endpoint).to eql(api_endpoint)
       end
     end

--- a/spec/lib/danger/request_source/github_spec.rb
+++ b/spec/lib/danger/request_source/github_spec.rb
@@ -26,9 +26,8 @@ describe Danger::RequestSources::GitHub, host: :github do
         expect(Octokit.api_endpoint).to eql(api_endpoint)
       end
 
-      # Old variable for backwards compatibility
-      it "allows the GitHub API host to be overridden with `DANGER_GITHUB_API_HOST`" do
-        api_endpoint = "https://git.club-mateusa.com/api/v3/"
+      it "allows the GitHub API host to be overridden with `DANGER_GITHUB_API_HOST` for backwards compatibility" do
+        api_endpoint = "https://git.club-mateusa.com/api/v4/"
         gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_API_HOST" => api_endpoint }
         Danger::RequestSources::GitHub.new(stub_ci, gh_env)
         expect(Octokit.api_endpoint).to eql(api_endpoint)

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -21,7 +21,7 @@ describe Danger::GitRepo, host: :github do
         File.open(@tmp_dir + "/file", "w") {}
         `git add .`
         `git commit -m "ok"`
-        `git checkout -b new`
+        `git checkout -b new --quiet`
         File.open(@tmp_dir + "/file2", "w") {}
         `git add .`
         `git commit -m "another"`
@@ -45,7 +45,7 @@ describe Danger::GitRepo, host: :github do
         File.open(@tmp_dir + "/file", "w") {}
         `git add .`
         `git commit -m "ok"`
-        `git checkout -b new`
+        `git checkout -b new --quiet`
         File.open(@tmp_dir + "/file2", "w") {}
         `git add .`
         `git commit -m "another"`
@@ -77,7 +77,7 @@ describe Danger::GitRepo, host: :github do
           `git add .`
           `git commit -m "ok"`
 
-          `git checkout -b new`
+          `git checkout -b new --quiet`
           File.open(dir + "/file2", "w") {}
           `git add .`
           `git commit -m "another"`
@@ -98,7 +98,7 @@ describe Danger::GitRepo, host: :github do
           `git add .`
           `git commit -m "ok"`
 
-          `git checkout -b new`
+          `git checkout -b new --quiet`
           File.delete(dir + "/file")
           `git add . --all`
           `git commit -m "another"`
@@ -119,7 +119,7 @@ describe Danger::GitRepo, host: :github do
           `git add .`
           `git commit -m "ok"`
 
-          `git checkout -b new`
+          `git checkout -b new --quiet`
           File.open(dir + "/file", "a") { |file| file.write("ok\nmorestuff") }
           `git add .`
           `git commit -m "another"`
@@ -142,7 +142,7 @@ describe Danger::GitRepo, host: :github do
           `git add .`
           `git commit -m "ok"`
 
-          `git checkout -b new`
+          `git checkout -b new --quiet`
           File.open(dir + "/file", "a") { |file| file.write("hi\n\najsdha") }
           `git add .`
           `git commit -m "another"`
@@ -163,7 +163,7 @@ describe Danger::GitRepo, host: :github do
           `git add .`
           `git commit -m "ok"`
 
-          `git checkout -b new`
+          `git checkout -b new --quiet`
           File.open(dir + "/file", "w") { |file| file.write("1\n2\n3\n5\n") }
           `git add .`
           `git commit -m "another"`
@@ -185,7 +185,7 @@ describe Danger::GitRepo, host: :github do
             `git add .`
             `git commit -m "ok"`
 
-            `git checkout -b new`
+            `git checkout -b new --quiet`
             File.open(dir + "/file", "a") { |file| file.write("hi\n\najsdha") }
             `git add .`
             `git commit -m "another"`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,7 +89,7 @@ def markdowns(messages)
   messages.map { |s| markdown(s) }
 end
 
-def with_git_repo(origin: origin = "git@github.com:artsy/eigen")
+def with_git_repo(origin: "git@github.com:artsy/eigen")
   Dir.mktmpdir do |dir|
     Dir.chdir dir do
       `git init`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,7 @@ def with_git_repo(origin: origin = "git@github.com:artsy/eigen")
       `git add .`
       `git commit -m "ok"`
 
-      `git checkout -b new`
+      `git checkout -b new --quiet`
       File.open(dir + "/file2", "w") {}
       `git add .`
       `git commit -m "another"`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -88,3 +88,22 @@ end
 def markdowns(messages)
   messages.map { |s| markdown(s) }
 end
+
+def with_git_repo(origin: origin = "git@github.com:artsy/eigen")
+  Dir.mktmpdir do |dir|
+    Dir.chdir dir do
+      `git init`
+      File.open(dir + "/file1", "w") {}
+      `git add .`
+      `git commit -m "ok"`
+
+      `git checkout -b new`
+      File.open(dir + "/file2", "w") {}
+      `git add .`
+      `git commit -m "another"`
+      `git remote add origin #{origin}`
+
+      yield
+    end
+  end
+end

--- a/spec/support/bitbucket_cloud_helper.rb
+++ b/spec/support/bitbucket_cloud_helper.rb
@@ -24,25 +24,6 @@ module Danger
         url = "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080"
         WebMock.stub_request(:get, url).to_return(raw_file)
       end
-
-      def with_git_repo
-        Dir.mktmpdir do |dir|
-          Dir.chdir dir do
-            `git init`
-            File.open(dir + "/file1", "w") {}
-            `git add .`
-            `git commit -m "ok"`
-
-            `git checkout -b new`
-            File.open(dir + "/file2", "w") {}
-            `git add .`
-            `git commit -m "another"`
-            `git remote add origin git@stash.example.com:artsy/eigen`
-
-            yield
-          end
-        end
-      end
     end
   end
 end

--- a/spec/support/bitbucket_server_helper.rb
+++ b/spec/support/bitbucket_server_helper.rb
@@ -25,25 +25,6 @@ module Danger
         url = "https://stash.example.com/rest/api/1.0/projects/ios/repos/fancyapp/pull-requests/2080"
         WebMock.stub_request(:get, url).to_return(raw_file)
       end
-
-      def with_git_repo
-        Dir.mktmpdir do |dir|
-          Dir.chdir dir do
-            `git init`
-            File.open(dir + "/file1", "w") {}
-            `git add .`
-            `git commit -m "ok"`
-
-            `git checkout -b new`
-            File.open(dir + "/file2", "w") {}
-            `git add .`
-            `git commit -m "another"`
-            `git remote add origin git@stash.example.com:artsy/eigen`
-
-            yield
-          end
-        end
-      end
     end
   end
 end

--- a/spec/support/github_helper.rb
+++ b/spec/support/github_helper.rb
@@ -24,25 +24,6 @@ module Danger
       def stub_request_source
         Danger::RequestSources::GitHub.new(stub_ci, stub_env)
       end
-
-      def with_git_repo
-        Dir.mktmpdir do |dir|
-          Dir.chdir dir do
-            `git init`
-            File.open(dir + "/file1", "w") {}
-            `git add .`
-            `git commit -m "ok"`
-
-            `git checkout -b new`
-            File.open(dir + "/file2", "w") {}
-            `git add .`
-            `git commit -m "another"`
-            `git remote add origin git@github.com:artsy/eigen`
-
-            yield
-          end
-        end
-      end
     end
   end
 end

--- a/spec/support/gitlab_helper.rb
+++ b/spec/support/gitlab_helper.rb
@@ -52,25 +52,6 @@ module Danger
         url = "https://gitlab.com/api/v3/projects/#{escaped_slug}/merge_requests/#{merge_request_id}/notes"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
-
-      def with_git_repo
-        Dir.mktmpdir do |dir|
-          Dir.chdir dir do
-            `git init`
-            File.open(dir + "/file1", "w") {}
-            `git add .`
-            `git commit -m "ok"`
-
-            `git checkout -b new`
-            File.open(dir + "/file2", "w") {}
-            `git add .`
-            `git commit -m "another"`
-            `git remote add origin git@gitlab.com:k0nserv/danger-test.git`
-
-            yield
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
`with_git_repo` was kinda duplicates across different spec_helpers. pulled it up and made the origin more specific in the tests where it actually mattered.
Also removed all of the `switched to branch 'new'` logs in the spec output. That backwards compatibility test in `github_spec.rb` was passing without invoking anything, because the url would be set from the previous test already.