### PR TITLE
Inline Comments: Transform `line` into an int before comparing it with ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contribution below
 
+* Transform `line` into an int before comparing it with ranges when posting inline comments to GitHub - barbosa
+
 ## 4.0.4
 
 [Full Changelog](https://github.com/danger/danger/compare/v4.0.3...v4.0.4)

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -353,8 +353,8 @@ module Danger
           end
 
           # We are past the line position, just abort
-          break if message.line < range_start
-          next unless message.line >= range_start && message.line <= range_end
+          break if message.line.to_i < range_start
+          next unless message.line.to_i >= range_start && message.line.to_i <= range_end
 
           file_line = range_start
         end


### PR DESCRIPTION
Fixes #692 

`range_start` and `range_end` are integers. The comparison between two different `message.line`s are working because both are strings declared in the `Violation` [model](https://github.com/danger/danger/blob/master/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb#L94-L95). But it doesn't for `message.line` and these ranges.

These two lines are raising an `ArgumentError`:

```ruby
# We are past the line position, just abort
break if message.line < range_start
next unless message.line >= range_start && message.line <= range_end
```

```
/home/travis/.rvm/gems/ruby-2.3.1/gems/danger-4.0.4/lib/danger/request_sources/github.rb:356:in `<': comparison of String with 1 failed (ArgumentError)
```

I don't know if `Violation#line` is really supposed to be a string, but changing it would affect the whole feature. So I only changed the comparison, transforming all calls for `message.line` to an integer before it.

Please, let me know if this is enough or if we need to change it somewhere else.

Thanks!