### PR TITLE
Use `git-merge-base` instead of ruby-git to find more merge bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   ```
 * Adds the '--new-comment' argument, which makes Danger post a brand new comment by ignoring other Danger instances - Bruno Rocha
 * Fixed an issue where EnvironmentManager's output UI could be nil, and would blackhole error messages - @notjosh
-* Finding more git merge bases - Juanito Fatas
+* Fix crash in git_repo.rb (#636) - Kyle McAlpine & Juanito Fatas
 
 ## 3.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   ```
   danger pr https://github.com/danger/danger/pull/518 --dangerfile ~/Dangerfile
   ```
+* Adds the '--new-comment' argument, which makes Danger post a brand new comment by ignoring other Danger instances - Bruno Rocha
+* Fixed an issue where EnvironmentManager's output UI could be nil, and would blackhole error messages - @notjosh
+* Finding more git merge bases - Juanito Fatas
 
 ## 3.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add your own contribution below
 * Show warning when Danger is missing permissions to update PR status, even on successful build - hanneskaeufler
+* Fix crash in git_repo.rb (#636) - Kyle McAlpine & Viktor Benei & orta & Juanito Fatas
 
 ## 3.5.4
 
@@ -18,9 +19,6 @@
   ```
   danger pr https://github.com/danger/danger/pull/518 --dangerfile ~/Dangerfile
   ```
-* Adds the '--new-comment' argument, which makes Danger post a brand new comment by ignoring other Danger instances - Bruno Rocha
-* Fixed an issue where EnvironmentManager's output UI could be nil, and would blackhole error messages - @notjosh
-* Fix crash in git_repo.rb (#636) - Kyle McAlpine & Juanito Fatas
 
 ## 3.5.3
 
@@ -226,7 +224,7 @@
   danger.import_dangerfile github: 'ruby-grape/danger'
   ```
 
-  You can package a Dangerfile in a gem, add it to Gemfile and import it.
+  You can package a Dangerfile in a gem, add it to Gemfile and import it.
 
   ```ruby
   danger.import_dangerfile gem: 'ruby-grape-danger'

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -77,11 +77,19 @@ module Danger
     end
 
     def best_merge_base(repo, from, to)
-      possible_merge_base = [repo.merge_base(from, to)].find { |base| commit_exists?(base) }
+      possible_merge_base = possible_merge_base(repo, from, to)
+      if !possible_merge_base
+        exec("fetch --unshallow")
+        possible_merge_base = possible_merge_base(repo, from, to)
+      end
 
       raise "Cannot find a merge base between #{from} and #{to}." unless possible_merge_base
 
       possible_merge_base
+    end
+
+    def possible_merge_base(repo, from, to)
+      [repo.merge_base(from, to)].find { |base| commit_exists?(base) }
     end
   end
 end

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -51,7 +51,7 @@ module Danger
     end
 
     def ensure_commitish_exists!(commitish)
-      exec("fetch --all") if commit_not_exists?(commitish)
+      exec("fetch --unshallow") if commit_not_exists?(commitish)
 
       if commit_not_exists?(commitish)
         raise_if_we_cannot_find_the_commit(commitish)

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -341,14 +341,14 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       it "setups the danger branches" do
         @g.fetch_details
         expect(@g.scm).to receive(:exec)
-          .with("rev-parse --quiet --verify \"704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}\"")
+          .with("rev-parse --quiet --verify 704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}")
           .and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6").twice
 
         expect(@g.scm).to receive(:exec)
           .with("branch danger_base 704dc55988c6996f69b6873c2424be7d1de67bbe")
 
         expect(@g.scm).to receive(:exec)
-          .with("rev-parse --quiet --verify \"561827e46167077b5e53515b4b7349b8ae04610b^{commit}\"")
+          .with("rev-parse --quiet --verify 561827e46167077b5e53515b4b7349b8ae04610b^{commit}")
           .and_return("561827e46167077b5e53515b4b7349b8ae04610b").twice
 
         expect(@g.scm).to receive(:exec)
@@ -360,13 +360,13 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       it "fetches when the branches are not in the local store" do
         # not in history
         expect(@g.scm).to receive(:exec).
-          with("rev-parse --quiet --verify \"704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}\"").
+          with("rev-parse --quiet --verify 704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}").
           and_return("")
         # fetch it
         expect(@g.scm).to receive(:exec).with("fetch")
         # still not in history
         expect(@g.scm).to receive(:exec).
-          with("rev-parse --quiet --verify \"704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}\"").
+          with("rev-parse --quiet --verify 704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}").
           and_return("")
 
         expect do

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
           with("rev-parse --quiet --verify 704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}").
           and_return("")
         # fetch it
-        expect(@g.scm).to receive(:exec).with("fetch")
+        expect(@g.scm).to receive(:exec).with("fetch --unshallow")
         # still not in history
         expect(@g.scm).to receive(:exec).
           with("rev-parse --quiet --verify 704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}").

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -116,12 +116,12 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
       expect(subject).to receive(:base_commit).
         and_return("0e4db308b6579f7cc733e5a354e026b272e1c076").twice
       expect(subject.scm).to receive(:exec)
-        .with("rev-parse --quiet --verify \"345e74fabb2fecea93091e8925b1a7a208b48ba6^{commit}\"")
+        .with("rev-parse --quiet --verify 345e74fabb2fecea93091e8925b1a7a208b48ba6^{commit}")
         .and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6").twice
       expect(subject.scm).to receive(:exec)
         .with("branch danger_head 345e74fabb2fecea93091e8925b1a7a208b48ba6")
       expect(subject.scm).to receive(:exec)
-        .with("rev-parse --quiet --verify \"0e4db308b6579f7cc733e5a354e026b272e1c076^{commit}\"")
+        .with("rev-parse --quiet --verify 0e4db308b6579f7cc733e5a354e026b272e1c076^{commit}")
         .and_return("0e4db308b6579f7cc733e5a354e026b272e1c076").twice
       expect(subject.scm).to receive(:exec)
         .with("branch danger_base 0e4db308b6579f7cc733e5a354e026b272e1c076")

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Danger::GitRepo, host: :github do
 
         expect do
           @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
-        end.to raise_error(RuntimeError, /Commit (\w+|\b[0-9a-f]{5,40}\b) doesn't exist/)
+        end.to raise_error(RuntimeError, /doesn't exist/)
       end
     end
   end
@@ -72,20 +72,19 @@ RSpec.describe Danger::GitRepo, host: :github do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
+          `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`
           `git commit -m "ok"`
-
           `git checkout -b new --quiet`
           File.delete(dir + "/file")
           `git add . --all`
           `git commit -m "another"`
+
+          @dm = testing_dangerfile
+          @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+          expect(@dm.git.deleted_files).to eq(["file"])
         end
-
-        @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
-
-        expect(@dm.git.deleted_files).to eq(["file"])
       end
     end
 
@@ -93,20 +92,20 @@ RSpec.describe Danger::GitRepo, host: :github do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
+          `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`
           `git commit -m "ok"`
-
           `git checkout -b new --quiet`
           File.open(dir + "/file", "a") { |file| file.write("ok\nmorestuff") }
           `git add .`
           `git commit -m "another"`
+
+          @dm = testing_dangerfile
+          @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+
+          expect(@dm.git.modified_files).to eq(["file"])
         end
-
-        @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
-
-        expect(@dm.git.modified_files).to eq(["file"])
       end
     end
   end
@@ -116,6 +115,7 @@ RSpec.describe Danger::GitRepo, host: :github do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
+          `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`
           `git commit -m "ok"`
@@ -124,12 +124,12 @@ RSpec.describe Danger::GitRepo, host: :github do
           File.open(dir + "/file", "a") { |file| file.write("hi\n\najsdha") }
           `git add .`
           `git commit -m "another"`
+
+          @dm = testing_dangerfile
+          @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+
+          expect(@dm.git.insertions).to eq(3)
         end
-
-        @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
-
-        expect(@dm.git.insertions).to eq(3)
       end
     end
 
@@ -137,6 +137,7 @@ RSpec.describe Danger::GitRepo, host: :github do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
+          `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("1\n2\n3\n4\n5\n") }
           `git add .`
           `git commit -m "ok"`
@@ -145,12 +146,12 @@ RSpec.describe Danger::GitRepo, host: :github do
           File.open(dir + "/file", "w") { |file| file.write("1\n2\n3\n5\n") }
           `git add .`
           `git commit -m "another"`
+
+          @dm = testing_dangerfile
+          @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
+
+          expect(@dm.git.deletions).to eq(1)
         end
-
-        @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
-
-        expect(@dm.git.deletions).to eq(1)
       end
     end
 

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe Danger::GitRepo, host: :github do
           @dm = testing_dangerfile
           @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
-          expect(@dm.git.modified_files).to eq(["file"])
+          # Need to compact here because c50713a changes make AppVeyor fail
+          expect(@dm.git.modified_files.compact).to eq(["file"])
         end
       end
     end


### PR DESCRIPTION
Will this solve #634 I am not sure 😞 .

But I find `git merge-base --all` can find multiple common ancestors 🎩 as the docs said:

> Output all merge bases for the commits, instead of just one.
> -- [git merge-base](https://git-scm.com/docs/git-merge-base)

--

The tests were wrong 😱, should exercise in the created tmp folder:

```
@dm = testing_dangerfile
@dm.env.scm.diff_for_folder(dir, from: "master", to: "new")

expect(@dm.git.deleted_files).to eq(["file"])
```