### PR TITLE
Improves `danger local` merged Pull Request finding logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Simplify initialization of Octokit client in request_sources/github.rb - Juanito Fatas
 * Ensure commits exist inside the local git repo before using them for diffs - orta
 * Big improvements to the warning around no API tokens being found - orta
+* Improves `danger local` merged Pull Request finding logic - Juanito Fatas
 
 ## 3.3.2
 

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -46,7 +46,7 @@ module Danger
       ).call
 
       pull_request_id, sha = MergedPullRequestFinder.new(
-        env["LOCAL_GIT_PR_ID"] || "",
+        env.fetch("LOCAL_GIT_PR_ID") { "" },
         run_git("log --oneline -1000000".freeze)
       ).call
 

--- a/lib/danger/ci_source/support/merged_pull_request_finder.rb
+++ b/lib/danger/ci_source/support/merged_pull_request_finder.rb
@@ -17,20 +17,20 @@ module Danger
 
     # @return [String] "#42"
     def pull_request_ref
-      specific_pull_request_id ? "##{specific_pull_request_id}" : "".freeze
+      !specific_pull_request_id.empty? ? "##{specific_pull_request_id}" : "#\\d+".freeze
     end
 
     # @return [String] Log line of format: "Merge pull request #42"
     def most_recent_merged_pull_request
       @most_recent_merged_pull_request ||= begin
-        git_logs.lines.grep(/Merge pull request #{pull_request_ref}/)[0]
+        git_logs.lines.grep(/Merge pull request #{pull_request_ref} from/)[0]
       end
     end
 
     # @return [String] Log line of format: "description (#42)"
     def most_recent_squash_and_merged_pull_request
       @most_recent_squash_and_merged_pull_request ||= begin
-        git_logs.lines.grep(/#{pull_request_ref}/)[0]
+        git_logs.lines.grep(/\(#{pull_request_ref}\)/)[0]
       end
     end
 
@@ -38,16 +38,45 @@ module Danger
     def merged_pull_request
       return if pull_request_ref.empty?
 
-      if most_recent_merged_pull_request
+      if both_present?
+        pick_the_most_recent_one_from_two_matches
+      elsif only_merged_pull_request_present?
         most_recent_merged_pull_request
-      elsif most_recent_squash_and_merged_pull_request
+      elsif only_squash_and_merged_pull_request_present?
         most_recent_squash_and_merged_pull_request
+      end
+    end
+
+    def both_present?
+      most_recent_merged_pull_request && most_recent_squash_and_merged_pull_request
+    end
+
+    def only_merged_pull_request_present?
+      return false if most_recent_squash_and_merged_pull_request
+
+      !most_recent_merged_pull_request.nil? && !most_recent_merged_pull_request.empty?
+    end
+
+    def only_squash_and_merged_pull_request_present?
+      return false if most_recent_merged_pull_request
+
+      !most_recent_squash_and_merged_pull_request.nil? && !most_recent_squash_and_merged_pull_request.empty?
+    end
+
+    def pick_the_most_recent_one_from_two_matches
+      merged_index = git_logs.lines.index(most_recent_merged_pull_request)
+      squash_and_merged_index = git_logs.lines.index(most_recent_squash_and_merged_pull_request)
+
+      if merged_index > squash_and_merged_index # smaller index is more recent
+        most_recent_squash_and_merged_pull_request
+      else
+        most_recent_merged_pull_request
       end
     end
 
     def check_if_any_merged_pull_request!
       if merged_pull_request.to_s.empty?
-        if specific_pull_request_id
+        if !specific_pull_request_id.empty?
           raise "Could not find the Pull Request (#{specific_pull_request_id}) inside the git history for this repo."
         else
           raise "No recent Pull Requests found for this repo, danger requires at least one Pull Request for the local mode.".freeze

--- a/spec/fixtures/ci_source/support/two-kinds-of-merge-both-present.log
+++ b/spec/fixtures/ci_source/support/two-kinds-of-merge-both-present.log
@@ -1,0 +1,5 @@
+1234567 This is fake commit
+9f8c75a Fail on errors (#2)
+8e9a3ab Fixes typo in init.rb #trivial (#588)
+f029131 Merge pull request #2 from orta/KrauseFx-patch-1
+54bff64 Initial commit

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -119,12 +119,12 @@ describe Danger::LocalGitRepo do
         end
 
         it "handles finding the resulting PR" do
-          run_in_repo do
+          run_in_repo(merge_pr: true) do
             add_another_pr
 
             env = { "DANGER_USE_LOCAL_GIT" => "true", "LOCAL_GIT_PR_ID" => "1234" }
             t = Danger::LocalGitRepo.new(env)
-            expect(t.pull_request_id).to eql("1234")
+            expect(t.pull_request_id).to eq("1234")
           end
         end
       end
@@ -134,7 +134,7 @@ describe Danger::LocalGitRepo do
           run_in_repo do
             valid_env["LOCAL_GIT_PR_ID"] = "1238"
 
-            expect { source }.to raise_error RuntimeError
+            expect { source }.to raise_error RuntimeError, "Could not find the Pull Request (1238) inside the git history for this repo."
           end
         end
       end
@@ -142,7 +142,7 @@ describe Danger::LocalGitRepo do
       context "no PRs" do
         it "raise an exception" do
           run_in_repo(merge_pr: false) do
-            expect { source }.to raise_error RuntimeError
+            expect { source }.to raise_error RuntimeError, "No recent Pull Requests found for this repo, danger requires at least one Pull Request for the local mode."
           end
         end
       end

--- a/spec/lib/danger/ci_sources/support/merged_pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/merged_pull_request_finder_spec.rb
@@ -16,6 +16,10 @@ describe Danger::MergedPullRequestFinder do
     IO.read("spec/fixtures/ci_source/support/swiftweekly.github.io-git.log")
   end
 
+  def two_kinds_of_merge_log
+    IO.read("spec/fixtures/ci_source/support/two-kinds-of-merge-both-present.log")
+  end
+
   describe "#call" do
     context "not specified Pull Request ID" do
       context "merge pull request type Pull Request" do
@@ -54,6 +58,15 @@ describe Danger::MergedPullRequestFinder do
           expect(pull_request_id).to eq "77"
           expect(sha).to eq "3f7047a"
         end
+      end
+    end
+
+    context "merged and squash-and-merged both present" do
+      it "returns the most recent one" do
+        pull_request_id, sha = finder(pull_request_id: "2", logs: two_kinds_of_merge_log).call
+
+        expect(pull_request_id).to eq "2"
+        expect(sha).to eq "9f8c75a"
       end
     end
   end


### PR DESCRIPTION
This Pull Request improves `danger local` finding merged Pull Request logic.

I was trying to use `danger local` against my repo and found this bug 😢 

--

<details>
<summary>Implementation Details</summary>
- Feed in PR ID correctly to `MergedPullRequestFinder`:

  Given `LOCAL_GIT_PR_ID="2"`

  Before

  `env["LOCAL_GIT_PR_ID"] || "" # => ""`

  After

  `env.fetch("LOCAL_GIT_PR_ID") { "" } # => "2"`

- Handle case that both merged and squash-and-merged (same as rebase merge) PR both presents

  * `Something (#2)`
  * `Merge pull request #2`

    Pick the most recent one in these two.

- Improves the RegExp for finding merged pull request and
squash-and-merged pull request.

  * Merged PR:

    - Before: `"Merge pull request #2"`
    - After: `"Merge pull request #2 from"`

  * Squash-and-merged PR:

    - Before: `"#2"`
    - After: `"(#2)"`

- When PR ID not specified, use`/#\d+/` to search a recent PR.
</details>