### PR TITLE
Print out an error when posting a comment to BitBucket Server fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contribution below
 
+* Print out an error when posting a comment to BitBucket Server fails - Buju77
+
 ## 4.0.2
 
 [Full Changelog](https://github.com/danger/danger/compare/v4.0.1...v4.0.2)

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -63,8 +63,16 @@ module Danger
         req = Net::HTTP::Post.new(uri.request_uri, { "Content-Type" => "application/json" })
         req.basic_auth @username, @password
         req.body = body
-        Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
           http.request(req)
+        end
+
+        # show error to the user when BitBucket Server returned an error
+        case res
+        when Net::HTTPClientError, Net::HTTPServerError
+          # HTTP 4xx - 5xx
+          abort "\nError posting comment to BitBucket Server: #{res.code} (#{res.message})\n\n"
         end
       end
 


### PR DESCRIPTION
This PR should address #669 