### PR TITLE
Raises error if plugin file doesn't contain any plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Big improvements to the warning around no API tokens being found - orta
 * Support for failing on errors - orta/Juanito Fatas (the PR is pretty sharedgit)
 * Improves `danger local` merged Pull Request finding logic - Juanito Fatas
+* Raises error if plugin file doesn't contain any class inherits from Plugin - Juanito Fatas
 
 ## 3.3.2
 

--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -197,9 +197,19 @@ module Danger
     # @return [void]
     def import_local(path)
       Dir[path].each do |file|
+        validate_file_contains_plugin!(file)
+
         # Without the expand_path it would fail if the path doesn't start with ./
         require File.expand_path(file)
         refresh_plugins
+      end
+    end
+
+    def validate_file_contains_plugin!(file)
+      content = IO.read(file)
+
+      if content.scan(/class\s+(?<plugin_class>[\w]+)\s+<\s+Plugin/i).empty?
+        raise("#{file} doesn't contain any valid danger plugin.")
       end
     end
   end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -19,14 +19,10 @@ describe Danger::Dangerfile::DSL, host: :github do
         expect(dm.example_globbing.echo).to eq("Hi there globbing")
       end
 
-      # This is going to become a lot more complicated in the future, so I'm
-      # happy to have it pending for now.
-      xit "raises an error when calling a plugin that's not a subclass of Plugin" do
-        dm.danger.import_plugin("spec/fixtures/plugins/example_broken.rb")
-
+      it "raises an error when calling a plugin that's not a subclass of Plugin" do
         expect do
-          dm.example_broken
-        end.to raise_error("'example_broken' is not a valid danger plugin".red)
+          dm.danger.import_plugin("spec/fixtures/plugins/example_broken.rb")
+        end.to raise_error(RuntimeError, %r{spec/fixtures/plugins/example_broken.rb doesn't contain any valid danger plugin})
       end
     end
 


### PR DESCRIPTION
This PR adds a feature that if plugin file doesn't contain any class inherits from `Plugin` then raises an error message: `"danger-orta-plugin.rb doesn't contain any valid danger plugin."`