### PR TITLE
Add some specs for Runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Big improvements to the warning around no API tokens being found - orta
 * Support for failing on errors - orta/Juanito Fatas (the PR is pretty sharedgit)
 * Improves `danger local` merged Pull Request finding logic - Juanito Fatas
+* Adds some tests for Danger::Runner - Juanito Fatas
 
 ## 3.3.2
 

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -29,7 +29,7 @@ module Danger
 
     def initialize(argv)
       dangerfile = argv.option("dangerfile", "Dangerfile")
-      @dangerfile_path = dangerfile if File.exist? dangerfile
+      @dangerfile_path = dangerfile if File.exist?(dangerfile)
       @base = argv.option("base")
       @head = argv.option("head")
       @fail_on_errors = argv.option("fail-on-errors", false)
@@ -42,7 +42,7 @@ module Danger
     def validate!
       super
       if self.class == Runner && !@dangerfile_path
-        help! "Could not find a Dangerfile."
+        help!("Could not find a Dangerfile.")
       end
     end
 

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -1,126 +1,89 @@
-module Command
-  describe Danger::Runner do
-    before do
-      # Danger local stuff
-      allow(ENV).to receive(:[]).with("DANGER_USE_LOCAL_GIT").and_return(nil)
-      allow(ENV).to receive(:[]).with("DANGER_GITHUB_HOST").and_return("")
-      allow(ENV).to receive(:[]).with("DANGER_GITHUB_API_TOKEN").and_return("11")
-      allow(ENV).to receive(:[]).with("DANGER_GITHUB_API_BASE_URL").and_return(nil)
+require "danger/commands/runner"
+require "danger/danger_core/executor"
 
-      # We'll take the first CI Source
-      allow(ENV).to receive(:[]).with("BUILDKITE").and_return("SURE")
-      allow(ENV).to receive(:[]).with("BUILDKITE_PULL_REQUEST_REPO").and_return("git@github.com:artsy/eigen.git")
-      allow(ENV).to receive(:[]).with("BUILDKITE_PULL_REQUEST").and_return("800")
-
-      # ENV vars used under the hood
-      allow(ENV).to receive(:[]).with("http_proxy").and_return(nil)
-      allow(ENV).to receive(:[]).with("TMPDIR").and_return(nil)
-      allow(ENV).to receive(:[]).with("TMP").and_return(nil)
-      allow(ENV).to receive(:[]).with("TEMP").and_return(nil)
-      allow(ENV).to receive(:[]).with("CLAIDE_DISABLE_AUTO_WRAP").and_return(nil)
-      allow(ENV).to receive(:[]).with("GEM_REQUIREMENT_DANGER").and_return(nil)
-
-      # Mock out the octokit object with our fixtured data
-      octokit_mock = Object
-
-      pr_response = JSON.parse(fixture("github_api/pr_response"), symbolize_names: true)
-      allow(octokit_mock).to receive(:pull_request).with("artsy/eigen", "800").and_return(pr_response)
-      issue_response = JSON.parse(fixture("github_api/issue_response"), symbolize_names: true)
-      allow(octokit_mock).to receive(:get).with("https://api.github.com/repos/artsy/eigen/issues/800").and_return(issue_response)
-      issue_comments_response = JSON.parse(fixture("github_api/issue_comments"), symbolize_names: true)
-      allow(octokit_mock).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issue_comments_response)
-
-      issue_comment_response = JSON.parse(fixture("github_api/issue_response"), symbolize_names: true)
-      allow(octokit_mock).to receive(:add_comment).and_return(issue_comment_response)
-
-      allow(Octokit::Client).to receive(:new).and_return octokit_mock
-    end
-
-    xit "runtime errors when no Dangerfile found" do
-      allow(STDOUT).to receive(:puts) # this disables puts
+describe Danger::Runner do
+  context "without Dangerfile" do
+    it "raises error" do
+      argv = CLAide::ARGV.new([])
 
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
-          expect { Danger::Runner.run([]) }.to raise_error SystemExit
+          runner = described_class.new(argv)
+          expect { runner.validate! }.to raise_error(StandardError, /Could not find a Dangerfile./)
         end
       end
     end
+  end
 
-    describe "Calls Executor" do
-      it "works without parameters" do
-        a = "fake"
-        expect(Danger::Executor).to receive(:new).and_return(a)
-        expect(a).to receive(:run).with({
-          base: nil,
-          head: nil,
-          dangerfile_path: "Dangerfile",
-          danger_id: "danger",
-          fail_on_errors: false
-        })
-        Danger::Runner.run([])
-      end
+  context "default options" do
+    it "sets instance variables accrodingly" do
+      argv = CLAide::ARGV.new([])
+
+      runner = described_class.new(argv)
+      ui = runner.instance_variable_get(:"@cork")
+
+      expect(runner).to have_instance_variables(
+        "@dangerfile_path" => "Dangerfile",
+        "@base" => nil,
+        "@head" => nil,
+        "@fail_on_errors" => false,
+        "@danger_id" => "danger"
+      )
+      expect(ui).to be_a Cork::Board
+      expect(ui).to have_instance_variables(
+        "@silent" => false,
+        "@verbose" => false
+      )
+    end
+  end
+
+  describe "#run" do
+    it "invokes Executor" do
+      argv = CLAide::ARGV.new([])
+      runner = described_class.new(argv)
+      executor = double("Executor")
+
+      expect(Danger::Executor).to receive(:new) { executor }
+      expect(executor).to receive(:run).with(
+        base: nil,
+        head: nil,
+        dangerfile_path: "Dangerfile",
+        danger_id: "danger",
+        fail_on_errors: false
+      )
+
+      runner.run
     end
 
-    describe "full run" do
-      before do
-        @git_mock = Danger::GitRepo.new
-        allow(Danger::GitRepo).to receive(:new).and_return @git_mock
+    context "with custom CLI options passed in" do
+      before { IO.write("MyDangerfile", "") }
 
-        git_commands = [
-          { "rev-parse --quiet --verify danger_base" => "OK" },
-          { "rev-parse --quiet --verify danger_head" => "OK" },
-          { "rev-parse HEAD" => "561827e46167077b5e53515b4b7349b8ae04610b" },
-          { "branch danger_base 704dc55988c6996f69b6873c2424be7d1de67bbe" => "" },
-          { "branch danger_head 561827e46167077b5e53515b4b7349b8ae04610b" => "" },
-          { "remote show origin -n | grep \"Fetch URL\" | cut -d ':' -f 2-" => "git@github.com:artsy/eigen.git" },
-          { "branch -D danger_base" => "" },
-          { "branch -D danger_head" => "" }
-        ]
+      it "overrides default options" do
+        argv = CLAide::ARGV.new(
+          [
+            "--base=my-base",
+            "--head=my-head",
+            "--dangerfile=MyDangerfile",
+            "--danger_id=my-danger-id",
+            "--fail-on-errors=true"
+          ]
+        )
+        runner = described_class.new(argv)
+        executor = double("Executor")
 
-        git_commands.each do |command|
-          allow(@git_mock).to receive(:exec).with(command.keys.first).and_return(command.values.first)
-        end
+        expect(Danger::Executor).to receive(:new) { executor }
+        expect(executor).to receive(:run).with(
+          base: "my-base",
+          head: "my-head",
+          dangerfile_path: "MyDangerfile",
+          danger_id: "my-danger-id",
+          fail_on_errors: "true"
+        )
+
+        runner.run
       end
 
-      xit "gets through the whole command" do
-        Dir.mktmpdir do |dir|
-          Dir.chdir dir do
-            `git init`
-            `git remote add origin git@github.com:artsy/eigen.git`
-            `touch Dangerfile`
-            Danger::Runner.run([])
-          end
-        end
-      end
-
-      xit "handles an example dangerfile well" do
-        allow(STDOUT).to receive(:puts) # this disables puts
-
-        Dir.mktmpdir do |dir|
-          Dir.chdir dir do
-            `git init`
-            `git remote add origin git@github.com:artsy/eigen.git`
-
-            File.write("Dangerfile", %{
-              message "Hi"
-              warn "OK"
-              fail "Not OK"
-              markdown "OK [link](http://sure.com)"
-
-              warn("ok", sticky: false)
-              fail("not ok", sticky: false)
-              message("hi", sticky: false)
-            })
-
-            # This will call `abort` due to the fails in the Dangerfile
-            expect { Danger::Runner.run([]) }.to raise_error(SystemExit)
-          end
-        end
-      end
-
-      xit "has the correct version" do
-        expect(Danger::Runner.version).to eq(Danger::VERSION)
-      end
+      after { FileUtils.rm("MyDangerfile") }
     end
   end
 end

--- a/spec/support/matchers/have_instance_variables_matcher.rb
+++ b/spec/support/matchers/have_instance_variables_matcher.rb
@@ -1,0 +1,25 @@
+RSpec::Matchers.define(:have_instance_variables) do |expected|
+  match do |actual|
+    expected.each do |instance_variable, expected_value|
+      expect(actual.instance_variable_get(instance_variable)).to eq(expected_value)
+    end
+  end
+
+  failure_message do |actual|
+    expected.each do |instance_variable, expected_value|
+      actual_value = actual.instance_variable_get(instance_variable)
+      if actual_value != expected_value
+        return "expected #{actual}#{instance_variable} to match #{expected_value}, but got #{actual_value}."
+      end
+    end
+  end
+
+  failure_message_when_negated do |actual|
+    expected.each do |instance_variable, expected_value|
+      actual_value = actual.instance_variable_get(instance_variable)
+      if actual_value == expected_value
+        return "expected #{actual}#{instance_variable} not to match #{expected_value}, but got #{actual_value}."
+      end
+    end
+  end
+end


### PR DESCRIPTION
I think these pending tests should belongs to the executor specs. Will do in following PRs.

- Test no Dangerfile present
- Test instance variables' default values
- Test default CLI options
- Test correctly sending messages to Executor
- Introduce new RSpec matcher: `have_instance_variables` (similar to have_attributes, but for instance variables)