### PR TITLE
Fix danger pr command cannot specify API host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add your own contribution below
 
 * Transform `line` into an int before comparing it with ranges when posting inline comments to GitHub - barbosa
+* Fix danger pr command cannot specify API host - Juanito Fatas
 
 ## 4.0.4
 

--- a/lib/danger/ci_source/support/pull_request_finder.rb
+++ b/lib/danger/ci_source/support/pull_request_finder.rb
@@ -116,7 +116,15 @@ module Danger
 
     def client
       require "octokit"
-      Octokit::Client.new(access_token: ENV["DANGER_GITHUB_API_TOKEN"])
+      Octokit::Client.new(access_token: ENV["DANGER_GITHUB_API_TOKEN"], api_endpoint: api_url)
+    end
+
+    def api_url
+      ENV.fetch("DANGER_GITHUB_API_HOST") do
+        ENV.fetch("DANGER_GITHUB_API_BASE_URL") do
+          "https://api.github.com/".freeze
+        end
+      end
     end
   end
 end

--- a/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
@@ -103,5 +103,29 @@ RSpec.describe Danger::PullRequestFinder do
         expect(result.base).to eq "pr 518 base commit sha1"
       end
     end
+
+    context "specify api endpoint of octokit client" do
+      it "By DANGER_GITHUB_API_HOST" do
+        ENV["DANGER_GITHUB_API_HOST"] = "https://enterprise.artsy.net"
+
+        allow(Octokit::Client).to receive(:new).with(
+          access_token: ENV["DANGER_GITHUB_API_TOKEN"],
+          api_endpoint: "https://enterprise.artsy.net"
+        ) { spy("Octokit::Client") }
+
+        finder(pull_request_id: "42", remote: true, logs: "not important").call
+      end
+
+      it "fallbacks to DANGER_GITHUB_API_BASE_URL" do
+        ENV["DANGER_GITHUB_API_BASE_URL"] = "https://enterprise.artsy.net"
+
+        allow(Octokit::Client).to receive(:new).with(
+          access_token: ENV["DANGER_GITHUB_API_TOKEN"],
+          api_endpoint: "https://enterprise.artsy.net"
+        ) { spy("Octokit::Client") }
+
+        finder(pull_request_id: "42", remote: true, logs: "not important").call
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #691.

After this PR, can specify API host by the following command:

```
$ DANGER_GITHUB_API_HOST=https://foo.bar.com https://foo.bar.com/org/repo/pulls/111
```

/cc @mtitolo 