### PR TITLE
Added option to run a Dangerfile from a `branch` and/or `path` when using a remote repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.4.0
 
+* Added option to run a Dangerfile from a `branch` and/or `path` when using a remote repo - felipesabino
 * Simplify initialization of Octokit client in request_sources/github.rb - Juanito Fatas
 * Ensure commits exist inside the local git repo before using them for diffs - orta
 * Big improvements to the warning around no API tokens being found - orta

--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -29,6 +29,10 @@ module Danger
   #
   #          danger.import_dangerfile(gitlab: "ruby-grape/danger")
   #
+  # @example Run a Dangerfile from inside a repo branch and path
+  #
+  #          danger.import_dangerfile(github: "ruby-grape/danger", branch: "custom", path: "path/to/Dangerfile")
+  #
   # @see  danger/danger
   # @tags core, plugins
 
@@ -73,7 +77,7 @@ module Danger
         import_dangerfile_from_github(opts)
       elsif opts.kind_of?(Hash)
         if opts.key?(:github) || opts.key?(:gitlab)
-          import_dangerfile_from_github(opts[:github] || opts[:gitlab])
+          import_dangerfile_from_github(opts[:github] || opts[:gitlab], opts[:branch], opts[:path])
         elsif opts.key?(:path)
           import_dangerfile_from_path(opts[:path])
         elsif opts.key?(:gem)
@@ -141,12 +145,16 @@ module Danger
     #
     # @param    [String] slug
     #           A slug that represents the repo where the Dangerfile is.
+    # @param    [String] branch
+    #           A branch from repo where the Dangerfile is.
+    # @param    [String] path
+    #           The path at the repo where Dangerfile is.
     # @return   [void]
     #
-    def import_dangerfile_from_github(slug)
+    def import_dangerfile_from_github(slug, branch = nil, path = nil)
       raise "`import_dangerfile_from_github` requires a string" unless slug.kind_of?(String)
       org, repo = slug.split("/")
-      download_url = env.request_source.file_url(organisation: org, repository: repo, branch: "master", path: "Dangerfile")
+      download_url = env.request_source.file_url(organisation: org, repository: repo, branch: branch || "master", path: path || "Dangerfile")
       local_path = download(download_url)
       @dangerfile.parse(Pathname.new(local_path))
     end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -71,11 +71,33 @@ describe Danger::Dangerfile::DSL, host: :github do
       expect(dm.status_report[:messages]).to eq(["OK"])
     end
 
+    it "github: 'repo/name', branch: 'custom-branch', path: 'path/to/Dangefile'" do
+      outer_dangerfile = "danger.import_dangerfile(github: 'example/example', branch: 'custom-branch', path: 'path/to/Dangefile')"
+      inner_dangerfile = "message('OK')"
+
+      url = "https://raw.githubusercontent.com/example/example/custom-branch/path/to/Dangefile"
+      stub_request(:get, url).to_return(status: 200, body: inner_dangerfile)
+
+      dm.parse(Pathname.new("."), outer_dangerfile)
+      expect(dm.status_report[:messages]).to eq(["OK"])
+    end
+
     it "gitlab: 'repo/name'" do
       outer_dangerfile = "danger.import_dangerfile(gitlab: 'example/example')"
       inner_dangerfile = "message('OK')"
 
       url = "https://raw.githubusercontent.com/example/example/master/Dangerfile"
+      stub_request(:get, url).to_return(status: 200, body: inner_dangerfile)
+
+      dm.parse(Pathname.new("."), outer_dangerfile)
+      expect(dm.status_report[:messages]).to eq(["OK"])
+    end
+
+    it "gitlab: 'repo/name', branch: 'custom-branch', path: 'path/to/Dangefile'" do
+      outer_dangerfile = "danger.import_dangerfile(gitlab: 'example/example', branch: 'custom-branch', path: 'path/to/Dangerfile')"
+      inner_dangerfile = "message('OK')"
+
+      url = "https://raw.githubusercontent.com/example/example/custom-branch/path/to/Dangerfile"
       stub_request(:get, url).to_return(status: 200, body: inner_dangerfile)
 
       dm.parse(Pathname.new("."), outer_dangerfile)


### PR DESCRIPTION
### Problem

Having a centralized `Dangerfile` for several projects inside an organization. As the branch and path where hardcoded to `master` and `Dangerfile` respectively, achieving this goal demanded too many repositories to be created, making it hard to mantain and a hassle hard to test changes on `Dangerfile`s without needing to create new repositories or risking breaking all builds.

### Solution

`import_dangerfile_from_github` receives the repo `slug` to create the download URL, so 2 new optional parameters were added for the `branch` and `path` be set, keeping `master` and `Dangerfile` as the default values.

