### PR TITLE
Attempt to workaround the shallow fetch problem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,3 +131,6 @@ Style/FileName:
 
 Style/IndentHeredoc:
   Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -122,3 +122,12 @@ Style/MultilineMethodCallIndentation:
 # FIXME: 25
 Metrics/BlockLength:
   Max: 345
+
+Style/MixinGrouping:
+  Enabled: false
+
+Style/FileName:
+  Enabled: false
+
+Style/IndentHeredoc:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 
 * Fixed --new-comment not working with Bitbucket - Bruno Rocha
 * Adjust GitHub comment output for new Markdown parser - Yuki Izumi
+* Change from git fetch --unshallow to git fetch --depth=1000000 - Juanito Fatas
 
 ## 4.0.0
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -12,7 +12,7 @@ end
 message(":tada:") if is_version_bump && github.pr_author != "orta"
 
 # Make a note about contributors not in the organization
-unless github.api.organization_member?('danger', github.pr_author)
+unless github.api.organization_member?("danger", github.pr_author)
   message "@#{github.pr_author} is not a contributor yet, would you like to join the Danger org?"
 
   # Pay extra attention if they modify the gemspec
@@ -38,7 +38,7 @@ end
 core_plugins_docs = `bundle exec danger plugins lint lib/danger/danger_core/plugins/*.rb --warnings-as-errors`
 
 # If it failed, fail the build, and include markdown with the output error.
-unless $?.success?
+unless $CHILD_STATUS.success?
   # We want to strip ANSI colors for our markdown, and make paths relative
   colourless_error = core_plugins_docs.gsub(/\e\[(\d+)(;\d+)*m/, "")
   markdown("### Core Docs Errors \n\n#{colourless_error}")
@@ -58,16 +58,15 @@ files.protect_files(path: "danger.gemspec", message: ".gemspec modified", fail_b
 
 # Ensure that our core plugins all have 100% documentation
 core_plugins = Dir.glob("lib/danger/danger_core/plugins/*.rb")
-core_lint_output = `bundle exec yard stats #{core_plugins.join ' '} --list-undoc --tag tags`
+core_lint_output = `bundle exec yard stats #{core_plugins.join " "} --list-undoc --tag tags`
 
 if !core_lint_output.include?("100.00%")
   fail "The core plugins are not at 100% doc'd - see below:", sticky: false
-  markdown "```\n#{core_lint_output}```"
 elsif core_lint_output.include? "warning"
   warn "The core plugins are have yard warnings - see below", sticky: false
   markdown "```\n#{core_lint_output}```"
 end
 
 junit.parse "junit-results.xml"
-junit.headers = [:file, :name]
+junit.headers = %i(file name)
 junit.report

--- a/Dangerfile
+++ b/Dangerfile
@@ -38,7 +38,7 @@ end
 core_plugins_docs = `bundle exec danger plugins lint lib/danger/danger_core/plugins/*.rb --warnings-as-errors`
 
 # If it failed, fail the build, and include markdown with the output error.
-unless $CHILD_STATUS.success?
+unless $?.success?
   # We want to strip ANSI colors for our markdown, and make paths relative
   colourless_error = core_plugins_docs.gsub(/\e\[(\d+)(;\d+)*m/, "")
   markdown("### Core Docs Errors \n\n#{colourless_error}")

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "danger/version"

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -212,7 +212,7 @@ module Danger
       return if (violations[:errors] + violations[:warnings] + violations[:messages] + status[:markdowns]).count.zero?
 
       ui.section("Results:") do
-        [:errors, :warnings, :messages].each do |key|
+        %i(errors warnings messages).each do |key|
           formatted = key.to_s.capitalize + ":"
           title = case key
                   when :errors

--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/plugin_support/plugin"
 
 module Danger

--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/plugin_support/plugin"
 
 module Danger

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -234,7 +234,7 @@ module Danger
       @github.dismiss_out_of_range_messages = dismiss == true
     end
 
-    [:title, :body, :author, :labels, :json].each do |suffix|
+    %i(title body author labels json).each do |suffix|
       alias_method "mr_#{suffix}".to_sym, "pr_#{suffix}".to_sym
     end
 

--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -207,7 +207,7 @@ module Danger
       paths.first(paths.count - 1).join(", ") + " & " + paths.last
     end
 
-    [:title, :body, :author, :labels, :json, :diff].each do |suffix|
+    %i(title body author labels json diff).each do |suffix|
       alias_method "pr_#{suffix}".to_sym, "mr_#{suffix}".to_sym
     end
 

--- a/lib/danger/request_sources/bitbucket_cloud.rb
+++ b/lib/danger/request_sources/bitbucket_cloud.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/helpers/comments_helper"
 require "danger/request_sources/bitbucket_cloud_api"
 

--- a/lib/danger/request_sources/bitbucket_cloud_api.rb
+++ b/lib/danger/request_sources/bitbucket_cloud_api.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/helpers/comments_helper"
 
 module Danger

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/helpers/comments_helper"
 require "danger/request_sources/bitbucket_server_api"
 

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/helpers/comments_helper"
 
 module Danger

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "octokit"
 require "danger/helpers/comments_helper"
 require "danger/helpers/comment"

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "octokit"
 require "danger/ci_source/ci_source"
 require "danger/request_sources/github/octokit_pr_review"

--- a/lib/danger/request_sources/github/github_review_resolver.rb
+++ b/lib/danger/request_sources/github/github_review_resolver.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/request_sources/github/github_review"
 
 module Danger

--- a/lib/danger/request_sources/github/github_review_unsupported.rb
+++ b/lib/danger/request_sources/github/github_review_unsupported.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 module Danger
   module RequestSources
     module GitHubSource

--- a/lib/danger/request_sources/github/octokit_pr_review.rb
+++ b/lib/danger/request_sources/github/octokit_pr_review.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "octokit"
 
 module Octokit

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/helpers/comments_helper"
 require "danger/helpers/comment"
 
@@ -36,7 +37,6 @@ module Danger
         params[:endpoint] = endpoint
 
         @client ||= Gitlab.client(params)
-
       rescue LoadError
         puts "The GitLab gem was not installed, you will need to change your Gem from `danger` to `danger-gitlab`.".red
         puts "\n - See https://github.com/danger/danger/blob/master/CHANGELOG.md#400"

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -37,7 +37,7 @@ module Danger
     end
 
     def ensure_commitish_exists!(commitish)
-      git_shallow_fetch if commit_not_exists?(commitish)
+      git_in_depth_fetch if commit_not_exists?(commitish)
 
       if commit_not_exists?(commitish)
         raise_if_we_cannot_find_the_commit(commitish)
@@ -46,8 +46,8 @@ module Danger
 
     private
 
-    def git_shallow_fetch
-      exec("fetch --unshallow")
+    def git_in_depth_fetch
+      exec("fetch --depth 1000000")
     end
 
     def default_env
@@ -70,7 +70,7 @@ module Danger
       possible_merge_base = possible_merge_base(repo, from, to)
 
       unless possible_merge_base
-        git_shallow_fetch
+        git_in_depth_fetch
         possible_merge_base = possible_merge_base(repo, from, to)
       end
 

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -123,17 +123,17 @@ RSpec.describe Danger::Dangerfile, host: :github do
       dm = testing_dangerfile
       methods = dm.core_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
 
-      expect(methods).to eq [:fail, :markdown, :message, :status_report, :violation_report, :warn]
+      expect(methods).to eq %i(fail markdown message status_report violation_report warn)
     end
 
     # These are things that require scoped access
     it "exposes no external attributes by default" do
       dm = testing_dangerfile
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
-      expect(methods).to eq [
-        :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files,
-        :deletions, :diff_for_file, :dismiss_out_of_range_messages, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :review, :scm_provider
-      ]
+      expect(methods).to eq %i(
+        added_files api base_commit branch_for_base branch_for_head commits deleted_files
+        deletions diff_for_file dismiss_out_of_range_messages head_commit html_link import_dangerfile import_plugin info_for_file insertions lines_of_code modified_files mr_author mr_body mr_json mr_labels mr_title pr_author pr_body pr_diff pr_json pr_labels pr_title review scm_provider
+      )
     end
 
     it "exposes all external plugin attributes by default" do
@@ -201,12 +201,12 @@ RSpec.describe Danger::Dangerfile, host: :github do
         # Ensure consistent ordering, and only extract the keys
         data = sort_data(data).map { |d| d.first.to_sym }
 
-        expect(data).to eq [
-          :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files, :deletions, :head_commit,
-          :insertions, :lines_of_code, :modified_files,
-          :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title,
-          :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :review, :scm_provider
-        ]
+        expect(data).to eq %i(
+          added_files api base_commit branch_for_base branch_for_head commits deleted_files deletions head_commit
+          insertions lines_of_code modified_files
+          mr_author mr_body mr_json mr_labels mr_title
+          pr_author pr_body pr_diff pr_json pr_labels pr_title review scm_provider
+        )
       end
 
       it "skips raw PR/MR JSON, and diffs" do

--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
       with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
         dangerfile.env.request_source.fetch_details
 
-        [
-          :id, :iid, :project_id, :title, :description, :state, :created_at,
-          :updated_at, :target_branch, :source_branch, :upvotes, :downvotes,
-          :author, :assignee, :source_project_id, :target_project_id, :labels,
-          :work_in_progress, :milestone, :merge_when_build_succeeds, :merge_status,
-          :subscribed, :user_notes_count, :approvals_before_merge,
-          :should_remove_source_branch, :force_remove_source_branch
-        ].each do |key|
+        %i(
+          id iid project_id title description state created_at
+          updated_at target_branch source_branch upvotes downvotes
+          author assignee source_project_id target_project_id labels
+          work_in_progress milestone merge_when_build_succeeds merge_status
+          subscribed user_notes_count approvals_before_merge
+          should_remove_source_branch force_remove_source_branch
+        ).each do |key|
           key_present = plugin.pr_json.key?(key.to_s)
           expect(key_present).to be_truthy, "Expected key #{key} not found"
         end

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/helpers/comments_helper"
 require "danger/danger_core/messages/violation"
 

--- a/spec/lib/danger/plugin_support/plugin_parser_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_parser_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Danger::PluginParser do
     classes = parser.classes_in_file
 
     class_syms = classes.map(&:name)
-    expect(class_syms).to eq [:Dangerfile, :ExampleBroken]
+    expect(class_syms).to eq %i(Dangerfile ExampleBroken)
   end
 
   it "skips non-subclasses of Danger::Plugin" do

--- a/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
+++ b/spec/lib/danger/request_sources/bibucket_cloud_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/request_sources/bitbucket_cloud"
 
 RSpec.describe Danger::RequestSources::BitbucketCloud, host: :bitbucket_cloud do

--- a/spec/lib/danger/request_sources/bibucket_server_spec.rb
+++ b/spec/lib/danger/request_sources/bibucket_server_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/request_sources/bitbucket_server"
 
 RSpec.describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server do

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "danger/request_sources/github/github"
 require "danger/request_sources/github/octokit_pr_review"
 require "danger/ci_source/circle"

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
           with("rev-parse --quiet --verify 704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}").
           and_return("")
         # fetch it
-        expect(@g.scm).to receive(:exec).with("fetch --unshallow")
+        expect(@g.scm).to receive(:exec).with("fetch --depth 1000000")
         # still not in history
         expect(@g.scm).to receive(:exec).
           with("rev-parse --quiet --verify 704dc55988c6996f69b6873c2424be7d1de67bbe^{commit}").

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require "erb"
 
 require "danger/request_sources/gitlab"


### PR DESCRIPTION
Attempt to help #660.

Workaround steals from [git fetch --unshallow no longer working - travis-ci/travis-ci #4942](https://github.com/travis-ci/travis-ci/issues/4942).