### PR TITLE
Patch/environment manager specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master
 
 * Added option to run a Dangerfile from a `branch` and/or `path` when using a remote repo - felipesabino
-
+* Add specs for `Danger::EnvironmentManager` - Juanito Fatas
 
 ## 3.4.0
 

--- a/lib/danger/ci_source/ci_source.rb
+++ b/lib/danger/ci_source/ci_source.rb
@@ -19,7 +19,7 @@ module Danger
     end
 
     def supports?(request_source)
-      supported_request_sources.include? request_source
+      supported_request_sources.include?(request_source)
     end
 
     def self.validates_as_ci?(_env)

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -63,12 +63,12 @@ module Danger
       end
     end
 
-    def meta_info_for_base
-      scm.exec("--no-pager log #{EnvironmentManager.danger_base_branch} -n1")
-    end
-
     def meta_info_for_head
       scm.exec("--no-pager log #{EnvironmentManager.danger_head_branch} -n1")
+    end
+
+    def meta_info_for_base
+      scm.exec("--no-pager log #{EnvironmentManager.danger_base_branch} -n1")
     end
 
     def raise_error_for_no_request_source(env, ui)

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -15,6 +15,16 @@ module Danger
       local_ci_source(env).validates_as_pr?(env)
     end
 
+    # @return [String] danger's default head branch
+    def self.danger_head_branch
+      "danger_head".freeze
+    end
+
+    # @return [String] danger's default base branch
+    def self.danger_base_branch
+      "danger_base".freeze
+    end
+
     def initialize(env, ui)
       ci_klass = self.class.local_ci_source(env)
       self.ci_source = ci_klass.new(env)
@@ -59,14 +69,6 @@ module Danger
 
     def meta_info_for_head
       scm.exec("--no-pager log #{EnvironmentManager.danger_head_branch} -n1")
-    end
-
-    def self.danger_head_branch
-      "danger_head"
-    end
-
-    def self.danger_base_branch
-      "danger_base"
     end
 
     def raise_error_for_no_request_source(env, ui)

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -203,6 +203,21 @@ describe Danger::EnvironmentManager, use: :ci_helper do
     end
   end
 
+  describe "#clean_up" do
+    it "delete danger branches" do
+      git_repo_with_danger_branches_setup do |_, _|
+        with_travis_setup_and_is_a_pull_request do |system_env|
+          described_class.new(system_env, testing_ui).clean_up
+
+          branches = `git branch`.lines.map(&:strip!)
+
+          expect(branches).not_to include("danger_head")
+          expect(branches).not_to include("danger_base")
+        end
+      end
+    end
+  end
+
   describe "#meta_info_for_head" do
     it "returns last commit of danger head branch" do
       git_repo_with_danger_branches_setup do |head_sha, _base_sha|

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -161,6 +161,18 @@ describe Danger::EnvironmentManager do
     end
   end
 
+  describe ".danger_head_branch" do
+    it "returns danger_head" do
+      expect(described_class.danger_head_branch).to eq("danger_head")
+    end
+  end
+
+  describe ".danger_base_branch" do
+    it "returns danger_base" do
+      expect(described_class.danger_base_branch).to eq("danger_base")
+    end
+  end
+
   describe "#pr?", use: :ci_helper do
     it "returns true if has a ci source" do
       with_travis_setup_and_is_a_pull_request do |env|

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -75,9 +75,9 @@ describe Danger::EnvironmentManager do
     end
 
     it "does not return a CI source with no ENV deets" do
-      env = { "KEY" => "VALUE" }
-
-      expect(Danger::EnvironmentManager.local_ci_source(env)).to eq nil
+      we_dont_have_ci_setup do |system_env|
+        expect(Danger::EnvironmentManager.local_ci_source(system_env)).to eq nil
+      end
     end
   end
 
@@ -158,6 +158,15 @@ describe Danger::EnvironmentManager do
       env = { "KEY" => "VALUE" }
 
       expect(Danger::EnvironmentManager.local_ci_source(env)).to eq nil
+    end
+  end
+
+  describe "#pr?", use: :ci_helper do
+    it "returns true if has a ci source" do
+      with_travis_setup_and_is_a_pull_request do |env|
+        env_manager = Danger::EnvironmentManager.new(env, testing_ui)
+        expect(env_manager.pr?).to eq true
+      end
     end
   end
 

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -81,6 +81,86 @@ describe Danger::EnvironmentManager do
     end
   end
 
+  describe ".pr?", use: :ci_helper do
+    it "loads Bitrise" do
+      with_bitrise_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Buildkite" do
+      with_buildkite_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Circle" do
+      with_circle_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Drone" do
+      with_drone_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads GitLab CI" do
+      with_gitlabci_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Jenkins" do
+      with_jenkins_setup_github_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Local Git Repo" do
+      with_localgitrepo_setup do |system_env|
+        expect(described_class.pr?(system_env)).to eq(false)
+      end
+    end
+
+    it "loads Semaphore" do
+      with_semaphore_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Surf" do
+      with_surf_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads TeamCity" do
+      with_teamcity_setup_github_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Travis" do
+      with_travis_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Xcode Server" do
+      with_xcodeserver_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "does not return a CI source with no ENV deets" do
+      env = { "KEY" => "VALUE" }
+
+      expect(Danger::EnvironmentManager.local_ci_source(env)).to eq nil
+    end
+  end
+
   it "stores travis in the source" do
     number = 123
     env = { "DANGER_GITHUB_API_TOKEN" => "abc123",

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -1,10 +1,84 @@
 require "danger/danger_core/environment_manager"
 
 describe Danger::EnvironmentManager do
-  it "does not return a CI source with no ENV deets" do
-    env = { "KEY" => "VALUE" }
+  describe ".local_ci_source", use: :ci_helper do
+    it "loads Bitrise" do
+      with_bitrise_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::Bitrise
+      end
+    end
 
-    expect(Danger::EnvironmentManager.local_ci_source(env)).to eq nil
+    it "loads Buildkite" do
+      with_buildkite_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::Buildkite
+      end
+    end
+
+    it "loads Circle" do
+      with_circle_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::CircleCI
+      end
+    end
+
+    it "loads Drone" do
+      with_drone_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::Drone
+      end
+    end
+
+    it "loads GitLab CI" do
+      with_gitlabci_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::GitLabCI
+      end
+    end
+
+    it "loads Jenkins" do
+      with_jenkins_setup_github_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::Jenkins
+      end
+    end
+
+    it "loads Local Git Repo" do
+      with_localgitrepo_setup do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::LocalGitRepo
+      end
+    end
+
+    it "loads Semaphore" do
+      with_semaphore_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::Semaphore
+      end
+    end
+
+    it "loads Surf" do
+      with_surf_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::Surf
+      end
+    end
+
+    it "loads TeamCity" do
+      with_teamcity_setup_github_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::TeamCity
+      end
+    end
+
+    it "loads Travis" do
+      with_travis_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::Travis
+      end
+    end
+
+    it "loads Xcode Server" do
+      with_xcodeserver_setup_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::XcodeServer
+      end
+    end
+
+    it "does not return a CI source with no ENV deets" do
+      env = { "KEY" => "VALUE" }
+
+      expect(Danger::EnvironmentManager.local_ci_source(env)).to eq nil
+    end
   end
 
   it "stores travis in the source" do

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -225,7 +225,7 @@ describe Danger::EnvironmentManager, use: :ci_helper do
         with_travis_setup_and_is_a_pull_request(request_source: :github) do |env|
           result = described_class.new(env, testing_ui).meta_info_for_head
 
-          expect(result).to match(/#{head_sha}.+HEAD/)
+          expect(result).to include(head_sha)
         end
       end
     end
@@ -237,7 +237,7 @@ describe Danger::EnvironmentManager, use: :ci_helper do
         with_travis_setup_and_is_a_pull_request(request_source: :github) do |env|
           result = described_class.new(env, testing_ui).meta_info_for_base
 
-          expect(result).to match(/#{base_sha}.+BASE/)
+          expect(result).to include(base_sha)
         end
       end
     end

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -1,7 +1,7 @@
 require "danger/danger_core/executor"
 
 # If you cannot find a method, please check spec/support/executor_helper.rb.
-describe Danger::Executor, use: :executor_helper do
+describe Danger::Executor, use: :ci_helper do
   describe "#validate!" do
     context "with CI + is a PR" do
       it "not raises error on Bitrise" do
@@ -18,12 +18,6 @@ describe Danger::Executor, use: :executor_helper do
 
       it "not raises error on Circle" do
         with_circle_setup_and_is_a_pull_request do |system_env|
-          expect { described_class.new(system_env).validate!(testing_ui) }.not_to raise_error
-        end
-      end
-
-      it "not raises error on Circle API" do
-        with_circleapi_setup_and_is_a_pull_request do |system_env|
           expect { described_class.new(system_env).validate!(testing_ui) }.not_to raise_error
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
   config.include Danger::Support::GitHubHelper, host: :github
   config.include Danger::Support::BitbucketServerHelper, host: :bitbucket_server
   config.include Danger::Support::BitbucketCloudHelper, host: :bitbucket_cloud
-  config.include Danger::Support::ExecutorHelper, use: :executor_helper
+  config.include Danger::Support::CIHelper, use: :ci_helper
 
   config.run_all_when_everything_filtered = true
   config.filter_run focus: true

--- a/spec/support/ci_helper.rb
+++ b/spec/support/ci_helper.rb
@@ -2,7 +2,7 @@
 
 module Danger
   module Support
-    module ExecutorHelper
+    module CIHelper
       def with_bitrise_setup_and_is_a_pull_request
         system_env = {
           "BITRISE_IO" => "true",
@@ -23,18 +23,6 @@ module Danger
       end
 
       def with_circle_setup_and_is_a_pull_request
-        system_env = {
-          "CIRCLE_BUILD_NUM" => "1589",
-          "CI_PULL_REQUEST" => "https://circleci.com/gh/danger/danger/1589",
-          "CIRCLE_CI_API_TOKEN" => "circle api token",
-          "CIRCLE_PROJECT_USERNAME" => "danger",
-          "CIRCLE_PROJECT_REPONAME" => "danger"
-        }
-
-        yield(system_env)
-      end
-
-      def with_circleapi_setup_and_is_a_pull_request
         system_env = {
           "CIRCLE_BUILD_NUM" => "1589",
           "CI_PULL_REQUEST" => "https://circleci.com/gh/danger/danger/1589",

--- a/spec/support/ci_helper.rb
+++ b/spec/support/ci_helper.rb
@@ -4,7 +4,7 @@ module Danger
   module Support
     module CIHelper
       def github_token
-        { "DANGER_GITHUB_API_TOKEN" => "1234567890"*4 }
+        { "DANGER_GITHUB_API_TOKEN" => "1234567890" * 4 }
       end
 
       def with_bitrise_setup_and_is_a_pull_request

--- a/spec/support/ci_helper.rb
+++ b/spec/support/ci_helper.rb
@@ -3,6 +3,10 @@
 module Danger
   module Support
     module CIHelper
+      def github_token
+        { "DANGER_GITHUB_API_TOKEN" => "1234567890"*4 }
+      end
+
       def with_bitrise_setup_and_is_a_pull_request
         system_env = {
           "BITRISE_IO" => "true",
@@ -119,12 +123,16 @@ module Danger
         yield(system_env)
       end
 
-      def with_travis_setup_and_is_a_pull_request
+      def with_travis_setup_and_is_a_pull_request(request_source: nil)
         system_env = {
           "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
           "TRAVIS_PULL_REQUEST" => "42",
           "TRAVIS_REPO_SLUG" => "orta/orta"
         }
+
+        if request_source == :github
+          system_env.merge!(github_token)
+        end
 
         yield(system_env)
       end


### PR DESCRIPTION
This PR adds some tests for `EnvironmentManager` class.

Specs just quit exceptionally by RSpec JUnit Formatter:

```
$ bundle exec rspec spec/lib/danger/danger_core/environment_manager_spec.rb:176

bundler: failed to load command: rspec (/Users/Juan/.gem/ruby/2.2.5/bin/rspec)
NoMethodError: undefined method `xml_dump_' for #<RSpecJUnitFormatter:0x007ff9011e44a0>
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec_junit_formatter-0.2.3/lib/rspec_junit_formatter.rb:29:in `block in xml_dump_examples'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec_junit_formatter-0.2.3/lib/rspec_junit_formatter.rb:28:in `each'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec_junit_formatter-0.2.3/lib/rspec_junit_formatter.rb:28:in `xml_dump_examples'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec_junit_formatter-0.2.3/lib/rspec_junit_formatter.rb:23:in `block in xml_dump'
  /Users/Juan/.gem/ruby/2.2.5/gems/builder-3.2.2/lib/builder/xmlbase.rb:175:in `call'
  /Users/Juan/.gem/ruby/2.2.5/gems/builder-3.2.2/lib/builder/xmlbase.rb:175:in `_nested_structures'
  /Users/Juan/.gem/ruby/2.2.5/gems/builder-3.2.2/lib/builder/xmlbase.rb:68:in `tag!'
  /Users/Juan/.gem/ruby/2.2.5/gems/builder-3.2.2/lib/builder/xmlbase.rb:93:in `method_missing'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec_junit_formatter-0.2.3/lib/rspec_junit_formatter.rb:20:in `xml_dump'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec_junit_formatter-0.2.3/lib/rspec_junit_formatter/rspec3.rb:19:in `dump_summary'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/reporter.rb:201:in `block in notify'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/reporter.rb:200:in `each'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/reporter.rb:200:in `notify'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/reporter.rb:179:in `block in finish'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/reporter.rb:187:in `close_after'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/reporter.rb:168:in `finish'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/reporter.rb:79:in `ensure in report'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/reporter.rb:79:in `report'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/runner.rb:111:in `run_specs'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/runner.rb:87:in `run'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/runner.rb:71:in `run'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/lib/rspec/core/runner.rb:45:in `invoke'
  /Users/Juan/.gem/ruby/2.2.5/gems/rspec-core-3.5.3/exe/rspec:4:in `<top (required)>'
  /Users/Juan/.gem/ruby/2.2.5/bin/rspec:23:in `load'
  /Users/Juan/.gem/ruby/2.2.5/bin/rspec:23:in `<top (required)>'
Coverage report generated for RSpec to /Users/Juan/dev/danger/coverage. 877 / 2384 LOC (36.79%) covered.
```

I cannot run the specs `¯\_(ツ)_/¯`...