### PR TITLE
Improve handling of long comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Transform `line` into an int before comparing it with ranges when posting inline comments to GitHub - barbosa
 * Fix danger pr command cannot specify API host - Juanito Fatas
+* Better handling of long comments - Juanito Fatas
 
 ## 4.0.4
 

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -14,7 +14,7 @@
      </tr>
   </thead>
   <tbody>
-    <%- max_num_violations = 700 -%>
+    <%- max_num_violations = FindMaxNumViolations.new(table[:content]).call -%>
     <%- table[:content].take(max_num_violations).each do |violation| -%>
     <tr>
       <td>:<%= table[:emoji] %>:</td>

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -1,6 +1,7 @@
 require "kramdown"
 require "danger/helpers/comments_parsing_helper"
 require "danger/helpers/emoji_mapper"
+require "danger/helpers/find_max_num_violations"
 
 # rubocop:disable Metrics/ModuleLength
 

--- a/lib/danger/helpers/find_max_num_violations.rb
+++ b/lib/danger/helpers/find_max_num_violations.rb
@@ -1,0 +1,31 @@
+# Find max_num_violations in lib/danger/comment_generators/github.md.erb.
+class FindMaxNumViolations
+  # Save ~ 5000 for contents other than violations to avoid exceeded 65536 max comment length limit.
+  LIMIT = 60_000
+
+  def initialize(violations)
+    @violations = violations
+  end
+
+  def call
+    total = 0
+    num_of_violations_allowed = 0
+
+    violations.each do |violation|
+      message_length = violation.message.length + 80 # 80 is ~ the size of html wraps violation message.
+
+      if total + message_length < LIMIT
+        total += message_length
+        num_of_violations_allowed += 1
+      else
+        break
+      end
+    end
+
+    num_of_violations_allowed
+  end
+
+  private
+
+  attr_reader :violations
+end

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -60,13 +60,11 @@ end
 
 RSpec.describe Danger::Helpers::CommentsHelper do
   let(:dummy) do
-    d = Dummy.new
-    d.extend(described_class)
-    d
+    Dummy.new.tap { |dummy| dummy.extend(described_class) }
   end
 
   describe "#markdown_parser" do
-    it "is a Redcarpet::Markdown instance" do
+    it "is a Kramdown::Document instance" do
       parser = dummy.markdown_parser("")
       expect(parser).to be_an_instance_of(Kramdown::Document)
     end
@@ -392,7 +390,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
     end
 
     it "truncates comments which would exceed githubs maximum comment length" do
-      warnings = (1..900).map { |i| "warning #{i}" }
+      warnings = (1..900).map { |i| "single long warning" * (rand(10) + 1) + i.to_s }
       result = dummy.generate_comment(warnings: violations(warnings), errors: violations([]), messages: [])
       expect(result.length).to be <= GITHUB_MAX_COMMENT_LENGTH
       expect(result).to include("has been truncated")


### PR DESCRIPTION
Fixes #698.

In [generated github markdown](https://github.com/danger/danger/blob/bf55d62f1847f8b45c356125163db7a582d156d2/lib/danger/comment_generators/github.md.erb#L17), we take a [static number of violations (700)](https://github.com/danger/danger/blob/bf55d62f1847f8b45c356125163db7a582d156d2/lib/danger/comment_generators/github.md.erb#L17) assume each message looks like `"warning #{i}"`.

In reality the warning is not fixed length, so we should adjust, and take dynamic number of violations within the length limit.