### PR TITLE
Multiple remotes support for Jenkins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Adds backwards compatibility for plugin testing API - sorry - @orta
+* Multiple remotes support for Jenkins - Juanito Fatas
 
 ## 3.4.1
 

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -53,7 +53,7 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_url = env["GIT_URL"]
+      self.repo_url = env.fetch("GIT_URL_1") { env["GIT_URL"] }
       self.pull_request_id = self.class.pull_request_id(env)
 
       repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -114,6 +114,17 @@ RSpec.describe Danger::Jenkins do
     end
   end
 
+  context "Multiple remotes support" do
+    it "gets out the repo slug from GIT_URL_1" do
+      source = described_class.new(
+        "JENKINS_URL" => "Hello",
+        "GIT_URL_1" => "https://githug.com/danger/danger.git"
+      )
+
+      expect(source.repo_slug).to eql("danger/danger")
+    end
+  end
+
   describe "#new" do
     describe "repo slug" do
       it "gets out a repo slug from a git+ssh repo" do


### PR DESCRIPTION
Capture `GIT_URL_1` if user's Jenkins has multiple remotes.

Fixes #474.

https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=69273545 (`⌘-F` for `GIT_URL_N` docs)