### PR TITLE
Changelog Fix - 'import_dangerfile' entry previously added to release instead of master #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## master
 
+* Added option to run a Dangerfile from a `branch` and/or `path` when using a remote repo - felipesabino
+
+
 ## 3.4.0
 
-* Added option to run a Dangerfile from a `branch` and/or `path` when using a remote repo - felipesabino
 * Simplify initialization of Octokit client in request_sources/github.rb - Juanito Fatas
 * Ensure commits exist inside the local git repo before using them for diffs - orta
 * Big improvements to the warning around no API tokens being found - orta


### PR DESCRIPTION
Previous PR had the 'import_dangerfile' `Changelog.md` entry added to `3.4.0` version instead of `master`.