### PR TITLE
Fail fast if still cannot find the commit after fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contribution below
 
+* fail fast if still cannot find the commit after fetch - Juanito Fatas
+
 ## 3.5.3
 
 [Full Changelog](https://github.com/danger/danger/compare/v3.5.2...v3.5.3)

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -51,7 +51,7 @@ module Danger
     end
 
     def raise_if_we_cannot_find_the_commit(commit)
-      raise "Commit #{commit[0..7]} doesn't exists. Are you running `danger local/pr` against the correct repository? Also this usually happens when you rebase/reset and force-pushed."
+      raise "Commit #{commit[0..7]} doesn't exist. Are you running `danger local/pr` against the correct repository? Also this usually happens when you rebase/reset and force-pushed."
     end
   end
 end

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -38,12 +38,20 @@ module Danger
 
     def ensure_commitish_exists!(commitish)
       exec("fetch") if exec("rev-parse --quiet --verify \"#{commitish}^{commit}\"").empty?
+
+      if exec("rev-parse --quiet --verify \"#{commitish}^{commit}\"").empty?
+        raise_if_we_cannot_find_the_commit(commitish)
+      end
     end
 
     private
 
     def default_env
       { "LANG" => "en_US.UTF-8" }
+    end
+
+    def raise_if_we_cannot_find_the_commit(commit)
+      raise "Commit #{commit[0..7]} doesn't exists. Are you running `danger local/pr` against the correct repository? Also this usually happens when you rebase/reset and force-pushed."
     end
   end
 end

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -117,12 +117,12 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
         and_return("0e4db308b6579f7cc733e5a354e026b272e1c076").twice
       expect(subject.scm).to receive(:exec)
         .with("rev-parse --quiet --verify \"345e74fabb2fecea93091e8925b1a7a208b48ba6^{commit}\"")
-        .and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
+        .and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6").twice
       expect(subject.scm).to receive(:exec)
         .with("branch danger_head 345e74fabb2fecea93091e8925b1a7a208b48ba6")
       expect(subject.scm).to receive(:exec)
         .with("rev-parse --quiet --verify \"0e4db308b6579f7cc733e5a354e026b272e1c076^{commit}\"")
-        .and_return("0e4db308b6579f7cc733e5a354e026b272e1c076")
+        .and_return("0e4db308b6579f7cc733e5a354e026b272e1c076").twice
       expect(subject.scm).to receive(:exec)
         .with("branch danger_base 0e4db308b6579f7cc733e5a354e026b272e1c076")
 

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Danger::GitRepo, host: :github do
   end
 
   describe "#diff_for_folder" do
-    it "fetches remote commits if it cannot find the merge commit" do
+    it "fetches if cannot find commits, raises if still can't find after fetched" do
       with_git_repo do |dir|
         @dm = testing_dangerfile
 
@@ -22,7 +22,9 @@ RSpec.describe Danger::GitRepo, host: :github do
         # This is the thing we care about
         allow(@dm.env.scm).to receive(:exec).with("fetch")
 
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+        expect do
+          @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+        end.to raise_error(RuntimeError, /Commit (\w+|\b[0-9a-f]{5,40}\b) doesn't exist/)
       end
     end
   end


### PR DESCRIPTION
This PR changes the behavior of ensure commit exists. Fixes #185 /cc @KrauseFx @jeroenvisser101

Before we failed untill [we are finding the merge base](https://github.com/danger/danger/blob/50afd1743d1228b1c7031eb7e32eeda91aad526b/lib/danger/scm_source/git_repo.rb#L13-L15) for commits that not exists.

```ruby
ensure_commitish_exists!(from)
ensure_commitish_exists!(to)
merge_base = repo.merge_base(from, to) # <--- failed here *before* this PR
```

Now we fail fast:

```ruby
ensure_commitish_exists!(from) # <--- failed here *after* this PR
ensure_commitish_exists!(to)
merge_base = repo.merge_base(from, to) 
```

--

<details>
<summary>Cases that commits not exist happened</summary>

- Run `danger pr https://github.com/artsy/eigen/pull/1811` on `danger/danger`

  ```
  Running your Dangerfile against this PR - https://github.com/artsy/eigen/pull/1811
  Turning on --verbose

  fatal: Not a valid branch point: 'df9db51d75a5fbffaea30e3f71d39c7ddb880c26'.
  fatal: Not a valid branch point: 'b033d903cb1b3427a4c0da601b445afd7e6b9398'.
  /Users/juanitofatas/.gem/ruby/2.3.1/gems/git-1.3.0/lib/git/lib.rb:937:in `command': git '--git-dir=/Users/juanitofatas/dev/danger/.git' '--work-tree=/Users/juanitofatas/dev/danger' merge-base 'danger_base' 'danger_head'  2>&1:fatal: Not a valid object name danger_base (Git::GitExecuteError)
    from /Users/juanitofatas/.gem/ruby/2.3.1/gems/danger-3.5.3/lib/danger/scm_source/git_repo.rb:71:in `merge_base'
    from /Users/juanitofatas/.gem/ruby/2.3.1/gems/danger-3.5.3/lib/danger/scm_source/git_repo.rb:61:in `merge_base'
    from /Users/juanitofatas/.gem/ruby/2.3.1/gems/danger-3.5.3/lib/danger/scm_source/git_repo.rb:15:in `diff_for_folder'
    from /Users/juanitofatas/.gem/ruby/2.3.1/gems/danger-3.5.3/lib/danger/commands/pr.rb:106:in `run'
    from /Users/juanitofatas/.gem/ruby/2.3.1/gems/claide-1.0.0/lib/claide/command.rb:334:in `run'
    from /Users/juanitofatas/.gem/ruby/2.3.1/gems/danger-3.5.3/bin/danger:5:in `<top (required)>'
    from /Users/juanitofatas/.gem/ruby/2.3.1/bin/danger:22:in `load'
    from /Users/juanitofatas/.gem/ruby/2.3.1/bin/danger:22:in `<main>'
  ```

- Git rebase then force pushed
- Git reset then force pushed
</details>