### PR TITLE
Fixes the plugin JSON parser -

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Test on Ruby 2.4.0 - Connor Shea
 * Don't rely on regular expressions to determine whether or not a file will register a plugin. - Ray Zane
+* Fixes parsing Gems for pulling in their plugin JSON metadata - orta/barbosa
 
 ## 4.0.3
 

--- a/lib/danger/plugin_support/gems_resolver.rb
+++ b/lib/danger/plugin_support/gems_resolver.rb
@@ -9,19 +9,26 @@ module Danger
 
     # Returns an Array of paths (plugin lib file paths) and gems (of metadata)
     def call
+      path_gems = []
+
       Bundler.with_clean_env do
         Dir.chdir(dir) do
           create_gemfile_from_gem_names
           `bundle install --path vendor/gems`
+          path_gems = all_gems_metadata
         end
       end
 
-      return paths, gems
+      return path_gems
     end
 
     private
 
     attr_reader :gem_names, :dir
+
+    def all_gems_metadata
+      return paths, gems
+    end
 
     def create_gemfile_from_gem_names
       gemfile = File.new("Gemfile", "w")

--- a/spec/lib/danger/plugin_support/gems_resolver_spec.rb
+++ b/spec/lib/danger/plugin_support/gems_resolver_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe Danger::GemsResolver do
           fake_bundle_install_path_vendor_gems_in(spec_root)
         end
 
-        result = described_class.new(gem_names).call
+        resolver = described_class.new(gem_names)
+        resolver.call
+        result = resolver.send(:all_gems_metadata)
 
         expect(result).to be_a Array
         expect(result.first).to match_array expected_path(tmpdir)


### PR DESCRIPTION
Fixes https://github.com/danger/danger/issues/688

And un-blocks Danger.Systems from deploying. This is obviously not the most elegant answer 👯 - but I'm happy enough, I did experiment with putting th return inside the chdir, but figured that was way more likely to break everything.

thanks @barbosa - who did the hard work on digging what was causing it