### PR TITLE
Add missing require statements to CI subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * "danger local" can find squash-and-merge-type Pull Request - Juanito Fatas
 * Fix request_sources files and specs location - Juanito Fatas
+* trying to fix danger bugs - Juanito Fatas
 
 ## 3.3.0
 

--- a/circle.yml
+++ b/circle.yml
@@ -13,4 +13,5 @@ test:
     - git config --global user.email "danger@example.com"
     - git config --global user.name "Danger McShane"
     - bundle exec rake specs
-    - bundle exec danger
+    - bundle exec danger --verbose
+    - bundle exec danger init --mousey --impatient

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -1,4 +1,6 @@
 # http://devcenter.bitrise.io/docs/available-environment-variables
+require "danger/request_sources/github"
+require "danger/request_sources/gitlab"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -1,5 +1,7 @@
 # https://buildkite.com/docs/agent/osx
 # https://buildkite.com/docs/guides/environment-variables
+require "danger/request_sources/github"
+require "danger/request_sources/gitlab"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -1,6 +1,7 @@
 # https://circleci.com/docs/environment-variables
 require "uri"
 require "danger/ci_source/circle_api"
+require "danger/request_sources/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/drone.rb
+++ b/lib/danger/ci_source/drone.rb
@@ -1,4 +1,6 @@
 # http://readme.drone.io/usage/variables/
+require "danger/request_sources/github"
+require "danger/request_sources/gitlab"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -1,5 +1,6 @@
 # http://docs.gitlab.com/ce/ci/variables/README.html
 require "uri"
+require "danger/request_sources/gitlab"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -1,5 +1,9 @@
 # https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables
 # https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin
+require "danger/request_sources/github"
+require "danger/request_sources/gitlab"
+require "danger/request_sources/bitbucket_server"
+require "danger/request_sources/bitbucket_cloud"
 
 module Danger
   # https://jenkins-ci.org
@@ -38,7 +42,14 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab, Danger::RequestSources::BitbucketServer, Danger::RequestSources::BitbucketCloud]
+      @supported_request_sources ||= begin
+        [
+          Danger::RequestSources::GitHub,
+          Danger::RequestSources::GitLab,
+          Danger::RequestSources::BitbucketServer,
+          Danger::RequestSources::BitbucketCloud
+        ]
+      end
     end
 
     def initialize(env)

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -4,6 +4,7 @@ require "git"
 require "uri"
 require "danger/ci_source/support/remote_finder"
 require "danger/ci_source/support/merged_pull_request_finder"
+require "danger/request_sources/github"
 
 module Danger
   # ignore

--- a/lib/danger/ci_source/semaphore.rb
+++ b/lib/danger/ci_source/semaphore.rb
@@ -1,4 +1,5 @@
 # https://semaphoreci.com/docs/available-environment-variables.html
+require "danger/request_sources/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/surf.rb
+++ b/lib/danger/ci_source/surf.rb
@@ -1,4 +1,5 @@
 # http://github.com/surf-build/surf
+require "danger/request_sources/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/teamcity.rb
+++ b/lib/danger/ci_source/teamcity.rb
@@ -1,4 +1,6 @@
 # https://www.jetbrains.com/teamcity/
+require "danger/request_sources/github"
+require "danger/request_sources/gitlab"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/travis.rb
+++ b/lib/danger/ci_source/travis.rb
@@ -1,5 +1,6 @@
 # http://docs.travis-ci.com/user/osx-ci-environment/
 # http://docs.travis-ci.com/user/environment-variables/
+require "danger/request_sources/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/xcode_server.rb
+++ b/lib/danger/ci_source/xcode_server.rb
@@ -1,5 +1,6 @@
 # Following the advice from @czechboy0 https://github.com/danger/danger/issues/171
 # https://github.com/czechboy0/Buildasaur
+require "danger/request_sources/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -28,7 +28,7 @@ module Danger
         self.request_source = request_source
       end
 
-      raise "Could not find a Request Source for #{ci_klass}".red unless self.request_source
+      raise "Could not find a Request Source for #{ci_klass}\nCI: #{ci_source.inspect}".red unless self.request_source
       self.scm = self.request_source.scm
     end
 


### PR DESCRIPTION
* [danger/danger #1484 - CircleCI](https://circleci.com/gh/danger/danger/1484?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
* [Job #2334.1 - danger/danger - Travis CI](https://travis-ci.org/danger/danger/jobs/160656761)
* [Job #2339.3 - danger/danger - Travis CI](https://travis-ci.org/danger/danger/jobs/160682667)
* [Job #2337.2 - danger/danger - Travis CI](https://travis-ci.org/danger/danger/jobs/160680408)

They all cannot find their `supported_request_sources`, I think they need to require files they need in order to reference them.

#trivial