### PR TITLE
Remove duplicate env check in TeamCity's GitHub env check #trivial

### DIFF
--- a/lib/danger/ci_source/teamcity.rb
+++ b/lib/danger/ci_source/teamcity.rb
@@ -32,7 +32,7 @@ module Danger
   class TeamCity < CI
     class << self
       def validates_as_github_pr?(env)
-        ["GITHUB_PULL_REQUEST_ID", "GITHUB_REPO_URL", "GITHUB_REPO_URL"].all? { |x| env[x] && !env[x].empty? }
+        ["GITHUB_PULL_REQUEST_ID", "GITHUB_REPO_URL"].all? { |x| env[x] && !env[x].empty? }
       end
 
       def validates_as_gitlab_pr?(env)


### PR DESCRIPTION
Probably copy-pasta 🍝, this PR removes this duplicate check.