### PR TITLE
No blank lines in GitHub output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add your own contribution below
 
 * Fixed --new-comment not working with Bitbucket - Bruno Rocha
+* Adjust GitHub comment output for new Markdown parser - Yuki Izumi
 
 ## 4.0.0
 

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -14,7 +14,7 @@
      </tr>
   </thead>
   <tbody>
-    <%- max_num_violations = 700 %>
+    <%- max_num_violations = 700 -%>
     <%- table[:content].take(max_num_violations).each do |violation| -%>
     <tr>
       <td>:<%= table[:emoji] %>:</td>

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -216,6 +216,22 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       expect(comment).to include("*Raw markdown*")
     end
 
+    it "produces HTML that a CommonMark parser will accept inline" do
+      ["github", "github_inline"].each do |template|
+        comment = dummy.generate_comment(
+          warnings: [violation("This is a warning")],
+          errors: [violation("This is an error", sticky: true)],
+          messages: [violation("This is a message")],
+          markdowns: [markdown("*Raw markdown*")],
+          danger_id: "my_danger_id",
+          template: template
+        )
+
+        # There should be no indented HTML tag after 2 or more newlines.
+        expect(comment).not_to match(%r{(\r?\n){2}[ \t]+<})
+      end
+    end
+
     it "produces the expected comment when there are newlines" do
       comment = dummy.generate_comment(
         warnings: [violation("This is a warning\nin two lines")],

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
         )
 
         # There should be no indented HTML tag after 2 or more newlines.
-        expect(comment).not_to match(%r{(\r?\n){2}[ \t]+<})
+        expect(comment).not_to match(/(\r?\n){2}[ \t]+</)
       end
     end
 


### PR DESCRIPTION
Addresses https://github.com/danger/danger/issues/663 — specifically, GitHub's using a CommonMark-compliant parser now, so there are some stricter rules around HTML blocks in Markdown.

One thing I don't really like about this PR is the location of the new spec — so far everything in `comments_helper_spec` is about the helper itself and not about any particular `comment_generator`. Do you think maybe this would be better placed in a new spec file for comment generators? Feel free to push directly to this branch with adjustments!