### PR TITLE
--new-comment improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 * Show warning when Danger is missing permissions to update PR status, even on successful build - hanneskaeufler
 * Fixed '--new-comment' creating multiple GitHub status checks, and removing the argument on a subsequent build will now make Danger correctly edit it's last comment - Bruno Rocha
 * Fix crash in git_repo.rb (#636) - Kyle McAlpine & Viktor Benei & orta & Juanito Fatas
-* Fixed '--new-comment' creating multiple GitHub status checks, and removing the argument on a subsequent build will now make Danger correctly edit it's last comment - Bruno Rocha
 
 ## 3.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add your own contribution below
 * Show warning when Danger is missing permissions to update PR status, even on successful build - hanneskaeufler
+* Fixed '--new-comment' creating multiple GitHub status checks, and removing the argument on a subsequent build will now make Danger correctly edit it's last comment - Bruno Rocha
 
 ## 3.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Show warning when Danger is missing permissions to update PR status, even on successful build - hanneskaeufler
 * Fixed '--new-comment' creating multiple GitHub status checks, and removing the argument on a subsequent build will now make Danger correctly edit it's last comment - Bruno Rocha
 * Fix crash in git_repo.rb (#636) - Kyle McAlpine & Viktor Benei & orta & Juanito Fatas
+* Fixed '--new-comment' creating multiple GitHub status checks, and removing the argument on a subsequent build will now make Danger correctly edit it's last comment - Bruno Rocha
 
 ## 3.5.4
 

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -37,8 +37,8 @@ module Danger
       @base = argv.option("base")
       @head = argv.option("head")
       @fail_on_errors = argv.option("fail-on-errors", false)
-      new_comment = argv.flag?("new-comment")
-      @danger_id = new_comment ? Time.now.strftime("%v %H:%M:%S") : argv.option("danger_id", "danger")
+      @new_comment = argv.flag?("new-comment")
+      @danger_id = argv.option("danger_id", "danger")
       @cork = Cork::Board.new(silent: argv.option("silent", false),
                               verbose: argv.option("verbose", false))
       super
@@ -58,7 +58,7 @@ module Danger
         ["--fail-on-errors=<true|false>", "Should always fail the build process, defaults to false"],
         ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"],
         ["--danger_id=<id>", "The identifier of this Danger instance"],
-        ["--new-comment", "Makes the build process ignore other Danger instances, resulting in a new comment. Overrides '--danger_id'."]
+        ["--new-comment", "Makes Danger post a new comment instead of editing it's previous one"]
       ].concat(super)
     end
 
@@ -68,6 +68,7 @@ module Danger
         head: @head,
         dangerfile_path: @dangerfile_path,
         danger_id: @danger_id,
+        new_comment: @new_comment,
         fail_on_errors: @fail_on_errors
       )
     end

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -241,7 +241,7 @@ module Danger
       violation_report[:errors].count > 0
     end
 
-    def post_results(danger_id)
+    def post_results(danger_id, new_comment)
       violations = violation_report
 
       env.request_source.update_pull_request!(
@@ -249,7 +249,8 @@ module Danger
         errors: violations[:errors],
         messages: violations[:messages],
         markdowns: status_report[:markdowns],
-        danger_id: danger_id
+        danger_id: danger_id,
+        new_comment: new_comment
       )
     end
 
@@ -258,7 +259,7 @@ module Danger
       env.scm.diff_for_folder(".".freeze, from: base_branch, to: head_branch)
     end
 
-    def run(base_branch, head_branch, dangerfile_path, danger_id)
+    def run(base_branch, head_branch, dangerfile_path, danger_id, new_comment)
       # Setup internal state
       init_plugins
       env.fill_environment_vars
@@ -273,7 +274,7 @@ module Danger
         # Push results to the API
         # Pass along the details of the run to the request source
         # to send back to the code review site.
-        post_results(danger_id)
+        post_results(danger_id, new_comment)
 
         # Print results in the terminal
         print_results

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -11,6 +11,7 @@ module Danger
             head: nil,
             dangerfile_path: nil,
             danger_id: nil,
+            new_comment: nil,
             fail_on_errors: nil)
       # Create a silent Cork instance if cork is nil, as it's likely a test
       cork ||= Cork::Board.new(silent: false, verbose: false)
@@ -27,7 +28,8 @@ module Danger
           base_branch(base),
           head_branch(head),
           dangerfile_path,
-          danger_id
+          danger_id,
+          new_comment
         )
       end
 

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -105,15 +105,16 @@ module Danger
       end
 
       # Sending data to GitHub
-      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger")
+      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false)
         comment_result = {}
         editable_comments = issue_comments.select { |comment| comment.generated_by_danger?(danger_id) }
+        last_comment = editable_comments.last
+        should_create_new_comment = new_comment || last_comment.nil?
 
-        if editable_comments.empty?
+        if should_create_new_comment
           previous_violations = {}
         else
-          comment = editable_comments.first.body
-          previous_violations = parse_comment(comment)
+          previous_violations = parse_comment(last_comment.body)
         end
 
         main_violations = (warnings + errors + messages + markdowns).reject(&:inline?)
@@ -154,11 +155,10 @@ module Danger
                                   danger_id: danger_id,
                                   template: "github")
 
-          if editable_comments.empty?
+          if should_create_new_comment
             comment_result = client.add_comment(ci_source.repo_slug, ci_source.pull_request_id, body)
           else
-            original_id = editable_comments.first.id
-            comment_result = client.update_comment(ci_source.repo_slug, original_id, body)
+            comment_result = client.update_comment(ci_source.repo_slug, last_comment.id, body)
           end
         end
 

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Danger::Runner do
         "@base" => nil,
         "@head" => nil,
         "@fail_on_errors" => false,
-        "@danger_id" => "danger"
+        "@danger_id" => "danger",
+        "@new_comment" => nil
       )
       expect(ui).to be_a Cork::Board
       expect(ui).to have_instance_variables(
@@ -49,6 +50,7 @@ RSpec.describe Danger::Runner do
         head: nil,
         dangerfile_path: "Dangerfile",
         danger_id: "danger",
+        new_comment: nil,
         fail_on_errors: false
       )
 
@@ -65,6 +67,7 @@ RSpec.describe Danger::Runner do
             "--head=my-head",
             "--dangerfile=MyDangerfile",
             "--danger_id=my-danger-id",
+            "--new-comment",
             "--fail-on-errors=true"
           ]
         )
@@ -77,6 +80,7 @@ RSpec.describe Danger::Runner do
           head: "my-head",
           dangerfile_path: "MyDangerfile",
           danger_id: "my-danger-id",
+          new_comment: true,
           fail_on_errors: "true"
         )
 

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
 
       expect(request_source).to receive(:update_pull_request!)
 
-      dm.post_results("danger-identifier")
+      dm.post_results("danger-identifier", nil)
     end
   end
 

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -208,6 +208,16 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
         @g.update_pull_request!(warnings: violations(["hi"]), errors: [], messages: [])
       end
 
+      it "creates a new comment instead of updating the issue if --new-comment is provided" do
+        comments = [{ "body" => "generated_by_danger", "id" => "12" }]
+        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
+
+        body = @g.generate_comment(warnings: violations(["hi"]), errors: [], messages: [])
+        expect(@g.client).to receive(:add_comment).with("artsy/eigen", "800", body).and_return({})
+
+        @g.update_pull_request!(warnings: violations(["hi"]), errors: [], messages: [], new_comment: true)
+      end
+
       it "updates the issue if no danger comments exist and a custom danger_id is provided" do
         comments = [{ "body" => "generated_by_another_danger", "id" => "12" }]
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)


### PR DESCRIPTION
As mentioned on [#641](https://github.com/danger/danger/issues/641):

- Made --new-comment work with a single danger_id, so now we only get one, pretty Danger checkmark on your PR instead of multiple ones.
- Danger now always retrieves it's last comment (used to be the first one since it never had more than one showing up at the same time), so removing the argument on a subsequent build will now make it edit the right comment.