### PR TITLE
Dump RSpec JUnit Formatter failures to a local .xml_dump_failures file #trivial 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ junit-results.xml
 
 # Byebug
 /.byebug_history
+
+# our forked RSpec JUnit Formatter
+/.xml_dump_failures

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ end
 # This should get removed when > 3.7.0 comes out
 gem "gitlab", git: "https://github.com/NARKOZ/gitlab.git", branch: "master"
 
-gem "rspec_junit_formatter", git: "https://github.com/orta/rspec_junit_formatter.git", branch: "errors"
+gem "rspec_junit_formatter", git: "https://github.com/JuanitoFatas/rspec_junit_formatter.git", branch: "dump-rspec_junit_formatter-failed-examples"
 gem "danger-junit", "~> 0.5"


### PR DESCRIPTION
So that the test suite won't emit a lot of scary stuff. If anyone want to checkout those failures, can see  this file [`.xml_dump_failures`](https://github.com/JuanitoFatas/rspec_junit_formatter/commit/95e7c7ffb7c5f35a26120f3d48d5bb1356162417) after tests ran.