### PR TITLE
Fix rubocop offenses and add parentheses to avoid Ruby emit warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Increase the number of commits `danger local` to search for merged PR - Juanito Fatas
+* Fix rubocop offenses in plugin_linter.rb - Juanito Fatas
 
 ## 3.3.1
 

--- a/lib/danger/plugin_support/plugin_linter.rb
+++ b/lib/danger/plugin_support/plugin_linter.rb
@@ -130,9 +130,9 @@ module Danger
     # Generates a link to see an example of said rule
     #
     def link(ref)
-      if ref.kind_of? Range
+      if ref.kind_of?(Range)
         "@see - " + "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref.min}#-L#{ref.max}".blue
-      elsif ref.kind_of? Fixnum
+      elsif ref.kind_of?(Integer)
         "@see - " + "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref}".blue
       else
         "@see - " + "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb".blue


### PR DESCRIPTION
This PR fixes rubocop warnings.