### PR TITLE
Fixing handling of files moved to other directories in git.diff_for_file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   # Tests use real git commands
   - git config --global user.email "danger@example.com"
   - git config --global user.name "Danger McShane"
+  - git config --global diff.renames true
   - bundle exec rubocop lib
   - bundle exec rake spec
   - bundle exec danger --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
   # Tests use real git commands
   - git config --global user.email "danger@example.com"
   - git config --global user.name "Danger McShane"
-  - git config --global diff.renames true
   - bundle exec rubocop lib
   - bundle exec rake spec
   - bundle exec danger --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 
+* #681, #498 Fixes handling of files moved across directories by using diff to get list of modified files. Please note that the fix is not backward-compatible due to moved files names being the original file names.
 * Add your own contribution below
 
 ## 4.3.4

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -72,7 +72,7 @@ module Danger
     # @return [FileList<String>] an [Array] subclass
     #
     def modified_files
-      Danger::FileList.new(@git.diff.stats[:files].keys)
+      Danger::FileList.new(@git.diff.select { |diff| diff.type == "modified" }.map(&:path))
     end
 
     # @!group Git Metadata

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe Danger::DangerfileGitPlugin, host: :github do
     end
 
     it "gets modified_files " do
-      stats = { files: { "my/path/file_name" => "thing" } }
-      diff = OpenStruct.new(stats: stats)
+      diff = [OpenStruct.new(type: "modified", path: "my/path/file_name")]
       allow(@repo).to receive(:diff).and_return(diff)
 
       expect(@dsl.modified_files).to eq(["my/path/file_name"])

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -120,8 +120,8 @@ RSpec.describe Danger::GitRepo, host: :github do
           `git add .`
           `git commit -m "ok"`
           `git checkout -b new --quiet`
-          `mkdir 'subfolder with => weird name'`
-          `git mv file 'subfolder with => weird name'`
+          `mkdir "subfolder with => weird name"`
+          `git mv file "subfolder with => weird name"`
           `git commit -m "another"`
 
           @dm = testing_dangerfile

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -113,6 +113,8 @@ RSpec.describe Danger::GitRepo, host: :github do
     it "handles moved files as expected" do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
+          subfolder = "subfolder"
+
           `git init`
           `git config diff.renames true`
           `git remote add origin git@github.com:danger/danger.git`
@@ -120,8 +122,8 @@ RSpec.describe Danger::GitRepo, host: :github do
           `git add .`
           `git commit -m "ok"`
           `git checkout -b new --quiet`
-          `mkdir "subfolder with => weird name"`
-          `git mv file "subfolder with => weird name"`
+          `mkdir "#{subfolder}"`
+          `git mv file "#{subfolder}"`
           `git commit -m "another"`
 
           @dm = testing_dangerfile

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -127,10 +127,8 @@ RSpec.describe Danger::GitRepo, host: :github do
           @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
           # Need to compact here because c50713a changes make AppVeyor fail
-          expect(@dm.git.modified_files.compact).to eq(["file => subfolder with => weird name/file"])
-          expect do
-            @dm.git.diff_for_file("file => subfolder with => weird name/file")
-          end.to_not raise_error
+          expect(@dm.git.modified_files.compact).to eq(["file"])
+          expect(@dm.git.diff_for_file("file")).not_to be_nil
         end
       end
     end

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe Danger::GitRepo, host: :github do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
           `git init`
+          `git config diff.renames true`
           `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`


### PR DESCRIPTION
We've encountered a crash inside `git.diff_for_file` when PR/MR diff includes files moved to other folders.

It looks like [the code](https://github.com/danger/danger/blob/8e9a3ab12a78c518fac6dd917878fc3fc4f55b2a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb#L115) is not enough to handle moves, here's how moved files are represented in `git.modified_files`:

```
Whatever/Path/{<old subpath> => <new subpath>}/File.m
```

But [@git.diff](https://github.com/danger/danger/blob/8e9a3ab12a78c518fac6dd917878fc3fc4f55b2a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb#L115) doesn't have an entry for a such path, it contains an entry for the original path of the moved file.

The first idea was to detect such modified files, extract original file name and get the diff. The problem is, I couldn't find a reliable way to do that, because folder names can contain `=>` string too (see [failing test](https://github.com/nikolaykasyanov/danger/commit/2b66cf244da29d9449198b59620de38afc1abb0b) for an example).

I'd appreciate any guidance & advice.

- [x] Provide a failing test case
- [x] Provide a fix