### PR TITLE
Fix the issue with interviewer ask method; #trivial

### DIFF
--- a/lib/danger/commands/init_helpers/interviewer.rb
+++ b/lib/danger/commands/init_helpers/interviewer.rb
@@ -52,21 +52,6 @@ module Danger
       system command
     end
 
-    def ask(question)
-      answer = ""
-      loop do
-        ui.puts "\n#{question}?"
-
-        show_prompt
-        answer = STDIN.gets.chomp
-
-        break unless answer.empty?
-
-        ui.print "\nYou need to provide an answer."
-      end
-      answer
-    end
-
     def ask_with_answers(question, possible_answers)
       ui.print "\n#{question}? ["
 

--- a/lib/danger/commands/init_helpers/interviewer.rb
+++ b/lib/danger/commands/init_helpers/interviewer.rb
@@ -60,7 +60,7 @@ module Danger
         show_prompt
         answer = STDIN.gets.chomp
 
-        break if answer.empty?
+        break unless answer.empty?
 
         ui.print "\nYou need to provide an answer."
       end


### PR DESCRIPTION
Not sure how this one has not been fixed so far, please correct me if it's an intended behavior.
However, right now if you provide an answer to the `interviewer` question, you'll see `You need to provide an answer.` and in a case of an empty string, it will work.
