### PR TITLE
EnvironmentManager constructor forwards self.ui, not ui method arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * fail fast if still cannot find the commit after fetch - Juanito Fatas
 * Adds the '--new-comment' argument, which makes Danger post a brand new comment by ignoring other Danger instances - Bruno Rocha
+* Fixed an issue where EnvironmentManager's output UI could be nil, and would blackhole error messages - @notjosh
 
 ## 3.5.3
 

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -39,7 +39,7 @@ module Danger
         self.request_source = request_source
       end
 
-      raise_error_for_no_request_source(env, ui) unless self.request_source
+      raise_error_for_no_request_source(env, self.ui) unless self.request_source
       self.scm = self.request_source.scm
     end
 

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -378,5 +378,19 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
 
       expect(ui.string).to include("Travis note: If you have an open source project, you should ensure 'Display value in build log' enabled for these flags, so that PRs from forks work.")
     end
+
+    context "cannot find request source" do
+      it "raises error" do
+        env = { "DANGER_USE_LOCAL_GIT" => "true" }
+        fake_ui = double("Cork::Board")
+        allow(Cork::Board).to receive(:new) { fake_ui }
+        allow(Danger::RequestSources::RequestSource).to receive(:available_request_sources) { [] }
+
+        expect(fake_ui).to receive(:title)
+        expect(fake_ui).to receive(:puts).exactly(5).times
+
+        expect { Danger::EnvironmentManager.new(env, nil) }.to raise_error(SystemExit)
+      end
+    end
   end
 end


### PR DESCRIPTION
I stumbled on this over at https://github.com/danger/danger-plugin-template/pull/10#issuecomment-252731193 when `EnvironmentManager` was trying to output errors to screen, but had no `ui` to output with. Not ideal.

This PR fixes that.

I couldn't find a particularly friendly way to test this. The bug is obvious enough, but preventing regressions would be nice. Passing in bad `env` params meant that it would fail to trigger the bug (it would bail beforehand), so I'm not sure :)