### PR TITLE
Remove unused options for `danger local`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Big improvements to the warning around no API tokens being found - orta
 * Support for failing on errors - orta/Juanito Fatas (the PR is pretty sharedgit)
 * Improves `danger local` merged Pull Request finding logic - Juanito Fatas
+* Remove unused CLI options from `danger local` - Juanito Fatas
 
 ## 3.3.2
 

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -9,6 +9,14 @@ module Danger
     self.summary = "Run the Dangerfile locally."
     self.command = "local"
 
+    def self.options
+      [
+        ["--use-merged-pr=[#id]", "The ID of an already merged PR inside your history to use as a reference for the local run."],
+        ["--clear-http-cache", "Clear the local http cache before running Danger locally."],
+        ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
+      ]
+    end
+
     def initialize(argv)
       @pr_num = argv.option("use-merged-pr")
       @clear_http_cache = argv.flag?("clear-http-cache", false)
@@ -37,14 +45,6 @@ module Danger
       cork.warn "Pry was not found, and is required for 'danger local --pry'."
       cork.print_warnings
       abort
-    end
-
-    def self.options
-      [
-        ["--use-merged-pr=[#id]", "The ID of an already merged PR inside your history to use as a reference for the local run."],
-        ["--clear-http-cache", "Clear the local http cache before running Danger locally."],
-        ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
-      ].concat(super)
     end
 
     def validate!

--- a/spec/lib/danger/commands/local_spec.rb
+++ b/spec/lib/danger/commands/local_spec.rb
@@ -1,0 +1,24 @@
+require "danger/commands/local"
+
+describe Danger::Local do
+  describe ".options" do
+    it "contains extra options for local command" do
+      result = described_class.options
+
+      expect(result).to include ["--use-merged-pr=[#id]", "The ID of an already merged PR inside your history to use as a reference for the local run."]
+      expect(result).to include ["--clear-http-cache", "Clear the local http cache before running Danger locally."]
+      expect(result).to include ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
+    end
+  end
+
+  context "default options" do
+    it "pr number is nil and clear_http_cache defaults to false" do
+      argv = CLAide::ARGV.new([])
+
+      result = described_class.new(argv)
+
+      expect(result.instance_variable_get(:"@pr_num")).to eq nil
+      expect(result.instance_variable_get(:"@clear_http_cache")).to eq false
+    end
+  end
+end


### PR DESCRIPTION
This PR removes unused options from `danger local` command. Fixes #593.

And move class method above instance methods.

