### PR TITLE
Fix commitish exists check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Adds backwards compatibility for plugin testing API - sorry - @orta
 * Multiple remotes support for Jenkins - Juanito Fatas
+* Fixed a problem when checking if the latest PR commit have been fetched - @fwal
 
 ## 3.4.1
 

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -37,7 +37,7 @@ module Danger
     end
 
     def ensure_commitish_exists!(commitish)
-      exec("fetch") if exec("rev-parse --quiet --verify #{commitish}").empty?
+      exec("fetch") if exec("rev-parse --quiet --verify \"#{commitish}^{commit}\"").empty?
     end
 
     private

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -305,14 +305,14 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       it "setups the danger branches" do
         @g.fetch_details
         expect(@g.scm).to receive(:exec)
-          .with("rev-parse --quiet --verify 704dc55988c6996f69b6873c2424be7d1de67bbe")
+          .with("rev-parse --quiet --verify \"704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}\"")
           .and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
 
         expect(@g.scm).to receive(:exec)
           .with("branch danger_base 704dc55988c6996f69b6873c2424be7d1de67bbe")
 
         expect(@g.scm).to receive(:exec)
-          .with("rev-parse --quiet --verify 561827e46167077b5e53515b4b7349b8ae04610b")
+          .with("rev-parse --quiet --verify \"561827e46167077b5e53515b4b7349b8ae04610b^{commit}\"")
           .and_return("561827e46167077b5e53515b4b7349b8ae04610b")
 
         expect(@g.scm).to receive(:exec)
@@ -324,14 +324,14 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       it "fetches when the branches are not in the local store" do
         @g.fetch_details
         # Check for commit turns up empty
-        expect(@g.scm).to receive(:exec).with("rev-parse --quiet --verify 704dc55988c6996f69b6873c2424be7d1de67bbe").and_return("")
+        expect(@g.scm).to receive(:exec).with("rev-parse --quiet --verify \"704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}\"").and_return("")
         # so fetch it
         expect(@g.scm).to receive(:exec).with("fetch")
         # Then make a known branch for it
         expect(@g.scm).to receive(:exec).with("branch danger_base 704dc55988c6996f69b6873c2424be7d1de67bbe")
 
         # Same as above but for head, not base
-        expect(@g.scm).to receive(:exec).with("rev-parse --quiet --verify 561827e46167077b5e53515b4b7349b8ae04610b").and_return("")
+        expect(@g.scm).to receive(:exec).with("rev-parse --quiet --verify \"561827e46167077b5e53515b4b7349b8ae04610b^{commit}\"").and_return("")
         expect(@g.scm).to receive(:exec).with("fetch")
         expect(@g.scm).to receive(:exec).with("branch danger_head 561827e46167077b5e53515b4b7349b8ae04610b")
 

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -107,14 +107,14 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
       expect(g).to receive(:base_commit).and_return("0e4db308b6579f7cc733e5a354e026b272e1c076").twice
 
       expect(g.scm).to receive(:exec)
-        .with("rev-parse --quiet --verify 345e74fabb2fecea93091e8925b1a7a208b48ba6")
+        .with("rev-parse --quiet --verify \"345e74fabb2fecea93091e8925b1a7a208b48ba6^{commit}\"")
         .and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
 
       expect(g.scm).to receive(:exec)
         .with("branch danger_head 345e74fabb2fecea93091e8925b1a7a208b48ba6")
 
       expect(g.scm).to receive(:exec)
-        .with("rev-parse --quiet --verify 0e4db308b6579f7cc733e5a354e026b272e1c076")
+        .with("rev-parse --quiet --verify \"0e4db308b6579f7cc733e5a354e026b272e1c076^{commit}\"")
         .and_return("0e4db308b6579f7cc733e5a354e026b272e1c076")
 
       expect(g.scm).to receive(:exec)


### PR DESCRIPTION
The current check just verifies that a commit hash is a valid hash rather than verifying that the commit exists in the repo. This may create problems as described in #609.