### PR TITLE
remove stout output in spec and be more specific #trivial

### DIFF
--- a/spec/lib/danger/commands/plugin_json_spec.rb
+++ b/spec/lib/danger/commands/plugin_json_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Danger::PluginJSON do
     Danger::Plugin.clear_external_plugins
   end
 
-  it "runs the command" do
-    described_class.run(["spec/fixtures/plugins/example_fully_documented.rb"])
+  it "outputs a plugins documentation as json" do
+    expect do
+      described_class.run(["spec/fixtures/plugins/example_fully_documented.rb"])
+    end.to output(/DangerProselint/).to_stdout
   end
 end


### PR DESCRIPTION
There was a bunch of json being outputted while running specs. Rspec makes it easy to capture that.
The assertion is pretty unspecific on purpose because the actual json is verified in another spec.