### PR TITLE
Example for diff_for_file is incorrect #trivial

### DIFF
--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -28,7 +28,7 @@ module Danger
   #
   # @example Warn when somebody tries to add nokogiri to the project
   #
-  #          diff = git.diff_for_file["Gemfile.lock"]
+  #          diff = git.diff_for_file("Gemfile.lock")
   #          if diff && diff.patch =~ "nokogiri"
   #            warn 'Please do not add nokogiri to the project. Thank you.'
   #          end


### PR DESCRIPTION
- Following the example on [danger.systems](http://danger.systems) confused me for a while.
- Does this text exist anywhere else for the website generation or just here?
