### PR TITLE
Replace eql to eq in specs #trivial 

### DIFF
--- a/spec/lib/danger/ci_sources/buildkite_spec.rb
+++ b/spec/lib/danger/ci_sources/buildkite_spec.rb
@@ -55,17 +55,17 @@ RSpec.describe Danger::Buildkite do
   describe "#new" do
     describe "repo slug" do
       it "gets out a repo slug from a git+ssh repo" do
-        expect(source.repo_slug).to eql("Danger/danger")
+        expect(source.repo_slug).to eq("Danger/danger")
       end
 
       it "gets out a repo slug from a https repo" do
         valid_env["BUILDKITE_REPO"] = "https://github.com/Danger/danger.git"
-        expect(source.repo_slug).to eql("Danger/danger")
+        expect(source.repo_slug).to eq("Danger/danger")
       end
     end
 
     it "sets the pull request id" do
-      expect(source.pull_request_id).to eql("12")
+      expect(source.pull_request_id).to eq("12")
     end
   end
 

--- a/spec/lib/danger/ci_sources/circle_api_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_api_spec.rb
@@ -12,10 +12,12 @@ RSpec.describe Danger::CircleAPI do
     build_response = JSON.parse(fixture("circle_build_response"), symbolize_names: true)
     allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with("artsy/eigen", "1500", nil).and_return(build_response)
 
-    t = Danger::CircleCI.new(env)
+    result = Danger::CircleCI.new(env)
 
-    expect(t.repo_slug).to eql("artsy/eigen")
-    expect(t.pull_request_id).to eql("1130")
+    expect(result).to have_attributes(
+      repo_slug: "artsy/eigen",
+      pull_request_id: "1130"
+    )
   end
 
   it "uses the new token DANGER_CIRCLE_CI_API_TOKEN if available" do
@@ -28,8 +30,9 @@ RSpec.describe Danger::CircleAPI do
     build_response = JSON.parse(fixture("circle_build_response"), symbolize_names: true)
     allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with("artsy/eigen", "1500", "token2").and_return(build_response)
 
-    t = Danger::CircleAPI.new
-    expect(t.pull_request_url(env)).to eql("https://github.com/artsy/eigen/pull/1130")
+    result = Danger::CircleAPI.new.pull_request_url(env)
+
+    expect(result).to eq("https://github.com/artsy/eigen/pull/1130")
   end
 
   it "uses Circle CI API to grab the url if available" do
@@ -42,8 +45,9 @@ RSpec.describe Danger::CircleAPI do
     build_response = JSON.parse(fixture("circle_build_response"), symbolize_names: true)
     allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with("artsy/eigen", "1500", "token").and_return(build_response)
 
-    t = Danger::CircleAPI.new
-    expect(t.pull_request_url(env)).to eql("https://github.com/artsy/eigen/pull/1130")
+    result = Danger::CircleAPI.new.pull_request_url(env)
+
+    expect(result).to eq("https://github.com/artsy/eigen/pull/1130")
   end
 
   it "uses Circle CI API to and can tell you it's not a PR'" do
@@ -56,7 +60,8 @@ RSpec.describe Danger::CircleAPI do
     build_response = JSON.parse(fixture("circle_build_no_pr_response"), symbolize_names: true)
     allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with("artsy/eigen", "1500", "token").and_return(build_response)
 
-    t = Danger::CircleAPI.new
-    expect(t.pull_request?(env)).to be_falsy
+    result = Danger::CircleAPI.new.pull_request?(env)
+
+    expect(result).to be_falsy
   end
 end

--- a/spec/lib/danger/ci_sources/drone_spec.rb
+++ b/spec/lib/danger/ci_sources/drone_spec.rb
@@ -29,14 +29,18 @@ RSpec.describe Danger::Drone do
 
   it "gets the pull request ID" do
     env = { "DRONE_PULL_REQUEST" => "2" }
-    t = Danger::Drone.new(env)
-    expect(t.pull_request_id).to eql("2")
+
+    result = Danger::Drone.new(env)
+
+    expect(result.pull_request_id).to eq("2")
   end
 
   it "gets the repo address" do
     env = { "DRONE_REPO" => "orta/danger" }
-    t = Danger::Drone.new(env)
-    expect(t.repo_slug).to eql("orta/danger")
+
+    result = Danger::Drone.new(env)
+
+    expect(result.repo_slug).to eq("orta/danger")
   end
 
   it "gets out a repo slug and pull request number" do
@@ -45,8 +49,11 @@ RSpec.describe Danger::Drone do
       "DRONE_PULL_REQUEST" => "800",
       "DRONE_REPO" => "artsy/eigen"
     }
-    t = Danger::Drone.new(env)
-    expect(t.repo_slug).to eql("artsy/eigen")
-    expect(t.pull_request_id).to eql("800")
+    result = Danger::Drone.new(env)
+
+    expect(result).to have_attributes(
+      repo_slug: "artsy/eigen",
+      pull_request_id: "800"
+    )
   end
 end

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -121,19 +121,20 @@ RSpec.describe Danger::Jenkins do
         "GIT_URL_1" => "https://githug.com/danger/danger.git"
       )
 
-      expect(source.repo_slug).to eql("danger/danger")
+      expect(source.repo_slug).to eq("danger/danger")
     end
   end
 
   describe "#new" do
     describe "repo slug" do
       it "gets out a repo slug from a git+ssh repo" do
-        expect(source.repo_slug).to eql("danger/danger")
+        expect(source.repo_slug).to eq("danger/danger")
       end
 
       it "gets out a repo slug from a https repo" do
         valid_env["GIT_URL"] = "https://gitlab.com/danger/danger.git"
-        expect(source.repo_slug).to eql("danger/danger")
+
+        expect(source.repo_slug).to eq("danger/danger")
       end
     end
   end

--- a/spec/lib/danger/commands/local_helpers/http_cache_spec.rb
+++ b/spec/lib/danger/commands/local_helpers/http_cache_spec.rb
@@ -20,15 +20,19 @@ RSpec.describe Danger::HTTPCache do
   it "will open a previous file by default" do
     store = PStore.new(TEST_CACHE_FILE)
     store.transaction { store["testing"] = { value: "pants", updated_at: Time.now } }
-    cache = described_class.new(TEST_CACHE_FILE)
-    expect(cache.read("testing")).to eql("pants")
+
+    result = described_class.new(TEST_CACHE_FILE).read("testing")
+
+    expect(result).to eq("pants")
   end
 
   it "will delete a previous file if told to" do
     store = PStore.new(TEST_CACHE_FILE)
     store.transaction { store["testing"] = "pants" }
-    cache = described_class.new(TEST_CACHE_FILE, clear_cache: true)
-    expect(cache.read("testing")).to be_nil
+
+    result = described_class.new(TEST_CACHE_FILE, clear_cache: true).read("testing")
+
+    expect(result).to be_nil
   end
 
   it "will honor the TTL when a read attempt is made" do
@@ -40,7 +44,8 @@ RSpec.describe Danger::HTTPCache do
     end
 
     cache = described_class.new(TEST_CACHE_FILE)
-    expect(cache.read("testing_valid_ttl")).to eql("pants")
+
+    expect(cache.read("testing_valid_ttl")).to eq("pants")
     expect(cache.read("testing_invalid_ttl")).to be_nil
   end
 
@@ -59,7 +64,7 @@ RSpec.describe Danger::HTTPCache do
     store = PStore.new(TEST_CACHE_FILE)
     store.transaction do
       expect(store["testing_write"]).to_not be_nil
-      expect(store["testing_write"][:value]).to eql("pants")
+      expect(store["testing_write"][:value]).to eq("pants")
       expect(store["testing_write"][:updated_at]).to be_within(1).of(Time.now.to_i)
     end
   end

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -43,9 +43,10 @@ RSpec.describe Danger::Dangerfile, host: :github do
     dm.parse Pathname.new(""), code
 
     results = dm.status_report
-    expect(results[:messages]).to eql(["A message"])
-    expect(results[:errors]).to eql(["An error"])
-    expect(results[:warnings]).to eql(["A warning"])
+
+    expect(results[:messages]).to eq(["A message"])
+    expect(results[:errors]).to eq(["An error"])
+    expect(results[:warnings]).to eq(["A warning"])
   end
 
   describe "#print_results" do

--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
     it "should render a html link to the given file" do
       with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
         dangerfile.env.request_source.fetch_details
-        expect(plugin.html_link("CHANGELOG.md")).to eql("<a href='https://gitlab.com/k0nserv/danger-test/blob/345e74fabb2fecea93091e8925b1a7a208b48ba6/CHANGELOG.md'>CHANGELOG.md</a>")
+
+        expect(plugin.html_link("CHANGELOG.md")).to eq("<a href='https://gitlab.com/k0nserv/danger-test/blob/345e74fabb2fecea93091e8925b1a7a208b48ba6/CHANGELOG.md'>CHANGELOG.md</a>")
       end
     end
   end

--- a/spec/lib/danger/plugins/dangerfile_bitbucket_server_plugin_spec.rb
+++ b/spec/lib/danger/plugins/dangerfile_bitbucket_server_plugin_spec.rb
@@ -21,43 +21,43 @@ RSpec.describe Danger::DangerfileBitbucketServerPlugin, host: :bitbucket_server 
 
     describe "#pr_title" do
       it "has a fetched title" do
-        expect(plugin.pr_title).to eql("This is a danger test")
+        expect(plugin.pr_title).to eq("This is a danger test")
       end
     end
 
     describe "#pr_author" do
       it "has a fetched author" do
-        expect(plugin.pr_author).to eql("a.user")
+        expect(plugin.pr_author).to eq("a.user")
       end
     end
 
     describe "#pr_link" do
       it "has a fetched link to it self" do
-        expect(plugin.pr_link).to eql("https://stash.example.com/projects/IOS/repos/fancyapp/pull-requests/2080")
+        expect(plugin.pr_link).to eq("https://stash.example.com/projects/IOS/repos/fancyapp/pull-requests/2080")
       end
     end
 
     describe "#branch_for_base" do
       it "has a fetched branch for base" do
-        expect(plugin.branch_for_base).to eql("develop")
+        expect(plugin.branch_for_base).to eq("develop")
       end
     end
 
     describe "#branch_for_head" do
       it "has a fetched branch for head" do
-        expect(plugin.branch_for_head).to eql("feature/Danger")
+        expect(plugin.branch_for_head).to eq("feature/Danger")
       end
     end
 
     describe "#base_commit" do
       it "has a fetched base commit" do
-        expect(plugin.base_commit).to eql("b366c9564ad57786f0e5c6b8333c7aa1e2e90b9a")
+        expect(plugin.base_commit).to eq("b366c9564ad57786f0e5c6b8333c7aa1e2e90b9a")
       end
     end
 
     describe "#head_commit" do
       it "has a fetched head commit" do
-        expect(plugin.head_commit).to eql("c50b3f61e90dac6a00b7d0c92e415a4348bb280a")
+        expect(plugin.head_commit).to eq("c50b3f61e90dac6a00b7d0c92e415a4348bb280a")
       end
     end
 

--- a/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
+++ b/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe Danger::RequestSources::BitbucketCloud, host: :bitbucket_cloud do
 
     describe "#pr_json[:id]" do
       it "has fetched the same pull request id as ci_sources's `pull_request_id`" do
-        expect(bs.pr_json[:id]).to eql(2080)
+        expect(bs.pr_json[:id]).to eq(2080)
       end
     end
 
     describe "#pr_json[:title]" do
       it "has fetched the pull requests title" do
-        expect(bs.pr_json[:title]).to eql("This is a danger test")
+        expect(bs.pr_json[:title]).to eq("This is a danger test")
       end
     end
   end

--- a/spec/lib/danger/request_sources/bibucket_server_spec.rb
+++ b/spec/lib/danger/request_sources/bibucket_server_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server 
 
   describe "#host" do
     it "sets the host specified by `DANGER_BITBUCKETSERVER_HOST`" do
-      expect(bs.host).to eql("stash.example.com")
+      expect(bs.host).to eq("stash.example.com")
     end
   end
 
@@ -35,13 +35,13 @@ RSpec.describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server 
 
     describe "#pr_json[:id]" do
       it "has fetched the same pull request id as ci_sources's `pull_request_id`" do
-        expect(bs.pr_json[:id]).to eql(2080)
+        expect(bs.pr_json[:id]).to eq(2080)
       end
     end
 
     describe "#pr_json[:title]" do
       it "has fetched the pull requests title" do
-        expect(bs.pr_json[:title]).to eql("This is a danger test")
+        expect(bs.pr_json[:title]).to eq("This is a danger test")
       end
     end
   end

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -8,14 +8,17 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
   describe "the github host" do
     it "sets a default GitHub host" do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi" }
-      g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
-      expect(g.host).to eql("github.com")
+
+      result = Danger::RequestSources::GitHub.new(stub_ci, gh_env).host
+
+      expect(result).to eq("github.com")
     end
 
     it "allows the GitHub host to be overridden" do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com" }
-      g = Danger::RequestSources::GitHub.new(stub_ci, gh_env)
-      expect(g.host).to eql("git.club-mateusa.com")
+      result = Danger::RequestSources::GitHub.new(stub_ci, gh_env).host
+
+      expect(result).to eq("git.club-mateusa.com")
     end
 
     describe "#api_url" do
@@ -71,8 +74,13 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
 
     it "sets the ignored violations" do
       @g.fetch_details
-      expect(@g.ignored_violations).to eql(["Developer Specific file shouldn't be changed",
-                                            "Some warning"])
+
+      expect(@g.ignored_violations).to eq(
+        [
+          "Developer Specific file shouldn't be changed",
+          "Some warning"
+        ]
+      )
     end
 
     describe "#organisation" do

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.git.modified_files.class).to eql(Danger::FileList)
+        expect(@dm.git.modified_files.class).to eq(Danger::FileList)
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.git.added_files.class).to eql(Danger::FileList)
+        expect(@dm.git.added_files.class).to eq(Danger::FileList)
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.git.deleted_files.class).to eql(Danger::FileList)
+        expect(@dm.git.deleted_files.class).to eq(Danger::FileList)
       end
     end
   end
@@ -62,7 +62,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.git.added_files).to eql(["file2"])
+        expect(@dm.git.added_files).to eq(["file2"])
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.git.deleted_files).to eql(["file"])
+        expect(@dm.git.deleted_files).to eq(["file"])
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.git.modified_files).to eql(["file"])
+        expect(@dm.git.modified_files).to eq(["file"])
       end
     end
   end
@@ -127,7 +127,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.git.insertions).to eql(3)
+        expect(@dm.git.insertions).to eq(3)
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm = testing_dangerfile
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-        expect(@dm.git.deletions).to eql(1)
+        expect(@dm.git.deletions).to eq(1)
       end
     end
 


### PR DESCRIPTION
We probably want `eq` and it is 1 character less.