### PR TITLE
Improves "danger local" Pull Request finding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.0
   Exclude:
     - 'spec/fixtures/**/*'
     - 'lib/danger/plugin_support/plugin_parser.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.1
   Exclude:
     - 'spec/fixtures/**/*'
     - 'lib/danger/plugin_support/plugin_parser.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* "danger local" can find squash-and-merge-type Pull Request - Juanito Fatas
+
 ## 3.3.0
 
 * Add support for Bitbucket Cloud - Wolfgang Damm

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.2"
   spec.add_development_dependency "webmock", "~> 2.1"
   spec.add_development_dependency "pry", "~> 0.10"
+  spec.add_development_dependency "pry-byebug"
 
   spec.add_development_dependency "rubocop", "~> 0.38"
   spec.add_development_dependency "yard", "~> 0.8"

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -41,7 +41,7 @@ module Danger
     def initialize(env = {})
       repo_slug = RemoteFinder.new(
         github_host: env["DANGER_GITHUB_HOST"] || "github.com".freeze,
-        remote_logs: run_git("remote show origin -n")
+        remote_logs: run_git("remote show origin -n".freeze)
       ).call
 
       pull_request_id, sha = MergedPullRequestFinder.new(

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -44,10 +44,18 @@ module Danger
 
       specific_pr = env["LOCAL_GIT_PR_ID"]
       pr_ref = specific_pr ? "##{specific_pr}" : ""
-      pr_command = "log --merges --oneline"
+      logs = "log --oneline"
 
       # get the most recent PR merge
-      pr_merge = run_git(pr_command.strip).lines.grep(Regexp.new("Merge pull request " + pr_ref))[0]
+      pr_merge = begin
+        if pr_ref.empty?
+          nil
+        elsif merge_pr = run_git(logs.strip).lines.grep(Regexp.new("Merge pull request " + pr_ref))[0]
+          merge_pr
+        elsif squash_merge = run_git(logs.strip).lines.grep(/#{pr_ref}/)[0]
+          squash_merge
+        end
+      end
 
       if pr_merge.to_s.empty?
         if specific_pr
@@ -56,6 +64,7 @@ module Danger
           raise "No recent pull requests found for this repo, danger requires at least one PR for the local mode."
         end
       end
+
       self.pull_request_id = pr_merge.match("#([0-9]+)")[1]
       sha = pr_merge.split(" ")[0]
       parents = run_git("rev-list --parents -n 1 #{sha}").strip.split(" ")

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -40,13 +40,13 @@ module Danger
 
     def initialize(env = {})
       repo_slug = RemoteFinder.new(
-        github_host: env["DANGER_GITHUB_HOST"] || "github.com".freeze,
-        remote_logs: run_git("remote show origin -n".freeze)
+        env["DANGER_GITHUB_HOST"] || "github.com".freeze,
+        run_git("remote show origin -n".freeze)
       ).call
 
       pull_request_id, sha = MergedPullRequestFinder.new(
-        specific_pull_request_id: env["LOCAL_GIT_PR_ID"] || "",
-        git_logs: run_git("log --oneline -50".freeze)
+        env["LOCAL_GIT_PR_ID"] || "",
+        run_git("log --oneline -50".freeze)
       ).call
 
       self.repo_slug = repo_slug ? repo_slug : print_repo_slug_warning

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -45,7 +45,7 @@ module Danger
       ).call
 
       pull_request_id, sha = MergedPullRequestFinder.new(
-        specific_pull_request_id: env["LOCAL_GIT_PR_ID"],
+        specific_pull_request_id: env["LOCAL_GIT_PR_ID"] || "",
         git_logs: run_git("log --oneline -50".freeze)
       ).call
 

--- a/lib/danger/ci_source/support/merged_pull_request_finder.rb
+++ b/lib/danger/ci_source/support/merged_pull_request_finder.rb
@@ -1,8 +1,8 @@
 module Danger
   class MergedPullRequestFinder
-    def initialize(specific_pull_request_id:, git:)
+    def initialize(specific_pull_request_id:, git_logs:)
       @specific_pull_request_id = specific_pull_request_id
-      @git = git
+      @git_logs = git_logs
     end
 
     def call
@@ -13,20 +13,11 @@ module Danger
 
     private
 
-    attr_reader :specific_pull_request_id, :git
-
-    def run_git(command)
-      git.exec(command)
-    end
+    attr_reader :specific_pull_request_id, :git_logs
 
     # @return [String] "#42"
     def pull_request_ref
       specific_pull_request_id ? "##{specific_pull_request_id}" : "".freeze
-    end
-
-    # @return [Array] Recent 50 commit logs in oneliner
-    def git_logs
-      @git_logs ||= run_git("log --oneline -50".freeze)
     end
 
     # @return [String] Log line of format: "Merge pull request #42"

--- a/lib/danger/ci_source/support/merged_pull_request_finder.rb
+++ b/lib/danger/ci_source/support/merged_pull_request_finder.rb
@@ -1,0 +1,75 @@
+module Danger
+  class MergedPullRequestFinder
+    def initialize(specific_pull_request_id:, git:)
+      @specific_pull_request_id = specific_pull_request_id
+      @git = git
+    end
+
+    def call
+      check_if_any_merged_pull_request!
+
+      [merged_pull_request_id, merged_pull_request_sha]
+    end
+
+    private
+
+    attr_reader :specific_pull_request_id, :git
+
+    def run_git(command)
+      git.exec(command)
+    end
+
+    # @return [String] "#42"
+    def pull_request_ref
+      specific_pull_request_id ? "##{specific_pull_request_id}" : "".freeze
+    end
+
+    # @return [Array] Recent 50 commit logs in oneliner
+    def git_logs
+      @git_logs ||= run_git("log --oneline -50".freeze)
+    end
+
+    # @return [String] Log line of format: "Merge pull request #42"
+    def most_recent_merged_pull_request
+      @last_merged_pull_request ||= begin
+        git_logs.lines.grep(/Merge pull request #{pull_request_ref}/)[0]
+      end
+    end
+
+    # @return [String] Log line of format: "description (#42)"
+    def most_recent_squash_and_merged_pull_request
+      @last_merged_pull_request ||= begin
+        git_logs.lines.grep(/#{pull_request_ref}/)[0]
+      end
+    end
+
+    # @return [String] Log line of most recent merged Pull Request
+    def merged_pull_request
+      return if pull_request_ref.empty?
+
+      if most_recent_merged_pull_request
+        most_recent_merged_pull_request
+      elsif most_recent_squash_and_merged_pull_request
+        most_recent_squash_and_merged_pull_request
+      end
+    end
+
+    def check_if_any_merged_pull_request!
+      if merged_pull_request.to_s.empty?
+        if specific_pull_request_id
+          raise "Could not find the Pull Request (#{specific_pull_request_id}) inside the git history for this repo."
+        else
+          raise "No recent Pull Requests found for this repo, danger requires at least one Pull Request for the local mode.".freeze
+        end
+      end
+    end
+
+    def merged_pull_request_id
+      merged_pull_request.match(/#(?<id>[0-9]+)/)[:id]
+    end
+
+    def merged_pull_request_sha
+      merged_pull_request.split(" ".freeze).first
+    end
+  end
+end

--- a/lib/danger/ci_source/support/merged_pull_request_finder.rb
+++ b/lib/danger/ci_source/support/merged_pull_request_finder.rb
@@ -1,6 +1,6 @@
 module Danger
   class MergedPullRequestFinder
-    def initialize(specific_pull_request_id:, git_logs:)
+    def initialize(specific_pull_request_id, git_logs)
       @specific_pull_request_id = specific_pull_request_id
       @git_logs = git_logs
     end

--- a/lib/danger/ci_source/support/remote_finder.rb
+++ b/lib/danger/ci_source/support/remote_finder.rb
@@ -1,0 +1,26 @@
+module Danger
+  class RemoteFinder
+    def initialize(github_host:, remote_logs:)
+      @github_host = github_host
+      @remote_logs = remote_logs
+    end
+
+    def call
+      remote_url_matches && remote_url_matches["repo_slug"]
+    end
+
+    private
+
+    attr_reader :remote_logs, :github_host
+
+    # @return [String] The remote URL
+    def remote
+      @remote ||= remote_logs.lines.grep(/Fetch URL/)[0].split(": ".freeze, 2)[1]
+    end
+
+    # @return [nil / MatchData] MatchData object or nil if not matched
+    def remote_url_matches
+      remote.match(%r{#{Regexp.escape github_host}(:|/)(?<repo_slug>.+/.+?)(?:\.git)?$})
+    end
+  end
+end

--- a/lib/danger/ci_source/support/remote_finder.rb
+++ b/lib/danger/ci_source/support/remote_finder.rb
@@ -1,6 +1,6 @@
 module Danger
   class RemoteFinder
-    def initialize(github_host:, remote_logs:)
+    def initialize(github_host, remote_logs)
       @github_host = github_host
       @remote_logs = remote_logs
     end

--- a/spec/fixtures/ci_source/support/danger-git.log
+++ b/spec/fixtures/ci_source/support/danger-git.log
@@ -1,0 +1,50 @@
+bde9ea7 Merge pull request #557 from danger/hk-spec-improvements
+4a86be0 fix ruby keyword argument syntax
+028fecb silence git output in specs
+e2ccd73 extract `with_git_repo` to spec_helper, be more explicit about git origin
+3f8645a use different url to allow spec to fail
+49f08b9 remove useless local variable
+9c84248 Update CHANGELOG.md
+0cd9198 Prepare for 3.3.0 (#556)
+d86321e Adds support for bitbucket cloud (#555)
+bf94ad0 Save Comment class out of CommentsHelper (#554)
+f43e6f1 Add docs for String #danger_pluralize & #danger_underscore (#551)
+6910c8a Remove unknown passings of nils (#552)
+cb48cc3 Remove unused danger_class method (#550)
+e965d64 Enable trim_trailing_whitespace for all files [ci skip] (#549)
+774d69b Add per-file info (insertions, deletions, before/after contents) (#542)
+13cc27e Prepare for 3.2.2 (#547)
+bfea803 Hk issue 543 (#546)
+4fb9179 Updating bitrise docs (#541)
+11f2107 Add `markdown_link` for the Bitbucket Server plugin (#537)
+07e5b52 Link to https://danger.systems rather than http://example.com (#536)
+d0905e9 [Dangerfile] Simplify text wrapping code (#531)
+becbabd CHANGELOG update for 321 (#530)
+ccd9cbc Fix for markdown crashing DM - fixes #520 (#529)
+81ce67b Add a check for the merge inflection points existing (#517)
+580ce6b [GitLab] Update branch accessors (#528)
+272c9f6 [Core] Provide a way to check the active scm host (#527)
+796f858 Merge pull request #526 from danger/patch/bitbucket-server-api-inspect-protection
+0a8ad84 Mask password when inspect BitbucketServerAPI
+7004f31 Update comment and remove unused referred name (#525)
+4d31448 Remove Bitbucket example that isn't possible (no api method), fix some terminology in the GitLab documentation. (#524)
+03a2b06 Improve handling of tables (#516)
+3b4ad47 Merge pull request #515 from danger/danger_import_docs
+9ff97c6 Improve docs for the core Danger plugin
+e7cfcdc Merge pull request #513 from danger/patch/danger/gem_path
+11d39e7 Merge pull request #514 from danger/patch/gemspec-homepage
+2cb1a4f Merge branch 'master' into patch/danger/gem_path
+dc4e96b Merge pull request #512 from danger/doc/fix-changelog
+193c164 Use https homepage url on rubygems.org
+6defddd Minor improvements to Danger.gem_path
+b70626b Add back the master section of CHANGELOG.md [ci skip]
+ca4e9a3 Merge pull request #511 from danger/release_230
+f7a49af Fix an CHANGELOG item [ci skip]
+19152e3 Update the CHANGELOG for the next release
+dec7ac7 Merge pull request #412 from danger/line_comment
+446e1cf Merge branch 'master' of https://github.com/danger/danger into line_comment
+517782a Merge pull request #485 from danger/git-english-env
+9edd7f3 Remove the main comment when there's no non-inline comments to post
+2686ca0 Use different command for windows & non-windows
+90f5e65 Use Open3::popen2 instead since we don't care about the error
+993e630 Use Open3#popen3 to run command with our ENV set

--- a/spec/fixtures/ci_source/support/enterprise-remote.log
+++ b/spec/fixtures/ci_source/support/enterprise-remote.log
@@ -1,0 +1,42 @@
+* remote origin
+  Fetch URL: git@artsyhub.com:enterdanger/enterdanger.git
+  Push  URL: git@artsyhub.com:enterdanger/enterdanger.git
+  HEAD branch: (not queried)
+  Remote branches: (status not queried)
+    add-scm-provider
+    bitbucket_prep
+    dangerfile
+    doc/fix-changelog
+    doc/fix-changelog-item
+    doc/request_source/validates_as_ci
+    enable-triming-whitespaces-for-all-files
+    feature/inline_messaging
+    get_local_started
+    git-english-env
+    gitlab
+    hk-spec-improvements
+    improve_warning_no_local
+    issues
+    js
+    line_comment
+    linter
+    master
+    merge_point
+    patch/bitbucket-server-api-inspect-protection
+    patch/comment
+    patch/danger/gem_path
+    patch/gemspec-homepage
+    patch/remove-unused-danger-class-method
+    patch/string-methods
+    patch/volation-args
+    readme_improvements
+    release
+    release_214
+    release_303
+    spec/orgnizations
+    youre_a_local_command_harry
+    youre_a_local_command_harry_two
+  Local branch configured for 'git pull':
+    master merges with remote master
+  Local ref configured for 'git push' (status not queried):
+    (matching) pushes to (matching)

--- a/spec/fixtures/ci_source/support/remote.log
+++ b/spec/fixtures/ci_source/support/remote.log
@@ -1,0 +1,42 @@
+* remote origin
+  Fetch URL: git@github.com:danger/danger.git
+  Push  URL: git@github.com:danger/danger.git
+  HEAD branch: (not queried)
+  Remote branches: (status not queried)
+    add-scm-provider
+    bitbucket_prep
+    dangerfile
+    doc/fix-changelog
+    doc/fix-changelog-item
+    doc/request_source/validates_as_ci
+    enable-triming-whitespaces-for-all-files
+    feature/inline_messaging
+    get_local_started
+    git-english-env
+    gitlab
+    hk-spec-improvements
+    improve_warning_no_local
+    issues
+    js
+    line_comment
+    linter
+    master
+    merge_point
+    patch/bitbucket-server-api-inspect-protection
+    patch/comment
+    patch/danger/gem_path
+    patch/gemspec-homepage
+    patch/remove-unused-danger-class-method
+    patch/string-methods
+    patch/volation-args
+    readme_improvements
+    release
+    release_214
+    release_303
+    spec/orgnizations
+    youre_a_local_command_harry
+    youre_a_local_command_harry_two
+  Local branch configured for 'git pull':
+    master merges with remote master
+  Local ref configured for 'git push' (status not queried):
+    (matching) pushes to (matching)

--- a/spec/fixtures/ci_source/support/swiftweekly.github.io-git.log
+++ b/spec/fixtures/ci_source/support/swiftweekly.github.io-git.log
@@ -1,0 +1,50 @@
+129045f Flesh out issue 38 (#89)
+300780c [38] draft update
+8f0f2d2 [38] Add accepted proposals 0139 & 0140 (#87)
+8c85645 Update 2016-09-15-issue-38.md
+65dfb06 Update Dangerfile
+684eeff Clarify publishing times in CONTRIBUTING.md (#81)
+19369ac [38] Add ClangImporter refactor (#83)
+81c2705 Update 2016-09-15-issue-38.md
+10b1ec7 Update new_draft.sh
+50b40c8 Add "TODO" and Apple projects to ignored Proselint words (#78)
+038d71c [38] Add Jesse's work on the SE Status Page (#85)
+9fb1cf5 [38] Add extended SE-0138 (#84)
+86238a7 Merge branch 'master' of https://github.com/SwiftWeekly/swiftweekly.github.io
+45a666b bundle install. fix/cleanup gems
+acc5a1b Fix code tag (#80)
+c4dde6d Typo fix (#82)
+3f7047a [38] Add blurb on CI cross-testing (#77)
+8f8d576 [38] Add cmpcodesize starter tasks (#76)
+8178b7e Merge branch 'master' of https://github.com/SwiftWeekly/swiftweekly.github.io
+2606da6 [37] oops. note iOS and OSX release dates
+bc865bb Update CONTRIBUTING.md
+78a707f Update CONTRIBUTING.md
+e4af163 [38] initial draft
+c537b81 [37] publish issue 37 (#73)
+e08e251 update ignored words in proselint
+f674bd8 [37] draft update
+a2776ec update ignored words
+ae8c9e0 update danger setup
+2e4da93 setup danger + proselint
+74de0a0 implement Jekyll SEO tag. close #38
+7849827 [37] draft update
+9a217c7 [37] draft update
+793517c [37] Remove returned proposals section (#69)
+704cc04 Update CONTRIBUTING.md
+6dac1a5 Update CONTRIBUTING.md
+b5fba45 [37] Add proposal SE-0140 (#67)
+d1e788b [37] Add two proposals in review (#66)
+7b2e552 Update CONTRIBUTING.md
+2901fbd [37] initial draft
+ef50aea publish issue 36
+3ad7efb [36] draft update
+f7b8ae3 [36] draft update
+9bae552 [36] draft update
+fb4bf4d [36] Add Apple event details (#65)
+e89f085 [36] initial draft
+84fd626 publish issue 35
+0fb9734 Update CONTRIBUTING.md
+71e960e Added info on Robotary (#62)
+76a1671 [35] draft update
+5fc8803 [35] Add -driver-time-compilation (#61)

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -31,7 +31,6 @@ describe Danger::LocalGitRepo do
   let(:valid_env) do
     {
       "DANGER_USE_LOCAL_GIT" => "true",
-      "LOCAL_GIT_PR_ID" => "1234"
     }
   end
 

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -30,7 +30,7 @@ end
 describe Danger::LocalGitRepo do
   let(:valid_env) do
     {
-      "DANGER_USE_LOCAL_GIT" => "true",
+      "DANGER_USE_LOCAL_GIT" => "true"
     }
   end
 

--- a/spec/lib/danger/ci_sources/support/merged_pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/merged_pull_request_finder_spec.rb
@@ -3,8 +3,8 @@ require "danger/ci_source/support/merged_pull_request_finder"
 describe Danger::MergedPullRequestFinder do
   def finder(pull_request_id: "", logs: nil)
     described_class.new(
-      specific_pull_request_id: pull_request_id,
-      git_logs: logs
+      pull_request_id,
+      logs
     )
   end
 

--- a/spec/lib/danger/ci_sources/support/merged_pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/merged_pull_request_finder_spec.rb
@@ -1,0 +1,60 @@
+require "danger/ci_source/support/merged_pull_request_finder"
+
+describe Danger::MergedPullRequestFinder do
+  def finder(pull_request_id: "", logs: nil)
+    described_class.new(
+      specific_pull_request_id: pull_request_id,
+      git_logs: logs
+    )
+  end
+
+  def merge_pull_request_log
+    IO.read("spec/fixtures/ci_source/support/danger-git.log")
+  end
+
+  def squash_and_merge_log
+    IO.read("spec/fixtures/ci_source/support/swiftweekly.github.io-git.log")
+  end
+
+  describe "#call" do
+    context "not specified Pull Request ID" do
+      context "merge pull request type Pull Request" do
+        it "returns correct Pull Request ID and SHA1" do
+          pull_request_id, sha = finder(logs: merge_pull_request_log).call
+
+          expect(pull_request_id).to eq "557"
+          expect(sha).to eq "bde9ea7"
+        end
+      end
+
+      context "squash and merge type Pull Request" do
+        it "returns correct Pull Request ID and SHA1" do
+          pull_request_id, sha = finder(logs: squash_and_merge_log).call
+
+          expect(pull_request_id).to eq "89"
+          expect(sha).to eq "129045f"
+        end
+      end
+    end
+
+    context "specify Pull Request ID" do
+      context "merge pull request type Pull Request" do
+        it "returns correct Pull Request ID and SHA1" do
+          pull_request_id, sha = finder(pull_request_id: "556", logs: merge_pull_request_log).call
+
+          expect(pull_request_id).to eq "556"
+          expect(sha).to eq "0cd9198"
+        end
+      end
+
+      context "squash and merge type Pull Request" do
+        it "returns correct Pull Request ID and SHA1" do
+          pull_request_id, sha = finder(pull_request_id: "77", logs: squash_and_merge_log).call
+
+          expect(pull_request_id).to eq "77"
+          expect(sha).to eq "3f7047a"
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/danger/ci_sources/support/remote_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/remote_finder_spec.rb
@@ -1,0 +1,25 @@
+require "danger/ci_source/support/remote_finder"
+
+describe Danger::RemoteFinder do
+  describe "#call" do
+    it "returns repo slug from logs" do
+      remote_logs = IO.read("spec/fixtures/ci_source/support/remote.log")
+      finder = described_class.new(github_host: "github.com", remote_logs: remote_logs)
+
+      result = finder.call
+
+      expect(result).to eq "danger/danger"
+    end
+
+    context "specify GitHub Enterprise URL" do
+      it "returns repo slug from logs" do
+        remote_logs = IO.read("spec/fixtures/ci_source/support/enterprise-remote.log")
+        finder = described_class.new(github_host: "artsyhub.com", remote_logs: remote_logs)
+
+        result = finder.call
+
+        expect(result).to eq "enterdanger/enterdanger"
+      end
+    end
+  end
+end

--- a/spec/lib/danger/ci_sources/support/remote_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/remote_finder_spec.rb
@@ -4,7 +4,7 @@ describe Danger::RemoteFinder do
   describe "#call" do
     it "returns repo slug from logs" do
       remote_logs = IO.read("spec/fixtures/ci_source/support/remote.log")
-      finder = described_class.new(github_host: "github.com", remote_logs: remote_logs)
+      finder = described_class.new("github.com", remote_logs)
 
       result = finder.call
 
@@ -14,7 +14,7 @@ describe Danger::RemoteFinder do
     context "specify GitHub Enterprise URL" do
       it "returns repo slug from logs" do
         remote_logs = IO.read("spec/fixtures/ci_source/support/enterprise-remote.log")
-        finder = described_class.new(github_host: "artsyhub.com", remote_logs: remote_logs)
+        finder = described_class.new("artsyhub.com", remote_logs)
 
         result = finder.call
 


### PR DESCRIPTION
Before this PR,

`danger local` can only find PR like `Merge pull request #42` from **merge commits**.

After this PR,

`danger local` can find PR like `Merge pull request #42` and `Summary (#42)` from [50 recent **commits**](https://github.com/danger/danger/blob/ccfbd83f289e716766161dd9802f0ff979fc51f3/lib/danger/ci_source/local_git_repo.rb#L49).

--

##### Misc.

- Add pry-byebug for debugging.
- Target Rubocop for >= Ruby 2.0

--

<details>
<summary>Merge commits v.s. commits</summary>
The commit logs given to find merged Pull Request changed from:

`git log --merges --oneline` to `git log --oneline -50`
</details>

<details>
<summary>Merge pull request v.s. squash and merge</summary>
`Merge pull request #42` is great old git merge, which we are using at [danger](https://github.com/danger/danger/commits/master):

<img width="635" alt="screenshot 2016-09-17 14 47 10" src="https://cloud.githubusercontent.com/assets/1000669/18606548/a55ccd7c-7ce5-11e6-9111-8cc301ddd89a.png">

`Summary (#42)` is GitHub's [new *squash and merge* type of merge](https://help.github.com/articles/about-pull-request-merges/), which is employed by [SwiftWeekly/swiftweekly.github.io](https://github.com/SwiftWeekly/swiftweekly.github.io/commits/master):

<img width="443" alt="screenshot 2016-09-17 14 47 15" src="https://cloud.githubusercontent.com/assets/1000669/18606549/a9845e7e-7ce5-11e6-9178-6b6cccc82f1a.png">
</details>
