### PR TITLE
Ensure that PR/MR diffs don't break the verbose table output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contribution below
 
+* Removes the mr/pr diff from the tabled output during `danger pr`, `danger local` and `danger --verbose`. This is because it can be a very large output that's not too useful, and can occasionally cause errors. - orta
+
 ## 3.5.2
 
 * `danger pr` takes an argument as PR URL instead of `--use-pr` option - Juanito Fatas

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ end
 # This should get removed when > 3.7.0 comes out
 gem "gitlab", git: "https://github.com/NARKOZ/gitlab.git", branch: "master"
 
+gem "rspec_junit_formatter", git: "https://github.com/orta/rspec_junit_formatter.git", branch: "errors"
 gem "danger-junit", "~> 0.5"

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -122,12 +122,15 @@ module Danger
           when :api
             value = "Octokit::Client"
 
-          when :pr_json
-            value = "[Skipped]"
+          when :pr_json, :mr_json
+            value = "[Skipped JSON]"
+
+          when :pr_diff, :mr_diff
+            value = "[Skipped Diff]"
 
           else
             value = plugin.send(method)
-            value = wrap_text(value) if value.kind_of?(String)
+            value = wrap_text(value.encode("utf-8")) if value.kind_of?(String)
             # So that we either have one value per row
             # or we have [] for an empty array
             value = value.join("\n") if value.kind_of?(Array) && value.count > 0

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -206,6 +206,15 @@ RSpec.describe Danger::Dangerfile, host: :github do
           :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider
         ]
       end
+
+      it "skips raw PR/MR JSON, and diffs" do
+        data = @dm.method_values_for_plugin_hashes(@dm.external_dsl_attributes)
+        data_hash = Hash[*data.collect { |v| [v.first, v.last] }.flatten]
+
+        expect(data_hash["pr_json"]).to eq("[Skipped JSON]")
+        expect(data_hash["mr_json"]).to eq("[Skipped JSON]")
+        expect(data_hash["pr_diff"]).to eq("[Skipped Diff]")
+      end
     end
   end
 


### PR DESCRIPTION
Also relates to #622 

-- 

Simplifies the table'd output when Danger shows the table, the diff can be really long and not too useful in that table - so I've removed it, and to add some extra paranoia, all metadata from plugins is not encoded into utf8