### PR TITLE
Better detection of plugin registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contribution below
 
+* Don't rely on regular expressions to determine whether or not a file will register a plugin. - Ray Zane
+
 ## 4.0.3
 
 [Full Changelog](https://github.com/danger/danger/compare/v4.0.2...v4.0.3)


### PR DESCRIPTION
A regular expression isn't a very reliable way of detecting whether or not a file will register a plugin. Prior to this commit, Danger would run a regular expression against the file and validate that the file includes `< Plugin`. In the case of subclasses, this is very likely to fail.

Closes https://github.com/danger/danger/issues/682