### PR TITLE
Hk status update improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contribution below
+* Show warning when Danger is missing permissions to update PR status, even on successful build - hanneskaeufler
 
 ## 3.5.4
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -199,6 +199,7 @@ module Danger
             end
           else
             puts message
+            puts "\nDanger does not have write access to the PR to set a PR status.".yellow
           end
         end
       end

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -155,11 +155,11 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
 
       it "aborts when access to setting the status was denied but there were errors" do
         stub_request(:post, "https://api.github.com/repos/artsy/eigen/statuses/pr_commit_ref")
-          .to_return(:status => 404)
+          .to_return(status: 404)
 
         @g.pr_json = {
           "head" => { "sha" => "pr_commit_ref" },
-          "base" => { "repo" => { "private" => true }}
+          "base" => { "repo" => { "private" => true } }
         }
 
         expect do
@@ -169,11 +169,11 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
 
       it "warns when access to setting the status was denied but no errors were reported" do
         stub_request(:post, "https://api.github.com/repos/artsy/eigen/statuses/pr_commit_ref")
-          .to_return(:status => 404)
+          .to_return(status: 404)
 
         @g.pr_json = {
           "head" => { "sha" => "pr_commit_ref" },
-          "base" => { "repo" => { "private" => true }}
+          "base" => { "repo" => { "private" => true } }
         }
 
         expect do

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -166,6 +166,20 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
           @g.submit_pull_request_status!(errors: violations(["error"]))
         end.to raise_error.and output(/Danger has failed this build/).to_stderr
       end
+
+      it "warns when access to setting the status was denied but no errors were reported" do
+        stub_request(:post, "https://api.github.com/repos/artsy/eigen/statuses/pr_commit_ref")
+          .to_return(:status => 404)
+
+        @g.pr_json = {
+          "head" => { "sha" => "pr_commit_ref" },
+          "base" => { "repo" => { "private" => true }}
+        }
+
+        expect do
+          @g.submit_pull_request_status!(warnings: violations(["error"]))
+        end.to output(/warning/i).to_stdout
+      end
     end
 
     describe "issue creation" do

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
 
         expect do
           @g.submit_pull_request_status!(warnings: violations(["error"]))
-        end.to output(/warning/i).to_stdout
+        end.to output(/warning.*not have write access/im).to_stdout
       end
     end
 


### PR DESCRIPTION
So when danger failed a build, it would output a comment if it was unable to update the PR status. However, when the danger run was not containing any errors, it would fail silently to update the PR status. Reported in #587 