### PR TITLE
Fix ability to have false positives specs #trivial

### DIFF
--- a/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
+++ b/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Danger::RequestSources::BitbucketCloud, host: :bitbucket_cloud do
 
   describe "#new" do
     it "should not raise uninitialized constant error" do
-      expect { described_class.new(stub_ci, env) }.not_to raise_error(NameError)
+      expect { described_class.new(stub_ci, env) }.not_to raise_error
     end
   end
 

--- a/spec/lib/danger/request_sources/bibucket_server_spec.rb
+++ b/spec/lib/danger/request_sources/bibucket_server_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server 
 
   describe "#new" do
     it "should not raise uninitialized constant error" do
-      expect { described_class.new(stub_ci, env) }.not_to raise_error(NameError)
+      expect { described_class.new(stub_ci, env) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
✨ 💖 

Notice when running the specs:


```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives,
since literally any other error would cause the expectation to pass, including those raised
by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are
intending to test may not even get reached. Instead consider using `expect {}.not_to raise_error`
or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by
setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. 
```