### PR TITLE
Add --dangerfile support to `danger pr` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * fail fast if still cannot find the commit after fetch - Juanito Fatas
 * Adds the '--new-comment' argument, which makes Danger post a brand new comment by ignoring other Danger instances - Bruno Rocha
 * Fixed an issue where EnvironmentManager's output UI could be nil, and would blackhole error messages - @notjosh
+* `danger pr` now accepts `--dangerfile` argument - Juanito Fatas
+
+  ```
+  danger pr https://github.com/danger/danger/pull/518 --dangerfile ~/Dangerfile
+  ```
 
 ## 3.5.3
 

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -12,15 +12,19 @@ module Danger
     def self.options
       [
         ["--clear-http-cache", "Clear the local http cache before running Danger locally."],
-        ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
+        ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."],
+        ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"]
       ]
     end
 
     def initialize(argv)
       @pr_url = argv.shift_argument
       @clear_http_cache = argv.flag?("clear-http-cache", false)
+      dangerfile = argv.option("dangerfile", "Dangerfile")
 
       super
+
+      @dangerfile_path = dangerfile if File.exist?(dangerfile)
 
       setup_pry if should_pry?(argv)
     end

--- a/spec/lib/danger/commands/pr_spec.rb
+++ b/spec/lib/danger/commands/pr_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe Danger::PR do
 
       expect(result).to include ["--clear-http-cache", "Clear the local http cache before running Danger locally."]
       expect(result).to include ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
+      expect(result).to include ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"]
+    end
+
+    it "dangerfile can be set" do
+      argv = CLAide::ARGV.new(["--dangerfile=/Users/Orta/Dangerfile"])
+      allow(File).to receive(:exist?) { true }
+
+      result = described_class.new(argv)
+
+      expect(result).to have_instance_variables(
+        "@dangerfile_path" => "/Users/Orta/Dangerfile"
+      )
     end
   end
 


### PR DESCRIPTION
This Pull Request adds `--dangerfile` support to `danger pr` command.

Implements #637.