### PR TITLE
Danger id as context of Github status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Use danger_id as context for Github status - Thiago Felix
+
 ## 3.3.1
 
 * "danger local" can find squash-and-merge-type Pull Request - Juanito Fatas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master
 
-* Use danger_id as context for Github status - Thiago Felix
+* Use danger_id as context for GitHub status - Thiago Felix
 
 ## 3.3.1
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -151,10 +151,11 @@ module Danger
         # Note: this can terminate the entire process.
         submit_pull_request_status!(warnings: warnings,
                                       errors: errors,
-                                 details_url: comment_result["html_url"])
+                                 details_url: comment_result["html_url"],
+                                   danger_id: danger_id)
       end
 
-      def submit_pull_request_status!(warnings: [], errors: [], details_url: [])
+      def submit_pull_request_status!(warnings: [], errors: [], details_url: [], danger_id: "danger")
         status = (errors.count.zero? ? "success" : "failure")
         message = generate_description(warnings: warnings, errors: errors)
         latest_pr_commit_ref = self.pr_json["head"]["sha"]
@@ -166,7 +167,7 @@ module Danger
         begin
           client.create_status(ci_source.repo_slug, latest_pr_commit_ref, status, {
             description: message,
-            context: "danger/danger",
+            context: "danger/#{danger_id}",
             target_url: details_url
           })
         rescue

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -132,6 +132,14 @@ describe Danger::RequestSources::GitHub, host: :github do
           @g.submit_pull_request_status!
         end.to raise_error("Couldn't find a commit to update its status".red)
       end
+
+      it "uses danger_id as context of status" do
+        options = hash_including(:context => "danger/special_context")
+        expect(@g.client).to receive(:create_status).with(any_args, options).and_return({})
+
+        @g.pr_json = { "head" => { "sha" => "pr_commit_ref" } }
+        @g.submit_pull_request_status!(danger_id: "special_context")
+      end
     end
 
     describe "issue creation" do

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -134,7 +134,7 @@ describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "uses danger_id as context of status" do
-        options = hash_including(:context => "danger/special_context")
+        options = hash_including("context" => "danger/special_context")
         expect(@g.client).to receive(:create_status).with(any_args, options).and_return({})
 
         @g.pr_json = { "head" => { "sha" => "pr_commit_ref" } }

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -134,7 +134,7 @@ describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "uses danger_id as context of status" do
-        options = hash_including("context" => "danger/special_context")
+        options = hash_including(context: "danger/special_context")
         expect(@g.client).to receive(:create_status).with(any_args, options).and_return({})
 
         @g.pr_json = { "head" => { "sha" => "pr_commit_ref" } }


### PR DESCRIPTION
This uses the danger_id to set the context of Github status. Should allow multiple status for multiple execution of danger cli.

See #570