### PR TITLE
Not raises error if plugin that inherits from Danger::Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added option to run a Dangerfile from a `branch` and/or `path` when using a remote repo - felipesabino
 * Add specs for `Danger::EnvironmentManager` - Juanito Fatas
+* Fixes plugin that inherits from `Danger::Plugin` should not raise error - Juanito Fatas
 
 ## 3.4.0
 

--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -216,7 +216,7 @@ module Danger
     def validate_file_contains_plugin!(file)
       content = IO.read(file)
 
-      if content.scan(/class\s+(?<plugin_class>[\w]+)\s+<\s+Plugin/i).empty?
+      if content.scan(/class\s+(?<plugin_class>[\w]+)\s+<\s+((Danger::)?Plugin)/i).empty?
         raise("#{file} doesn't contain any valid danger plugin.")
       end
     end

--- a/spec/fixtures/plugins/example_not_broken.rb
+++ b/spec/fixtures/plugins/example_not_broken.rb
@@ -1,0 +1,7 @@
+class Dangerfile
+  class ExampleBroken < Danger::Plugin
+    def run
+      return "Hi there"
+    end
+  end
+end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -19,6 +19,12 @@ describe Danger::Dangerfile::DSL, host: :github do
         expect(dm.example_globbing.echo).to eq("Hi there globbing")
       end
 
+      it "not raises an error when calling a plugin that's a subclass of Plugin" do
+        expect do
+          dm.danger.import_plugin("spec/fixtures/plugins/example_not_broken.rb")
+        end.not_to raise_error
+      end
+
       it "raises an error when calling a plugin that's not a subclass of Plugin" do
         expect do
           dm.danger.import_plugin("spec/fixtures/plugins/example_broken.rb")


### PR DESCRIPTION
Some users may not use `module Danger` on outer namespace. This PR fixes it.

If the regexp is not reliable, we can use Ruby [parser](https://github.com/whitequark/parser) gem.