### PR TITLE
Increase number of commits danger local can search for merged PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Increase the number of commits `danger local` to search for merged PR - Juanito Fatas
+
 ## 3.3.1
 
 * "danger local" can find squash-and-merge-type Pull Request - Juanito Fatas

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -47,7 +47,7 @@ module Danger
 
       pull_request_id, sha = MergedPullRequestFinder.new(
         env["LOCAL_GIT_PR_ID"] || "",
-        run_git("log --oneline -50".freeze)
+        run_git("log --oneline -1000000".freeze)
       ).call
 
       self.repo_slug = repo_slug ? repo_slug : print_repo_slug_warning


### PR DESCRIPTION
This size affects how many commits can `danger local` search for `--use-merged-pr`.

50 is too small (my fault in #559 😭). Let's increase to 1000000.

I did memory experiments against some repos to see if this size is too big:

```ruby
# measure.rb

require "objspace"
ObjectSpace.trace_object_allocations_start

pid = Process.pid; puts "Process: #{pid}"
before = Time.now
before_rss = `ps -eo pid,rss | grep #{pid} | awk '{print $2}'`.to_i

commits = `git log --oneline -n1000000`

after_rss = `ps -eo pid,rss | grep #{pid} | awk '{print $2}'`.to_i
puts "Elapsed time: #{Time.now - before} seconds"
difference = after_rss - before_rss

if difference >= 1024
  puts "Memory consumed: #{(after_rss-before_rss)/1024.0} MB"
else
  puts "Memory consumed: #{after_rss-before_rss} KB"
end

commits = nil
```

Use `ruby measure.rb` in the repo root.

- danger/danger (1281 commits as of 19 Sep 2016):

  ```
  Process: 5859
  Elapsed time: 0.109446 seconds
  Memory consumed: 180 KB
  ```

- rails/rails (59600 commits as of 19 Sep 2016)

  ```
  Process: 5853
  Elapsed time: 1.286322 seconds
  Memory consumed: 4.3515625 MB
  ```

- torvalds/linux (617821 commits as of 19 Sep 2016)

  ```
  Process: 5834
  Elapsed time: 8.914288 seconds
  Memory consumed: 36.8671875 MB
  ```

I think 1000000 is quite ok, because normally a project just few thousand commits.