### PR TITLE
Bring backwards API compaatbility for dangerfile and env manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Adds backwards compatibility for plugin testing API - sorry - @orta
+
 ## 3.4.1
 
 * Added option to run a Dangerfile from a `branch` and/or `path` when using a remote repo - felipesabino

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -68,10 +68,11 @@ module Danger
       super
     end
 
-    def initialize(env_manager, cork_board)
+    # cork_board not being set comes from plugins #585
+    def initialize(env_manager, cork_board = nil)
       @plugins = {}
       @core_plugins = []
-      @ui = cork_board
+      @ui = cork_board || Cork::Board.new(silent: false, verbose: false)
 
       # Triggers the core plugins
       @env = env_manager

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -25,10 +25,10 @@ module Danger
       "danger_base".freeze
     end
 
-    def initialize(env, ui)
+    def initialize(env, ui = nil)
       ci_klass = self.class.local_ci_source(env)
       self.ci_source = ci_klass.new(env)
-      self.ui = ui
+      self.ui = ui || Cork::Board.new(silent: false, verbose: false)
 
       RequestSources::RequestSource.available_request_sources.each do |klass|
         next unless self.ci_source.supports?(klass)


### PR DESCRIPTION
Just a quick API change, makes the Cork instance the most default it could be.

closes #585