### PR TITLE
Update configs to RSpec 3.5.3 #trivial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ build/
 .keys
 .idea
 junit-results.xml
+
+# RSpec
+/spec/examples.txt

--- a/spec/clients/rubygems_client_spec.rb
+++ b/spec/clients/rubygems_client_spec.rb
@@ -1,6 +1,6 @@
 require "danger/clients/rubygems_client"
 
-describe Danger::RubyGemsClient do
+RSpec.describe Danger::RubyGemsClient do
   describe ".latest_danger_version" do
     context "rubygems.org is operational" do
       it "returns latest danger version" do

--- a/spec/danger/helpers/comment_spec.rb
+++ b/spec/danger/helpers/comment_spec.rb
@@ -1,6 +1,6 @@
 require "danger/helpers/comment"
 
-describe Danger::Comment do
+RSpec.describe Danger::Comment do
   describe ".from_github" do
     it "initializes with GitHub comment data structure" do
       github_comment = { "id" => 42, "body" => "github comment" }

--- a/spec/danger_spec.rb
+++ b/spec/danger_spec.rb
@@ -1,6 +1,6 @@
 require "danger/clients/rubygems_client"
 
-describe Danger do
+RSpec.describe Danger do
   context "when installed danger is outdated and an error is raised" do
     before do
       stub_const("Danger::VERSION", "1.0.0")

--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/xcode_server"
 
-describe Danger::Bitrise do
+RSpec.describe Danger::Bitrise do
   let(:valid_env) do
     {
       "BITRISE_PULL_REQUEST" => "4",

--- a/spec/lib/danger/ci_sources/buildkite_spec.rb
+++ b/spec/lib/danger/ci_sources/buildkite_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/buildkite"
 
-describe Danger::Buildkite do
+RSpec.describe Danger::Buildkite do
   let(:valid_env) do
     {
       "BUILDKITE" => "true",

--- a/spec/lib/danger/ci_sources/ci_source_spec.rb
+++ b/spec/lib/danger/ci_sources/ci_source_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/ci_source"
 
-describe Danger::CI do
+RSpec.describe Danger::CI do
   describe ".available_ci_sources" do
     it "returns list of CI subclasses" do
       expect(described_class.available_ci_sources.map(&:to_s)).to match_array(

--- a/spec/lib/danger/ci_sources/circle_api_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_api_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/circle_api"
 
-describe Danger::CircleAPI do
+RSpec.describe Danger::CircleAPI do
   it "gets out a repo slug, pull request number and commit refs when PR url is not found" do
     env = {
       "CIRCLE_BUILD_NUM" => "1500",

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/circle"
 
-describe Danger::CircleCI do
+RSpec.describe Danger::CircleCI do
   let(:legit_pr) { "https://github.com/artsy/eigen/pulls/800" }
   let(:not_legit_pr) { "https://github.com/orta" }
 

--- a/spec/lib/danger/ci_sources/drone_spec.rb
+++ b/spec/lib/danger/ci_sources/drone_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/drone"
 
-describe Danger::Drone do
+RSpec.describe Danger::Drone do
   it "validates when DRONE variable is set" do
     env = { "DRONE" => "true",
             "DRONE_REPO" => "danger/danger",

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/gitlab_ci"
 
-describe Danger::GitLabCI, host: :gitlab do
+RSpec.describe Danger::GitLabCI, host: :gitlab do
   context "valid envrionment" do
     let(:gitlab_env) do
       {

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/circle"
 
-describe Danger::Jenkins do
+RSpec.describe Danger::Jenkins do
   let(:valid_env) do
     {
       "JENKINS_URL" => "Hello",

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -27,7 +27,7 @@ def run_in_repo(merge_pr: true, squash_and_merge_pr: false)
   end
 end
 
-describe Danger::LocalGitRepo do
+RSpec.describe Danger::LocalGitRepo do
   let(:valid_env) do
     {
       "DANGER_USE_LOCAL_GIT" => "true"

--- a/spec/lib/danger/ci_sources/semaphore_spec.rb
+++ b/spec/lib/danger/ci_sources/semaphore_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/travis"
 
-describe Danger::Semaphore do
+RSpec.describe Danger::Semaphore do
   let(:valid_env) do
     {
       "SEMAPHORE" => "true",

--- a/spec/lib/danger/ci_sources/support/merged_pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/merged_pull_request_finder_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/support/merged_pull_request_finder"
 
-describe Danger::MergedPullRequestFinder do
+RSpec.describe Danger::MergedPullRequestFinder do
   def finder(pull_request_id: "", logs: nil)
     described_class.new(
       pull_request_id,

--- a/spec/lib/danger/ci_sources/support/remote_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/remote_finder_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/support/remote_finder"
 
-describe Danger::RemoteFinder do
+RSpec.describe Danger::RemoteFinder do
   describe "#call" do
     it "returns repo slug from logs" do
       remote_logs = IO.read("spec/fixtures/ci_source/support/remote.log")

--- a/spec/lib/danger/ci_sources/surf_spec.rb
+++ b/spec/lib/danger/ci_sources/surf_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/surf"
 
-describe Danger::Surf do
+RSpec.describe Danger::Surf do
   let(:valid_env) do
     {
       "SURF_REPO" => "https://github.com/surf-build/surf",

--- a/spec/lib/danger/ci_sources/teamcity_spec.rb
+++ b/spec/lib/danger/ci_sources/teamcity_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/teamcity"
 
-describe Danger::TeamCity do
+RSpec.describe Danger::TeamCity do
   let(:valid_env) do
     {
       "TEAMCITY_VERSION" => "42"

--- a/spec/lib/danger/ci_sources/travis_spec.rb
+++ b/spec/lib/danger/ci_sources/travis_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/travis"
 
-describe Danger::Travis do
+RSpec.describe Danger::Travis do
   let(:valid_env) do
     {
       "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",

--- a/spec/lib/danger/ci_sources/xcode_server_spec.rb
+++ b/spec/lib/danger/ci_sources/xcode_server_spec.rb
@@ -1,6 +1,6 @@
 require "danger/ci_source/xcode_server"
 
-describe Danger::XcodeServer do
+RSpec.describe Danger::XcodeServer do
   let(:valid_env) do
     {
       "XCS_BOT_NAME" => "BuildaBot [danger/danger] PR #17"

--- a/spec/lib/danger/commands/local_helpers/http_cache_spec.rb
+++ b/spec/lib/danger/commands/local_helpers/http_cache_spec.rb
@@ -2,67 +2,65 @@ require "danger/commands/local_helpers/http_cache"
 
 TEST_CACHE_FILE = File.join(Dir.tmpdir, "http_cache_spec")
 
-module Danger
-  describe Danger::HTTPCache do
-    after do
-      File.delete TEST_CACHE_FILE if File.exist? TEST_CACHE_FILE
+RSpec.describe Danger::HTTPCache do
+  after do
+    File.delete TEST_CACHE_FILE if File.exist? TEST_CACHE_FILE
+  end
+
+  it "will default to a 300 second cache expiry" do
+    cache = described_class.new(TEST_CACHE_FILE)
+    expect(cache.expires_in).to eq(300)
+  end
+
+  it "will allow setting a custom cache expiry" do
+    cache = described_class.new(TEST_CACHE_FILE, expires_in: 1234)
+    expect(cache.expires_in).to eq(1234)
+  end
+
+  it "will open a previous file by default" do
+    store = PStore.new(TEST_CACHE_FILE)
+    store.transaction { store["testing"] = { value: "pants", updated_at: Time.now } }
+    cache = described_class.new(TEST_CACHE_FILE)
+    expect(cache.read("testing")).to eql("pants")
+  end
+
+  it "will delete a previous file if told to" do
+    store = PStore.new(TEST_CACHE_FILE)
+    store.transaction { store["testing"] = "pants" }
+    cache = described_class.new(TEST_CACHE_FILE, clear_cache: true)
+    expect(cache.read("testing")).to be_nil
+  end
+
+  it "will honor the TTL when a read attempt is made" do
+    now = Time.now.to_i
+    store = PStore.new(TEST_CACHE_FILE)
+    store.transaction do
+      store["testing_valid_ttl"] = { value: "pants", updated_at: now - 280 }
+      store["testing_invalid_ttl"] = { value: "pants", updated_at: now - 301 }
     end
 
-    it "will default to a 300 second cache expiry" do
-      cache = HTTPCache.new(TEST_CACHE_FILE)
-      expect(cache.expires_in).to eq(300)
-    end
+    cache = described_class.new(TEST_CACHE_FILE)
+    expect(cache.read("testing_valid_ttl")).to eql("pants")
+    expect(cache.read("testing_invalid_ttl")).to be_nil
+  end
 
-    it "will allow setting a custom cache expiry" do
-      cache = HTTPCache.new(TEST_CACHE_FILE, expires_in: 1234)
-      expect(cache.expires_in).to eq(1234)
-    end
+  it "will delete a key" do
+    cache = described_class.new(TEST_CACHE_FILE)
 
-    it "will open a previous file by default" do
-      store = PStore.new(TEST_CACHE_FILE)
-      store.transaction { store["testing"] = { value: "pants", updated_at: Time.now } }
-      cache = HTTPCache.new(TEST_CACHE_FILE)
-      expect(cache.read("testing")).to eql("pants")
-    end
+    cache.write("testing_delete", "pants")
+    cache.delete("testing_delete")
 
-    it "will delete a previous file if told to" do
-      store = PStore.new(TEST_CACHE_FILE)
-      store.transaction { store["testing"] = "pants" }
-      cache = HTTPCache.new(TEST_CACHE_FILE, clear_cache: true)
-      expect(cache.read("testing")).to be_nil
-    end
+    expect(cache.read("testing_delete")).to be_nil
+  end
 
-    it "will honor the TTL when a read attempt is made" do
-      now = Time.now.to_i
-      store = PStore.new(TEST_CACHE_FILE)
-      store.transaction do
-        store["testing_valid_ttl"] = { value: "pants", updated_at: now - 280 }
-        store["testing_invalid_ttl"] = { value: "pants", updated_at: now - 301 }
-      end
-
-      cache = HTTPCache.new(TEST_CACHE_FILE)
-      expect(cache.read("testing_valid_ttl")).to eql("pants")
-      expect(cache.read("testing_invalid_ttl")).to be_nil
-    end
-
-    it "will delete a key" do
-      cache = HTTPCache.new(TEST_CACHE_FILE)
-
-      cache.write("testing_delete", "pants")
-      cache.delete("testing_delete")
-
-      expect(cache.read("testing_delete")).to be_nil
-    end
-
-    it "will write a key and timestamp" do
-      cache = HTTPCache.new(TEST_CACHE_FILE)
-      cache.write("testing_write", "pants")
-      store = PStore.new(TEST_CACHE_FILE)
-      store.transaction do
-        expect(store["testing_write"]).to_not be_nil
-        expect(store["testing_write"][:value]).to eql("pants")
-        expect(store["testing_write"][:updated_at]).to be_within(1).of(Time.now.to_i)
-      end
+  it "will write a key and timestamp" do
+    cache = described_class.new(TEST_CACHE_FILE)
+    cache.write("testing_write", "pants")
+    store = PStore.new(TEST_CACHE_FILE)
+    store.transaction do
+      expect(store["testing_write"]).to_not be_nil
+      expect(store["testing_write"][:value]).to eql("pants")
+      expect(store["testing_write"][:updated_at]).to be_within(1).of(Time.now.to_i)
     end
   end
 end

--- a/spec/lib/danger/commands/local_spec.rb
+++ b/spec/lib/danger/commands/local_spec.rb
@@ -1,6 +1,6 @@
 require "danger/commands/local"
 
-describe Danger::Local do
+RSpec.describe Danger::Local do
   describe ".options" do
     it "contains extra options for local command" do
       result = described_class.options

--- a/spec/lib/danger/commands/plugin_json_spec.rb
+++ b/spec/lib/danger/commands/plugin_json_spec.rb
@@ -1,13 +1,11 @@
 require "danger/commands/plugins/plugin_json"
 
-module Danger
-  describe Danger::PluginJSON do
-    after do
-      Plugin.clear_external_plugins
-    end
+RSpec.describe Danger::PluginJSON do
+  after do
+    Danger::Plugin.clear_external_plugins
+  end
 
-    it "runs the command" do
-      Danger::PluginJSON.run(["spec/fixtures/plugins/example_fully_documented.rb"])
-    end
+  it "runs the command" do
+    described_class.run(["spec/fixtures/plugins/example_fully_documented.rb"])
   end
 end

--- a/spec/lib/danger/commands/plugins/plugin_lint_spec.rb
+++ b/spec/lib/danger/commands/plugins/plugin_lint_spec.rb
@@ -1,14 +1,12 @@
 require "danger/commands/plugins/plugin_lint"
 
-module Danger
-  describe Danger::PluginLint do
-    after do
-      Plugin.clear_external_plugins
-    end
+RSpec.describe Danger::PluginLint do
+  after do
+    Danger::Plugin.clear_external_plugins
+  end
 
-    it "runs the command" do
-      # allow(STDOUT).to receive(:puts) # this disables puts
-      Danger::PluginLint.run(["spec/fixtures/plugins/example_fully_documented.rb"])
-    end
+  it "runs the command" do
+    allow(STDOUT).to receive(:puts)
+    described_class.run(["spec/fixtures/plugins/example_fully_documented.rb"])
   end
 end

--- a/spec/lib/danger/commands/plugins/plugin_readme_spec.rb
+++ b/spec/lib/danger/commands/plugins/plugin_readme_spec.rb
@@ -1,14 +1,12 @@
 require "danger/commands/plugins/plugin_readme"
 
-module Danger
-  describe Danger::PluginReadme do
-    after do
-      Plugin.clear_external_plugins
-    end
+RSpec.describe Danger::PluginReadme do
+  after do
+    Danger::Plugin.clear_external_plugins
+  end
 
-    it "runs the command" do
-      allow(STDOUT).to receive(:puts).with(fixture_txt("commands/plugin_md_example"))
-      Danger::PluginReadme.run(["spec/fixtures/plugins/example_fully_documented.rb"])
-    end
+  it "runs the command" do
+    allow(STDOUT).to receive(:puts).with(fixture_txt("commands/plugin_md_example"))
+    described_class.run(["spec/fixtures/plugins/example_fully_documented.rb"])
   end
 end

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -1,7 +1,7 @@
 require "danger/commands/runner"
 require "danger/danger_core/executor"
 
-describe Danger::Runner do
+RSpec.describe Danger::Runner do
   context "without Dangerfile" do
     it "raises error" do
       argv = CLAide::ARGV.new([])

--- a/spec/lib/danger/core_ext/file_list_spec.rb
+++ b/spec/lib/danger/core_ext/file_list_spec.rb
@@ -1,6 +1,6 @@
 require "danger/core_ext/file_list"
 
-describe Danger::FileList do
+RSpec.describe Danger::FileList do
   describe "#include?" do
     before do
       paths = ["path1/file_name.txt", "path1/file_name1.txt", "path2/subfolder/example.json"]

--- a/spec/lib/danger/core_ext/string_spec.rb
+++ b/spec/lib/danger/core_ext/string_spec.rb
@@ -1,4 +1,4 @@
-describe String do
+RSpec.describe String do
   describe "#danger_pluralize" do
     examples = [
       { count: 0, string: "0 errors" },

--- a/spec/lib/danger/danger_core/danger_spec.rb
+++ b/spec/lib/danger/danger_core/danger_spec.rb
@@ -1,4 +1,4 @@
-describe Danger do
+RSpec.describe Danger do
   it "has a version number" do
     expect(Danger::VERSION).not_to be nil
   end

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -6,7 +6,7 @@ require "danger/danger_core/plugins/dangerfile_danger_plugin"
 require "danger/danger_core/plugins/dangerfile_git_plugin"
 require "danger/danger_core/plugins/dangerfile_github_plugin"
 
-describe Danger::Dangerfile, host: :github do
+RSpec.describe Danger::Dangerfile, host: :github do
   it "keeps track of the original Dangerfile" do
     file = make_temp_file ""
     dm = testing_dangerfile

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -1,6 +1,6 @@
 require "danger/danger_core/environment_manager"
 
-describe Danger::EnvironmentManager, use: :ci_helper do
+RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
   describe ".local_ci_source" do
     it "loads Bitrise" do
       with_bitrise_setup_and_is_a_pull_request do |system_env|

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -1,7 +1,7 @@
 require "danger/danger_core/executor"
 
 # If you cannot find a method, please check spec/support/executor_helper.rb.
-describe Danger::Executor, use: :ci_helper do
+RSpec.describe Danger::Executor, use: :ci_helper do
   describe "#validate!" do
     context "with CI + is a PR" do
       it "not raises error on Bitrise" do

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -1,7 +1,7 @@
 require "danger/danger_core/environment_manager"
 require "danger/danger_core/plugins/dangerfile_danger_plugin"
 
-describe Danger::Dangerfile::DSL, host: :github do
+RSpec.describe Danger::Dangerfile::DSL, host: :github do
   let(:dm) { testing_dangerfile }
 
   describe "#import" do

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -18,109 +18,107 @@ def run_in_repo_with_diff
   end
 end
 
-module Danger
-  describe DangerfileGitPlugin, host: :github do
-    it "fails init if the dangerfile's request source is not a GitRepo" do
+RSpec.describe Danger::DangerfileGitPlugin, host: :github do
+  it "fails init if the dangerfile's request source is not a GitRepo" do
+    dm = testing_dangerfile
+    dm.env.scm = []
+    expect { described_class.new dm }.to raise_error RuntimeError
+  end
+
+  describe "dsl" do
+    before do
       dm = testing_dangerfile
-      dm.env.scm = []
-      expect { DangerfileGitPlugin.new dm }.to raise_error RuntimeError
+      @dsl = described_class.new dm
+      @repo = dm.env.scm
     end
 
-    describe "dsl" do
-      before do
-        dm = testing_dangerfile
-        @dsl = DangerfileGitPlugin.new dm
-        @repo = dm.env.scm
-      end
+    it "gets added_files " do
+      diff = [OpenStruct.new(type: "new", path: "added")]
+      allow(@repo).to receive(:diff).and_return(diff)
 
-      it "gets added_files " do
-        diff = [OpenStruct.new(type: "new", path: "added")]
-        allow(@repo).to receive(:diff).and_return(diff)
+      expect(@dsl.added_files).to eq(["added"])
+    end
 
-        expect(@dsl.added_files).to eq(["added"])
-      end
+    it "gets deleted_files " do
+      diff = [OpenStruct.new(type: "deleted", path: "deleted")]
+      allow(@repo).to receive(:diff).and_return(diff)
 
-      it "gets deleted_files " do
-        diff = [OpenStruct.new(type: "deleted", path: "deleted")]
-        allow(@repo).to receive(:diff).and_return(diff)
+      expect(@dsl.deleted_files).to eq(["deleted"])
+    end
 
-        expect(@dsl.deleted_files).to eq(["deleted"])
-      end
+    it "gets modified_files " do
+      stats = { files: { "my/path/file_name" => "thing" } }
+      diff = OpenStruct.new(stats: stats)
+      allow(@repo).to receive(:diff).and_return(diff)
 
-      it "gets modified_files " do
-        stats = { files: { "my/path/file_name" => "thing" } }
-        diff = OpenStruct.new(stats: stats)
-        allow(@repo).to receive(:diff).and_return(diff)
+      expect(@dsl.modified_files).to eq(["my/path/file_name"])
+    end
 
-        expect(@dsl.modified_files).to eq(["my/path/file_name"])
-      end
+    it "gets lines_of_code" do
+      diff = OpenStruct.new(lines: 2)
+      allow(@repo).to receive(:diff).and_return(diff)
 
-      it "gets lines_of_code" do
-        diff = OpenStruct.new(lines: 2)
-        allow(@repo).to receive(:diff).and_return(diff)
+      expect(@dsl.lines_of_code).to eq(2)
+    end
 
-        expect(@dsl.lines_of_code).to eq(2)
-      end
+    it "gets deletions" do
+      diff = OpenStruct.new(deletions: 4)
+      allow(@repo).to receive(:diff).and_return(diff)
 
-      it "gets deletions" do
-        diff = OpenStruct.new(deletions: 4)
-        allow(@repo).to receive(:diff).and_return(diff)
+      expect(@dsl.deletions).to eq(4)
+    end
 
-        expect(@dsl.deletions).to eq(4)
-      end
+    it "gets insertions" do
+      diff = OpenStruct.new(insertions: 6)
+      allow(@repo).to receive(:diff).and_return(diff)
 
-      it "gets insertions" do
-        diff = OpenStruct.new(insertions: 6)
-        allow(@repo).to receive(:diff).and_return(diff)
+      expect(@dsl.insertions).to eq(6)
+    end
 
-        expect(@dsl.insertions).to eq(6)
-      end
+    it "gets commits" do
+      log = ["hi"]
+      allow(@repo).to receive(:log).and_return(log)
 
-      it "gets commits" do
-        log = ["hi"]
-        allow(@repo).to receive(:log).and_return(log)
+      expect(@dsl.commits).to eq(log)
+    end
 
-        expect(@dsl.commits).to eq(log)
-      end
-
-      describe "getting diff for a specific file" do
-        it "returns nil when a specific diff does not exist" do
-          run_in_repo_with_diff do |git|
-            diff = git.diff("master")
-            allow(@repo).to receive(:diff).and_return(diff)
-            expect(@dsl.diff_for_file("file_nope_no_way")).to be_nil
-          end
-        end
-
-        it "gets a specific diff" do
-          run_in_repo_with_diff do |git|
-            diff = git.diff("master")
-            allow(@repo).to receive(:diff).and_return(diff)
-            expect(@dsl.diff_for_file("file2")).to_not be_nil
-          end
+    describe "getting diff for a specific file" do
+      it "returns nil when a specific diff does not exist" do
+        run_in_repo_with_diff do |git|
+          diff = git.diff("master")
+          allow(@repo).to receive(:diff).and_return(diff)
+          expect(@dsl.diff_for_file("file_nope_no_way")).to be_nil
         end
       end
 
-      describe "getting info for a specific file" do
-        it "returns nil when specific info does not exist" do
-          run_in_repo_with_diff do |git|
-            diff = git.diff("master")
-            allow(@repo).to receive(:diff).and_return(diff)
-            expect(@dsl.info_for_file("file_nope_no_way")).to be_nil
-          end
+      it "gets a specific diff" do
+        run_in_repo_with_diff do |git|
+          diff = git.diff("master")
+          allow(@repo).to receive(:diff).and_return(diff)
+          expect(@dsl.diff_for_file("file2")).to_not be_nil
         end
+      end
+    end
 
-        it "returns file info when it exists" do
-          run_in_repo_with_diff do |git|
-            diff = git.diff("master")
-            allow(@repo).to receive(:diff).and_return(diff)
-            info = @dsl.info_for_file("file2")
-            expect(info).to_not be_nil
-            expect(info[:insertions]).to equal(1)
-            expect(info[:deletions]).to equal(2)
-            expect(info[:before]).to eq("Shorts.\nShoes.")
-            expect(info[:after]).to eq("Pants!")
-          end
+    describe "getting info for a specific file" do
+      it "returns nil when specific info does not exist" do
+        run_in_repo_with_diff do |git|
+          diff = git.diff("master")
+          allow(@repo).to receive(:diff).and_return(diff)
+          expect(@dsl.info_for_file("file_nope_no_way")).to be_nil
+        end
+      end
+
+      it "returns file info when it exists" do
+        run_in_repo_with_diff do |git|
+          diff = git.diff("master")
+          allow(@repo).to receive(:diff).and_return(diff)
+          info = @dsl.info_for_file("file2")
+          expect(info).to_not be_nil
+          expect(info[:insertions]).to equal(1)
+          expect(info[:deletions]).to equal(2)
+          expect(info[:before]).to eq("Shorts.\nShoes.")
+          expect(info[:after]).to eq("Pants!")
         end
       end
     end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_github_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_github_plugin_spec.rb
@@ -1,36 +1,34 @@
-module Danger
-  describe DangerfileGitHubPlugin, host: :github do
-    describe "dsl" do
-      before do
-        dm = testing_dangerfile
-        @dsl = DangerfileGitHubPlugin.new dm
-        pr_response = JSON.parse(fixture("github_api/pr_response"))
-        allow(@dsl).to receive(:pr_json).and_return(pr_response)
+RSpec.describe Danger::DangerfileGitHubPlugin, host: :github do
+  describe "dsl" do
+    before do
+      dm = testing_dangerfile
+      @dsl = described_class.new(dm)
+      pr_response = JSON.parse(fixture("github_api/pr_response"))
+      allow(@dsl).to receive(:pr_json).and_return(pr_response)
+    end
+
+    describe "html_link" do
+      it "works with a single path" do
+        link = @dsl.html_link("file.txt")
+        expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>")
       end
 
-      describe "html_link" do
-        it "works with a single path" do
-          link = @dsl.html_link("file.txt")
-          expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>")
-        end
+      it "can show just a path" do
+        link = @dsl.html_link("/path/file.txt", full_path: false)
+        expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/path/file.txt'>file.txt</a>")
+      end
 
-        it "can show just a path" do
-          link = @dsl.html_link("/path/file.txt", full_path: false)
-          expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/path/file.txt'>file.txt</a>")
-        end
+      it "works with 2 paths" do
+        link = @dsl.html_link(["file.txt", "example.json"])
+        expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a> & " \
+                           "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/example.json'>example.json</a>")
+      end
 
-        it "works with 2 paths" do
-          link = @dsl.html_link(["file.txt", "example.json"])
-          expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a> & " \
-                             "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/example.json'>example.json</a>")
-        end
-
-        it "works with 3+ paths" do
-          link = @dsl.html_link(["file.txt", "example.json", "script.rb#L30"])
-          expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>, " \
-                             "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/example.json'>example.json</a> & " \
-                             "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/script.rb#L30'>script.rb#L30</a>")
-        end
+      it "works with 3+ paths" do
+        link = @dsl.html_link(["file.txt", "example.json", "script.rb#L30"])
+        expect(link).to eq("<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>, " \
+                           "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/example.json'>example.json</a> & " \
+                           "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/script.rb#L30'>script.rb#L30</a>")
       end
     end
   end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -1,4 +1,4 @@
-describe Danger::DangerfileGitLabPlugin, host: :gitlab do
+RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
   let(:dangerfile) { testing_dangerfile }
   let(:plugin) { described_class.new(dangerfile) }
   before do

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -58,7 +58,7 @@ EOS
 class Dummy
 end
 
-describe Danger::Helpers::CommentsHelper do
+RSpec.describe Danger::Helpers::CommentsHelper do
   let(:dummy) do
     d = Dummy.new
     d.extend(described_class)

--- a/spec/lib/danger/plugin_support/plugin_linter_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_linter_spec.rb
@@ -7,48 +7,46 @@ def json_doc_for_path(path)
   parser.to_json
 end
 
-module Danger
-  describe PluginParser do
-    it "creates a set of errors for fixtured plugins" do
-      json = json_doc_for_path("spec/fixtures/plugins/plugin_many_methods.rb")
-      linter = PluginLinter.new(json)
-      linter.lint
-      titles = ["Description Markdown", "Examples", "Description", "Description"]
-      expect(linter.errors.map(&:title)).to eq(titles)
-    end
+RSpec.describe Danger::PluginParser do
+  it "creates a set of errors for fixtured plugins" do
+    json = json_doc_for_path("spec/fixtures/plugins/plugin_many_methods.rb")
+    linter = Danger::PluginLinter.new(json)
+    linter.lint
+    titles = ["Description Markdown", "Examples", "Description", "Description"]
+    expect(linter.errors.map(&:title)).to eq(titles)
+  end
 
-    it "creates a set of warnings for fixtured plugins" do
-      json = json_doc_for_path("spec/fixtures/plugins/plugin_many_methods.rb")
-      linter = PluginLinter.new(json)
-      linter.lint
+  it "creates a set of warnings for fixtured plugins" do
+    json = json_doc_for_path("spec/fixtures/plugins/plugin_many_methods.rb")
+    linter = Danger::PluginLinter.new(json)
+    linter.lint
 
-      titles = ["Tags", "References", "Return Type", "Return Type", "Return Type", "Unknown Param", "Return Type"]
-      expect(linter.warnings.map(&:title)).to eq(titles)
-    end
+    titles = ["Tags", "References", "Return Type", "Return Type", "Return Type", "Unknown Param", "Return Type"]
+    expect(linter.warnings.map(&:title)).to eq(titles)
+  end
 
-    it "fails when there are errors" do
-      linter = PluginLinter.new({})
-      expect(linter.failed?).to eq(false)
+  it "fails when there are errors" do
+    linter = Danger::PluginLinter.new({})
+    expect(linter.failed?).to eq(false)
 
-      linter.warnings = [1, 2, 3]
-      expect(linter.failed?).to eq(false)
+    linter.warnings = [1, 2, 3]
+    expect(linter.failed?).to eq(false)
 
-      linter.errors = [1, 2, 3]
-      expect(linter.failed?).to eq(true)
-    end
+    linter.errors = [1, 2, 3]
+    expect(linter.failed?).to eq(true)
+  end
 
-    it "handles outputting a warning" do
-      ui = testing_ui
-      linter = PluginLinter.new({})
-      warning = PluginLinter::Rule.new(:warning, 30, "Example Title", "Example Description", nil)
-      warning.metadata = { name: "NameOfExample" }
-      warning.type = "TypeOfThing"
+  it "handles outputting a warning" do
+    ui = testing_ui
+    linter = Danger::PluginLinter.new({})
+    warning = Danger::PluginLinter::Rule.new(:warning, 30, "Example Title", "Example Description", nil)
+    warning.metadata = { name: "NameOfExample" }
+    warning.type = "TypeOfThing"
 
-      linter.warnings << warning
+    linter.warnings << warning
 
-      linter.print_summary(ui)
+    linter.print_summary(ui)
 
-      expect(ui.string).to eq("\n[!] Passed\n\nWarnings\n  - Example Title - NameOfExample (TypeOfThing):\n    - Example Description\n    - @see - https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L30\n\n")
-    end
+    expect(ui.string).to eq("\n[!] Passed\n\nWarnings\n  - Example Title - NameOfExample (TypeOfThing):\n    - Example Description\n    - @see - https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L30\n\n")
   end
 end

--- a/spec/lib/danger/plugin_support/plugin_parser_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_parser_spec.rb
@@ -1,102 +1,100 @@
 require "danger/plugin_support/plugin_parser"
 
-module Danger
-  describe PluginParser do
-    it "includes an example plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_broken.rb"
-      parser.parse
+RSpec.describe Danger::PluginParser do
+  it "includes an example plugin" do
+    parser = described_class.new "spec/fixtures/plugins/example_broken.rb"
+    parser.parse
 
-      plugin_docs = parser.registry.at("Danger::Dangerfile::ExampleBroken")
-      expect(plugin_docs).to be_truthy
+    plugin_docs = parser.registry.at("Danger::Dangerfile::ExampleBroken")
+    expect(plugin_docs).to be_truthy
+  end
+
+  it "finds classes from inside the file" do
+    parser = described_class.new "spec/fixtures/plugins/example_broken.rb"
+    parser.parse
+
+    classes = parser.classes_in_file
+
+    class_syms = classes.map(&:name)
+    expect(class_syms).to eq [:Dangerfile, :ExampleBroken]
+  end
+
+  it "skips non-subclasses of Danger::Plugin" do
+    parser = described_class.new "spec/fixtures/plugins/example_broken.rb"
+    parser.parse
+
+    plugins = parser.plugins_from_classes(parser.classes_in_file)
+
+    class_syms = plugins.map(&:name)
+    expect(class_syms).to eq []
+  end
+
+  it "find subclasses of Danger::Plugin" do
+    parser = described_class.new "spec/fixtures/plugins/example_remote.rb"
+    parser.parse
+
+    plugins = parser.plugins_from_classes(parser.classes_in_file)
+
+    class_syms = plugins.map(&:name)
+    expect(class_syms).to eq [:ExampleRemote]
+  end
+
+  it "outputs JSON for badly documented subclasses of Danger::Plugin" do
+    parser = described_class.new "spec/fixtures/plugins/example_remote.rb"
+    parser.parse
+
+    plugins = parser.plugins_from_classes(parser.classes_in_file)
+    json = parser.to_h(plugins)
+    sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, "")
+
+    fixture = "spec/fixtures/plugin_json/example_remote.json"
+    # File.write(fixture, sanitized_json)
+
+    # Skipping this test for windows, pathing gets complex, and no-one
+    # is generating gem docs on windows.
+    if Gem.win_platform?
+      expect(1).to eq(1)
+    else
+      expect(sanitized_json).to eq File.read(fixture)
     end
+  end
 
-    it "finds classes from inside the file" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_broken.rb"
-      parser.parse
+  it "outputs JSON for well documented subclasses of Danger::Plugin" do
+    parser = described_class.new "spec/fixtures/plugins/example_fully_documented.rb"
+    parser.parse
 
-      classes = parser.classes_in_file
+    plugins = parser.plugins_from_classes(parser.classes_in_file)
+    json = parser.to_h(plugins)
+    sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, "")
 
-      class_syms = classes.map(&:name)
-      expect(class_syms).to eq [:Dangerfile, :ExampleBroken]
+    fixture = "spec/fixtures/plugin_json/example_fully_doc.json"
+    # File.write(fixture, sanitized_json)
+
+    # Skipping this test for windows, pathing gets complex, and no-one
+    # is generating gem docs on windows.
+    if Gem.win_platform?
+      expect(1).to eq(1)
+    else
+      expect(sanitized_json).to eq File.read(fixture)
     end
+  end
 
-    it "skips non-subclasses of Danger::Plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_broken.rb"
-      parser.parse
+  it "creates method descriptions that make sense" do
+    parser = described_class.new "spec/fixtures/plugins/plugin_many_methods.rb"
+    parser.parse
 
-      plugins = parser.plugins_from_classes(parser.classes_in_file)
+    plugins = parser.plugins_from_classes(parser.classes_in_file)
+    json = parser.to_h(plugins)
+    method_one_liners = json.first[:methods].map { |m| m[:one_liner] }
 
-      class_syms = plugins.map(&:name)
-      expect(class_syms).to eq []
-    end
-
-    it "find subclasses of Danger::Plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_remote.rb"
-      parser.parse
-
-      plugins = parser.plugins_from_classes(parser.classes_in_file)
-
-      class_syms = plugins.map(&:name)
-      expect(class_syms).to eq [:ExampleRemote]
-    end
-
-    it "outputs JSON for badly documented subclasses of Danger::Plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_remote.rb"
-      parser.parse
-
-      plugins = parser.plugins_from_classes(parser.classes_in_file)
-      json = parser.to_h(plugins)
-      sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, "")
-
-      fixture = "spec/fixtures/plugin_json/example_remote.json"
-      # File.write(fixture, sanitized_json)
-
-      # Skipping this test for windows, pathing gets complex, and no-one
-      # is generating gem docs on windows.
-      if Gem.win_platform?
-        expect(1).to eq(1)
-      else
-        expect(sanitized_json).to eq File.read(fixture)
-      end
-    end
-
-    it "outputs JSON for well documented subclasses of Danger::Plugin" do
-      parser = PluginParser.new "spec/fixtures/plugins/example_fully_documented.rb"
-      parser.parse
-
-      plugins = parser.plugins_from_classes(parser.classes_in_file)
-      json = parser.to_h(plugins)
-      sanitized_json = JSON.pretty_generate(json).gsub(Dir.pwd, "")
-
-      fixture = "spec/fixtures/plugin_json/example_fully_doc.json"
-      # File.write(fixture, sanitized_json)
-
-      # Skipping this test for windows, pathing gets complex, and no-one
-      # is generating gem docs on windows.
-      if Gem.win_platform?
-        expect(1).to eq(1)
-      else
-        expect(sanitized_json).to eq File.read(fixture)
-      end
-    end
-
-    it "creates method descriptions that make sense" do
-      parser = PluginParser.new "spec/fixtures/plugins/plugin_many_methods.rb"
-      parser.parse
-
-      plugins = parser.plugins_from_classes(parser.classes_in_file)
-      json = parser.to_h(plugins)
-      method_one_liners = json.first[:methods].map { |m| m[:one_liner] }
-
-      expect(method_one_liners).to eq([
-                                        "one",
-                                        "two",
-                                        "two_point_five",
-                                        "three(param1=nil: String)",
-                                        "four(param1=nil: Number, param2: String) -> String",
-                                        "five(param1=[]: Array<String>, param2: Filepath, param3: Unknown) -> String",
-                                        "six? -> Bool"
-                                      ])
-    end
+    expect(method_one_liners).to eq([
+                                      "one",
+                                      "two",
+                                      "two_point_five",
+                                      "three(param1=nil: String)",
+                                      "four(param1=nil: Number, param2: String) -> String",
+                                      "five(param1=[]: Array<String>, param2: Filepath, param3: Unknown) -> String",
+                                      "six? -> Bool"
+                                    ])
   end
 end

--- a/spec/lib/danger/plugin_support/plugin_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_spec.rb
@@ -1,4 +1,4 @@
-describe Danger::Plugin do
+RSpec.describe Danger::Plugin do
   it "creates an instance name based on the class name" do
     class DangerTestClassNamePlugin < Danger::Plugin; end
     expect(DangerTestClassNamePlugin.instance_name).to eq("test_class_name_plugin")

--- a/spec/lib/danger/plugins/dangerfile_bitbucket_server_plugin_spec.rb
+++ b/spec/lib/danger/plugins/dangerfile_bitbucket_server_plugin_spec.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-describe Danger::DangerfileBitbucketServerPlugin, host: :bitbucket_server do
+RSpec.describe Danger::DangerfileBitbucketServerPlugin, host: :bitbucket_server do
   let(:dangerfile) { testing_dangerfile }
   let(:plugin) { described_class.new(dangerfile) }
 

--- a/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
+++ b/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 require "danger/request_sources/bitbucket_cloud"
 
-describe Danger::RequestSources::BitbucketCloud, host: :bitbucket_cloud do
+RSpec.describe Danger::RequestSources::BitbucketCloud, host: :bitbucket_cloud do
   let(:env) { stub_env }
   let(:bs) { Danger::RequestSources::BitbucketCloud.new(stub_ci, env) }
 

--- a/spec/lib/danger/request_sources/bibucket_server_spec.rb
+++ b/spec/lib/danger/request_sources/bibucket_server_spec.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 require "danger/request_sources/bitbucket_server"
 
-describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server do
+RSpec.describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server do
   let(:env) { stub_env }
   let(:bs) { Danger::RequestSources::BitbucketServer.new(stub_ci, env) }
 

--- a/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
@@ -1,6 +1,6 @@
 require "danger/request_sources/bitbucket_cloud_api"
 
-describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud do
+RSpec.describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud do
   describe "#inspect" do
     it "masks password on inspect" do
       allow(ENV).to receive(:[]).with("ENVDANGER_BITBUCKETCLOUD_PASSWORD") { "supertopsecret" }

--- a/spec/lib/danger/request_sources/bitbucket_server_api_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_server_api_spec.rb
@@ -1,6 +1,6 @@
 require "danger/request_sources/bitbucket_server_api"
 
-describe Danger::RequestSources::BitbucketServerAPI, host: :bitbucket_server do
+RSpec.describe Danger::RequestSources::BitbucketServerAPI, host: :bitbucket_server do
   describe "#inspect" do
     it "masks password on inspect" do
       allow(ENV).to receive(:[]).with("ENVDANGER_BITBUCKETSERVER_PASSWORD") { "supertopsecret" }

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -4,7 +4,7 @@ require "danger/ci_source/circle"
 require "danger/ci_source/travis"
 require "danger/danger_core/messages/violation"
 
-describe Danger::RequestSources::GitHub, host: :github do
+RSpec.describe Danger::RequestSources::GitHub, host: :github do
   describe "the github host" do
     it "sets a default GitHub host" do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi" }

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -3,7 +3,7 @@ require "erb"
 
 require "danger/request_sources/gitlab"
 
-describe Danger::RequestSources::GitLab, host: :gitlab do
+RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
   let(:env) { stub_env }
   let(:g) { Danger::RequestSources::GitLab.new(stub_ci, env) }
 

--- a/spec/lib/danger/request_sources/request_source_spec.rb
+++ b/spec/lib/danger/request_sources/request_source_spec.rb
@@ -1,6 +1,6 @@
 require "danger/request_sources/github"
 
-describe Danger::RequestSources::RequestSource, host: :github do
+RSpec.describe Danger::RequestSources::RequestSource, host: :github do
   describe "the base request source" do
     it "validates when passed a corresponding repository" do
       git_mock = Danger::GitRepo.new

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -1,6 +1,6 @@
 require "danger/scm_source/git_repo"
 
-describe Danger::GitRepo, host: :github do
+RSpec.describe Danger::GitRepo, host: :github do
   describe "#exec" do
     it "run command with our env set" do
       git_repo = described_class.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,16 +16,25 @@ Dir["spec/support/**/*.rb"].each { |file| require(file) }
 
 RSpec.configure do |config|
   config.filter_gems_from_backtrace "bundler"
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  if config.files_to_run.one?
+    config.default_formatter = "doc"
+  end
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand config.seed
+
+  # Custom
   config.include Danger::Support::GitLabHelper, host: :gitlab
   config.include Danger::Support::GitHubHelper, host: :github
   config.include Danger::Support::BitbucketServerHelper, host: :bitbucket_server
   config.include Danger::Support::BitbucketCloudHelper, host: :bitbucket_cloud
   config.include Danger::Support::CIHelper, use: :ci_helper
-
-  config.run_all_when_everything_filtered = true
-  config.filter_run focus: true
-  config.order = :random
-  Kernel.srand config.seed
 end
 
 # Now that we could be using Danger's plugins in Danger


### PR DESCRIPTION
Saw this tweet:

<blockquote class="twitter-tweet" data-lang="en-gb"><p lang="en" dir="ltr">Why you should regenerate your spec_helper by <a href="https://twitter.com/KnuX">@KnuX</a>: <a href="https://t.co/yHnSucqIID">https://t.co/yHnSucqIID</a></p>&mdash; RSpec - BDD for Ruby (@rspec) <a href="https://twitter.com/rspec/status/780428625279451136">26 September 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

can't help to regenerate it...

Note:

- first `describe` in file need to have `RSpec.`
