### PR TITLE
Add new_comment parameter to GitLab request source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add your own contribution below
 * Support for Jenkins pipelines - fwal
+* Implemented '--new-comment' support for GitLab  
 
 ## 3.5.5
 

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -97,10 +97,12 @@ module Danger
         pr_body.chomp.scan(/>\s*danger\s*:\s*ignore\s*"(.*)"/i).flatten
       end
 
-      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger")
+      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false)
         editable_comments = mr_comments.select { |comment| comment.generated_by_danger?(danger_id) }
 
-        if editable_comments.empty?
+        should_create_new_comment = new_comment || editable_comments.empty?
+
+        if should_create_new_comment
           previous_violations = {}
         else
           comment = editable_comments.first.body

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -206,6 +206,25 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
             messages: []
           )
         end
+
+        it "creates a new comment instead of updating the existing one if --new-comment is provided" do
+          body = subject.generate_comment(
+            warnings: violations(["Test warning"]),
+            errors: violations(["Test error"]),
+            messages: violations(["Test message"]),
+            template: "gitlab"
+          )
+          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
+            body: "body=#{ERB::Util.url_encode(body)}",
+            headers: expected_headers
+          ).to_return(status: 200, body: "", headers: {})
+          subject.update_pull_request!(
+            warnings: violations(["Test warning"]),
+            errors: violations(["Test error"]),
+            messages: violations(["Test message"]),
+            new_comment: true
+          )
+        end
       end
 
       context "existing comment with no sticky messages" do


### PR DESCRIPTION
Implemented `new_comment` parameter support in GitLab request source. Test included, I'm pretty sure test will go red without my change.

Fixes #648.