### PR TITLE
Support for Jenkins pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contribution below
+* Support for Jenkins pipelines - fwal
 
 ## 3.5.5
 

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -80,8 +80,20 @@ module Danger
       if env["GIT_URL_1"]
         env["GIT_URL_1"]
       elsif env["CHANGE_URL"]
-        url_matches = env["CHANGE_URL"].match(%r{(.+)\/pull\/[0-9]+})
-        url_matches[1] unless url_matches.nil?
+        change_url = env["CHANGE_URL"]
+        case change_url
+        when %r{\/pull\/} # GitHub
+          matches = change_url.match(%r{(.+)\/pull\/[0-9]+})
+          matches[1] unless matches.nil?
+        when %r{\/merge_requests\/} # GitLab
+          matches = change_url.match(%r{(.+)\/merge_requests\/[0-9]+})
+          matches[1] unless matches.nil?
+        when %r{\/pull-requests\/} # Bitbucket
+          matches = change_url.match(%r{(.+)\/pull-requests\/[0-9]+})
+          matches[1] unless matches.nil?
+        else
+          change_url
+        end
       else
         env["GIT_URL"]
       end

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -17,6 +17,12 @@ module Danger
   #
   # With that set up, you can edit your job to add `bundle exec danger` at the build action.
   #
+  # ##### Pipeline
+  # If your're using [pipelines](https://jenkins.io/solutions/pipeline/) you should be using the [GitHub branch source plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Branch+Source+Plugin)
+  # for easy setup and handling of PRs.
+  #
+  # After you've set up the plugin, add a `sh 'bundle exec danger'` line in your pipeline script and make sure that build PRs is enabled.
+  #
   # #### GitLab
   # You will want to be using the [GitLab Plugin](https://github.com/jenkinsci/gitlab-plugin)
   # in order to ensure that you have the build environment set up for MR integration.

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -53,7 +53,7 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_url = env.fetch("GIT_URL_1") { env["GIT_URL"] }
+      self.repo_url = self.class.repo_url(env)
       self.pull_request_id = self.class.pull_request_id(env)
 
       repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
@@ -63,8 +63,21 @@ module Danger
     def self.pull_request_id(env)
       if env["ghprbPullId"]
         env["ghprbPullId"]
+      elsif env["CHANGE_ID"]
+        env["CHANGE_ID"]
       else
         env["gitlabMergeRequestId"]
+      end
+    end
+
+    def self.repo_url(env)
+      if env["GIT_URL_1"]
+        env["GIT_URL_1"]
+      elsif env["CHANGE_URL"]
+        url_matches = env["CHANGE_URL"].match(%r{(.+)\/pull\/[0-9]+})
+        url_matches[1] unless url_matches.nil?
+      else
+        env["GIT_URL"]
       end
     end
   end

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -157,6 +157,23 @@ RSpec.describe Danger::Jenkins do
       end
     end
 
+    describe ".repo_url()" do
+      it "gets the GitHub url" do
+        valid_env["CHANGE_URL"] = "https://github.com/danger/danger/pull/647"
+        expect(described_class.repo_url(valid_env)).to eq("https://github.com/danger/danger")
+      end
+
+      it "gets the GitLab url" do
+        valid_env["CHANGE_URL"] = "https://gitlab.com/danger/danger/merge_requests/1234"
+        expect(described_class.repo_url(valid_env)).to eq("https://gitlab.com/danger/danger")
+      end
+
+      it "gets the BitBucket url" do
+        valid_env["CHANGE_URL"] = "https://bitbucket.org/danger/danger/pull-requests/1"
+        expect(described_class.repo_url(valid_env)).to eq("https://bitbucket.org/danger/danger")
+      end
+    end
+
     describe "#new" do
       it "sets the pull_request_id" do
         expect(source.pull_request_id).to eq("647")

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -65,7 +65,56 @@ RSpec.describe Danger::Jenkins do
     end
   end
 
-  context "with GitHub (pipeline)" do
+  context "with GitLab" do
+    before do
+      valid_env["gitlabMergeRequestId"] = "1234"
+      valid_env["GIT_URL"] = "https://gitlab.com/danger/danger.git"
+    end
+
+    describe ".validates_as_ci?" do
+      it "validates when required env variables are set" do
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "validates even when `gitlabMergeRequestId` is missing" do
+        valid_env["gitlabMergeRequestId"] = nil
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "validates even when `gitlabMergeRequestId` is empty" do
+        valid_env["gitlabMergeRequestId"] = ""
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "doesn't validate when require env variables are not set" do
+        expect(described_class.validates_as_ci?(invalid_env)).to be false
+      end
+    end
+
+    describe ".validates_as_pr?" do
+      it "validates when the required variables are set" do
+        expect(described_class.validates_as_pr?(valid_env)).to be true
+      end
+
+      it "doesn't validate if `gitlabMergeRequestId` is missing" do
+        valid_env["gitlabMergeRequestId"] = nil
+        expect(described_class.validates_as_pr?(valid_env)).to be false
+      end
+
+      it "doesn't validate_as_pr if pull_request_repo is the empty string" do
+        valid_env["gitlabMergeRequestId"] = ""
+        expect(described_class.validates_as_pr?(valid_env)).to be false
+      end
+
+      describe "#new" do
+        it "sets the pull_request_id" do
+          expect(source.pull_request_id).to eq("1234")
+        end
+      end
+    end
+  end
+
+  context "with multibranch pipeline" do
     before do
       valid_env["GIT_URL"] = nil
       valid_env["CHANGE_ID"] = "647"
@@ -114,55 +163,6 @@ RSpec.describe Danger::Jenkins do
       end
       it "sets the repo_url" do
         expect(source.repo_url).to eq("https://github.com/danger/danger")
-      end
-    end
-  end
-
-  context "with GitLab" do
-    before do
-      valid_env["gitlabMergeRequestId"] = "1234"
-      valid_env["GIT_URL"] = "https://gitlab.com/danger/danger.git"
-    end
-
-    describe ".validates_as_ci?" do
-      it "validates when required env variables are set" do
-        expect(described_class.validates_as_ci?(valid_env)).to be true
-      end
-
-      it "validates even when `gitlabMergeRequestId` is missing" do
-        valid_env["gitlabMergeRequestId"] = nil
-        expect(described_class.validates_as_ci?(valid_env)).to be true
-      end
-
-      it "validates even when `gitlabMergeRequestId` is empty" do
-        valid_env["gitlabMergeRequestId"] = ""
-        expect(described_class.validates_as_ci?(valid_env)).to be true
-      end
-
-      it "doesn't validate when require env variables are not set" do
-        expect(described_class.validates_as_ci?(invalid_env)).to be false
-      end
-    end
-
-    describe ".validates_as_pr?" do
-      it "validates when the required variables are set" do
-        expect(described_class.validates_as_pr?(valid_env)).to be true
-      end
-
-      it "doesn't validate if `gitlabMergeRequestId` is missing" do
-        valid_env["gitlabMergeRequestId"] = nil
-        expect(described_class.validates_as_pr?(valid_env)).to be false
-      end
-
-      it "doesn't validate_as_pr if pull_request_repo is the empty string" do
-        valid_env["gitlabMergeRequestId"] = ""
-        expect(described_class.validates_as_pr?(valid_env)).to be false
-      end
-
-      describe "#new" do
-        it "sets the pull_request_id" do
-          expect(source.pull_request_id).to eq("1234")
-        end
       end
     end
   end

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -65,6 +65,59 @@ RSpec.describe Danger::Jenkins do
     end
   end
 
+  context "with GitHub (pipeline)" do
+    before do
+      valid_env["GIT_URL"] = nil
+      valid_env["CHANGE_ID"] = "647"
+      valid_env["CHANGE_URL"] = "https://github.com/danger/danger/pull/647"
+    end
+
+    describe ".validates_as_ci?" do
+      it "validates when requierd env variables are set" do
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "validates even when `CHANGE_ID` is missing" do
+        valid_env["CHANGE_ID"] = nil
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "validates even when `CHANGE_ID` is empty" do
+        valid_env["CHANGE_ID"] = ""
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "doesn't validate when require env variables are not set" do
+        expect(described_class.validates_as_ci?(invalid_env)).to be false
+      end
+    end
+
+    describe ".validates_as_pr?" do
+      it "validates when the required variables are set" do
+        expect(described_class.validates_as_pr?(valid_env)).to be true
+      end
+
+      it "doesn't validate if `CHANGE_ID` is missing" do
+        valid_env["CHANGE_ID"] = nil
+        expect(described_class.validates_as_pr?(valid_env)).to be false
+      end
+
+      it "doesn't validate_as_pr if pull_request_repo is the empty string" do
+        valid_env["CHANGE_ID"] = ""
+        expect(described_class.validates_as_pr?(valid_env)).to be false
+      end
+    end
+
+    describe "#new" do
+      it "sets the pull_request_id" do
+        expect(source.pull_request_id).to eq("647")
+      end
+      it "sets the repo_url" do
+        expect(source.repo_url).to eq("https://github.com/danger/danger")
+      end
+    end
+  end
+
   context "with GitLab" do
     before do
       valid_env["gitlabMergeRequestId"] = "1234"


### PR DESCRIPTION
Added support for [Jenkins pipelines](https://jenkins.io/solutions/pipeline/).

Pipelines is a new way of configuring your jobs and is the preferred way in Jenkins 2.0+.
Unfortunately the old env vars isn't supported but on the other hand the vars should be uniform regardless of scm provider.

Currently works with:
- [x] GitHub
- [x] GitLab
- [x] BitBucket