### PR TITLE
The post_results method belongs to Dangerfile #trivial

### DIFF
--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -237,6 +237,18 @@ module Danger
       violation_report[:errors].count > 0
     end
 
+    def post_results(danger_id)
+      violations = violation_report
+
+      env.request_source.update_pull_request!(
+        warnings: violations[:warnings],
+        errors: violations[:errors],
+        messages: violations[:messages],
+        markdowns: status_report[:markdowns],
+        danger_id: danger_id
+      )
+    end
+
     private
 
     def print_list(title, rows)

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -38,7 +38,9 @@ module Danger
         dm.parse Pathname.new(dangerfile_path)
 
         # Push results to the API
-        post_results dm, danger_id
+        # Pass along the details of the run to the request source
+        # to send back to the code review site.
+        dm.post_results(danger_id)
 
         # Print results in the terminal
         dm.print_results
@@ -76,22 +78,6 @@ module Danger
     # Could we determine that the CI source is inside a PR?
     def validate_is_pr?
       EnvironmentManager.pr?(@system_env)
-    end
-
-    # Pass along the details of the run to the request source
-    # to send back to the code review site.
-    def post_results(danger_file, danger_id)
-      request_source = danger_file.env.request_source
-      violations = danger_file.violation_report
-      status = danger_file.status_report
-
-      request_source.update_pull_request!(
-        warnings: violations[:warnings],
-        errors: violations[:errors],
-        messages: violations[:messages],
-        markdowns: status[:markdowns],
-        danger_id: danger_id
-      )
     end
   end
 end

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -207,4 +207,18 @@ describe Danger::Dangerfile, host: :github do
       end
     end
   end
+
+  describe "#post_results" do
+    it "delegates to corresponding request source" do
+      env_manager = double("Danger::EnvironmentManager", pr?: true)
+      allow(env_manager).to receive_message_chain(:scm, :class) { Danger::GitRepo }
+      request_source = double("Danger::RequestSources::GitHub")
+      allow(env_manager).to receive(:request_source) { request_source }
+      dm = Danger::Dangerfile.new(env_manager, testing_ui)
+
+      expect(request_source).to receive(:update_pull_request!)
+
+      dm.post_results("danger-identifier")
+    end
+  end
 end


### PR DESCRIPTION
# !!! This PR merges into #583

This method used `dangerfile` 3 times, it is jealous of `Dangerfile` ([feature envy](https://sourcemaking.com/refactoring/smells/feature-envy)), so this method should belong to `Dangerfile`.