### PR TITLE
GitHub pull request review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master
 
-* Add your own contribution below
+* PR Review in Beta. Provides access to creating a GitHub Review instead of a typical GitHub comment - antondomashnev
 
 ## 4.0.5
 

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "pry-byebug"
 
-  spec.add_development_dependency "rubocop", "~> 0.44"
+  spec.add_development_dependency "rubocop", "~> 0.46.0"
   spec.add_development_dependency "yard", "~> 0.8"
 
   spec.add_development_dependency "listen", "3.0.7"

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -1,5 +1,5 @@
 # http://devcenter.bitrise.io/docs/available-environment-variables
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 require "danger/request_sources/gitlab"
 
 module Danger

--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -1,6 +1,6 @@
 # https://buildkite.com/docs/agent/osx
 # https://buildkite.com/docs/guides/environment-variables
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 require "danger/request_sources/gitlab"
 
 module Danger

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -1,7 +1,7 @@
 # https://circleci.com/docs/environment-variables
 require "uri"
 require "danger/ci_source/circle_api"
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/drone.rb
+++ b/lib/danger/ci_source/drone.rb
@@ -1,5 +1,5 @@
 # http://readme.drone.io/usage/variables/
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 require "danger/request_sources/gitlab"
 
 module Danger

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -1,6 +1,6 @@
 # https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables
 # https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 require "danger/request_sources/gitlab"
 require "danger/request_sources/bitbucket_server"
 require "danger/request_sources/bitbucket_cloud"

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -3,7 +3,7 @@
 require "git"
 require "uri"
 
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 
 require "danger/ci_source/support/find_repo_info_from_url"
 require "danger/ci_source/support/find_repo_info_from_logs"

--- a/lib/danger/ci_source/semaphore.rb
+++ b/lib/danger/ci_source/semaphore.rb
@@ -1,5 +1,5 @@
 # https://semaphoreci.com/docs/available-environment-variables.html
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/surf.rb
+++ b/lib/danger/ci_source/surf.rb
@@ -1,5 +1,5 @@
 # http://github.com/surf-build/surf
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/teamcity.rb
+++ b/lib/danger/ci_source/teamcity.rb
@@ -1,5 +1,5 @@
 # https://www.jetbrains.com/teamcity/
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 require "danger/request_sources/gitlab"
 
 module Danger

--- a/lib/danger/ci_source/travis.rb
+++ b/lib/danger/ci_source/travis.rb
@@ -1,6 +1,6 @@
 # http://docs.travis-ci.com/user/osx-ci-environment/
 # http://docs.travis-ci.com/user/environment-variables/
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/ci_source/xcode_server.rb
+++ b/lib/danger/ci_source/xcode_server.rb
@@ -1,6 +1,6 @@
 # Following the advice from @czechboy0 https://github.com/danger/danger/issues/171
 # https://github.com/czechboy0/Buildasaur
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 
 module Danger
   # ### CI Setup

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -93,9 +93,22 @@ module Danger
     end
 
     # @!group PR Review
-    # Current PR Review object.
-    # @return [GitHubReview]
     #
+    # In Beta. Provides access to creating a GitHub Review instead of a typical GitHub comment.
+    #
+    # To use you announce the start of your review, and the end via the `start` and `submit` functions,
+    # for example:
+    #
+    # ```
+    #   github.review.start
+    #   github.review.fail("Please add a CHANGELOG entry") if has_no_changelog
+    #   github.review.warn("Highway to the Danger Zone") if pr_includes_word_danger
+    #   github.review.message("You might want to read #{url}") if may_require_docs
+    #   github.review.markdown("Please update your changelog entry according an #{example}") if changelog_format_not_valid
+    #   github.review.submit
+    # ```
+    #
+    # @return [ReviewDSL]
     def review
       @github.review
     end

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -92,6 +92,14 @@ module Danger
       "github"
     end
 
+    # @!group PR Review
+    # Current PR Review object.
+    # @return [GitHubReview]
+    #
+    def review
+      @github.review
+    end
+
     # @!group PR Metadata
     # The title of the Pull Request.
     # @return [String]

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -66,11 +66,11 @@ module Danger
 
       def review
         return @review unless @review.nil?
-        pr_danger_review = client.pull_request_reviews(ci_source.repo_slug, ci_source.pull_request_id)
+        @review = client.pull_request_reviews(ci_source.repo_slug, ci_source.pull_request_id)
           .map { |review_json| Danger::GitHub::Review.new(client, ci_source, review_json) }
+          .select { |review| review.generated_by_danger? }
           .last
-        pr_danger_review ||= Danger::GitHub::Review.new(client, ci_source)
-        @review = pr_danger_review
+        @review ||= Danger::GitHub::Review.new(client, ci_source)
         @review
       end
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -3,7 +3,7 @@ require "octokit"
 require "danger/helpers/comments_helper"
 require "danger/helpers/comment"
 require "danger/request_sources/github/github_review"
-
+require 'danger/request_sources/github/octokit_pr_review.rb'
 require "danger/request_sources/support/get_ignored_violation"
 
 module Danger
@@ -66,7 +66,7 @@ module Danger
 
       def review
         return @review unless @review.nil?
-        pr_danger_review = client.get(self.pr_json["_links"]["self"]["href"] + "/reviews")
+        pr_danger_review = client.pull_request_reviews(ci_source.repo_slug, ci_source.pull_request_id)
           .map { |review_json| GitHubReview.new(client, self.pr_json, review_json) }
           .filter(&:generated_by_danger?)
           .last

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -67,9 +67,9 @@ module Danger
       def review
         return @review unless @review.nil?
         pr_danger_review = client.pull_request_reviews(ci_source.repo_slug, ci_source.pull_request_id)
-          .map { |review_json| GitHubReview.new(client, ci_source, review_json) }
+          .map { |review_json| Danger::GitHub::Review.new(client, ci_source, review_json) }
           .last
-        pr_danger_review ||= GitHubReview.new(client, ci_source)
+        pr_danger_review ||= Danger::GitHub::Review.new(client, ci_source)
         @review = pr_danger_review
         @review
       end

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -3,7 +3,7 @@ require "octokit"
 require "danger/helpers/comments_helper"
 require "danger/helpers/comment"
 require "danger/request_sources/github/github_review"
-require 'danger/request_sources/github/octokit_pr_review.rb'
+require "danger/request_sources/github/octokit_pr_review.rb"
 require "danger/request_sources/support/get_ignored_violation"
 
 module Danger
@@ -68,7 +68,7 @@ module Danger
         return @review unless @review.nil?
         @review = client.pull_request_reviews(ci_source.repo_slug, ci_source.pull_request_id)
           .map { |review_json| Danger::RequestSources::GitHubSource::Review.new(client, ci_source, review_json) }
-          .select { |review| review.generated_by_danger? }
+          .select(&:generated_by_danger?)
           .last
         @review ||= Danger::RequestSources::GitHubSource::Review.new(client, ci_source)
         @review

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -67,10 +67,10 @@ module Danger
       def review
         return @review unless @review.nil?
         @review = client.pull_request_reviews(ci_source.repo_slug, ci_source.pull_request_id)
-          .map { |review_json| Danger::GitHub::Review.new(client, ci_source, review_json) }
+          .map { |review_json| Danger::RequestSources::GitHubSource::Review.new(client, ci_source, review_json) }
           .select { |review| review.generated_by_danger? }
           .last
-        @review ||= Danger::GitHub::Review.new(client, ci_source)
+        @review ||= Danger::RequestSources::GitHubSource::Review.new(client, ci_source)
         @review
       end
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -67,11 +67,11 @@ module Danger
       def review
         return @review unless @review.nil?
         pr_danger_review = client.pull_request_reviews(ci_source.repo_slug, ci_source.pull_request_id)
-          .map { |review_json| GitHubReview.new(client, self.pr_json, review_json) }
-          .filter(&:generated_by_danger?)
+          .map { |review_json| GitHubReview.new(client, ci_source, review_json) }
           .last
-        pr_danger_review ||= GitHubReview.new(client, self.pr_json)
+        pr_danger_review ||= GitHubReview.new(client, ci_source)
         @review = pr_danger_review
+        @review
       end
 
       def setup_danger_branches

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -65,13 +65,12 @@ module Danger
       end
 
       def review
-        return @review if @review != nil
-        pr_danger_review = client.get(reviews_url)
-          .take_while { |review_json| GitHubReview.new(client, self.pr_json, review_json).generated_by_danger? }
-          .first
-        unless pr_danger_review
-          @review = GitHubReview.new(client, self.pr_json)
-        end
+        return @review unless @review.nil?
+        pr_danger_review = client.get(self.pr_json["_links"]["self"]["href"] + "/reviews")
+          .map { |review_json| GitHubReview.new(client, self.pr_json, review_json) }
+          .filter(&:generated_by_danger?)
+          .last
+        pr_danger_review ||= GitHubReview.new(client, self.pr_json)
         @review = pr_danger_review
       end
 

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -1,0 +1,76 @@
+# coding: utf-8
+require "octokit"
+
+module Danger
+  module RequestSources
+    class GitHubReview
+      REVIEW_EVENT_APPROVE = "APPROVE"
+      REVIEW_EVENT_REQUEST_CHANGES = "REQUEST_CHANGES"
+      REVIEW_EVENT_COMMENT = "COMMENT"
+
+      DANGER_REVIEW_STATE_INITIAL = "INITIAL"
+      DANGER_REVIEW_STATE_STARTED = "STARTED"
+      DANGER_REVIEW_STATE_SUBMITTED = "SUBMITTED"
+
+      attr_accessor :review_json :comments :danger_state :inline_comments :comments
+
+      def initialize(ci_source, client, pr_json, review_json = nil)
+        @pr_json = pr_json
+        @client = client
+        @ci_source =
+        self.danger_state = DANGER_REVIEW_STATE_INITIAL
+        self.review_json = review_json
+      end
+
+      def start
+        raise "Review has been already started, please submit the ongoing review before starting again" if started?
+        self.review_json ||= @client.post(reviews_url)
+        self.danger_state = DANGER_REVIEW_STATE_STARTED
+      end
+
+      def submit
+        raise "Review has not started yet, please call github.review.start first" unless started?
+        raise "Review has been started submutted, please call start it again" if submitted?
+        @client.post(reviews_url)
+        self.danger_state = DANGER_REVIEW_STATE_SUBMITTED
+      end
+
+      def generated_by_danger?(danger_id = "danger")
+        self.review_json["body"].include?("generated_by_#{danger_id}")
+      end
+
+      def inline_comment(path, position, body)
+
+      end
+
+      def comment(body)
+
+      end
+
+      def inline_comments
+        @inline_comments ||= begin
+          @client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
+            .map { |comment| Comment.from_github(comment).generated_by_danger?("danger") }
+        end
+      end
+
+      private
+
+      def started?
+        return self.danger_state == DANGER_REVIEW_STATE_STARTED
+      end
+
+      def submitted?
+        return self.danger_state == DANGER_REVIEW_STATE_SUBMITTED
+      end
+
+      def pr_url
+        @pr_json["url"]
+      end
+
+      def reviews_url
+        pr_url + "/reviews"
+      end
+    end
+  end
+end

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -56,14 +56,9 @@ module Danger
           @markdowns = []
         end
 
-        # Submits the built review
-        # As on overview of pull request review it adds final markdown
-        # with the pull request review status such as Danger uses for pull request status
+        # Submits the prepared review
         def submit
           general_violations = generate_general_violations
-          submission_message = generate_description(warnings: general_violations[:warnings], errors: general_violations[:errors])
-          markdown submission_message
-
           submission_body = generate_body
 
           # If the review resolver says that there is nothing to submit we skip submission

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -16,14 +16,14 @@ module Danger
       def initialize(client, pr_json, review_json = nil)
         @pr_json = pr_json
         @client = client
-        @warnings = []
-        @errors = []
-        @messages = []
-        @markdowns = []
         self.review_json = review_json
       end
 
       def start
+        @warnings = []
+        @errors = []
+        @messages = []
+        @markdowns = []
       end
 
       def submit
@@ -39,19 +39,19 @@ module Danger
         self.review_json["body"].include?("generated_by_#{danger_id}")
       end
 
-      def message(message: String, sticky=true: Boolean, file=nil: String, line=nil: String)
+      def message(message, sticky=true, file=nil, line=nil)
         @messages << Violation.new(message, sticky, file, line)
       end
 
-      def warn(message: String, sticky=true: Boolean, file=nil: String, line=nil: String)
+      def warn(message, sticky=truу, file=nil, line=nil)
         @warnings << Violation.new(message, sticky, file, line)
       end
 
-      def fail(message: String, sticky=true: Boolean, file=nil: String, line=nil: String)
+      def fail(message, sticky=true, file=nil, line=nil)
         @errors << Violation.new(message, sticky, file, line)
       end
 
-      def markdown(message, file: nil, line: nil)
+      def markdown(message, file=nil, line=nil)
         @markdowns << Markdown.new(message, file, line)
       end
 

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -14,22 +14,23 @@ module Danger
       class Review
         include Danger::Helpers::CommentsHelper
 
+        # @see https://developer.github.com/v3/pulls/reviews/ for all possbile events
         EVENT_APPROVE = "APPROVE"
         EVENT_REQUEST_CHANGES = "REQUEST_CHANGES"
         EVENT_COMMENT = "COMMENT"
 
+        # Current review status, if the review has not been submitted yet -> STATUS_PENDING
         STATUS_APPROVED = "APPROVED"
         STATUS_REQUESTED_CHANGES = "CHANGES_REQUESTED"
         STATUS_COMMENTED = "COMMENTED"
         STATUS_PENDING = "PENDING"
 
-        attr_accessor :review_json
-        attr_reader :id, :body, :status
+        attr_reader :id, :body, :status, :review_json
 
         def initialize(client, ci_source, review_json = nil)
           @ci_source = ci_source
           @client = client
-          self.review_json = review_json
+          @review_json = review_json
         end
 
         def id
@@ -47,6 +48,7 @@ module Danger
           return self.review_json["state"]
         end
 
+        # Starts the new review process
         def start
           @warnings = []
           @errors = []
@@ -54,11 +56,13 @@ module Danger
           @markdowns = []
         end
 
+        # Submits the built review
+        # As on overview of pull request review it adds final markdown
+        # with the pull request review status such as Danger uses for pull request status
         def submit
-          # We wanna add final markdown with the pull request review status such as Danger uses for pull request status
           general_violations = generate_general_violations
           submission_message = generate_description(warnings: general_violations[:warnings], errors: general_violations[:errors])
-          @markdowns << Markdown.new(submission_message)
+          markdown submission_message
 
           submission_event = generate_event(general_violations)
           submission_body = generate_body

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -15,15 +15,15 @@ module Danger
         include Danger::Helpers::CommentsHelper
 
         # @see https://developer.github.com/v3/pulls/reviews/ for all possbile events
-        EVENT_APPROVE = "APPROVE"
-        EVENT_REQUEST_CHANGES = "REQUEST_CHANGES"
-        EVENT_COMMENT = "COMMENT"
+        EVENT_APPROVE = "APPROVE".freeze
+        EVENT_REQUEST_CHANGES = "REQUEST_CHANGES".freeze
+        EVENT_COMMENT = "COMMENT".freeze
 
         # Current review status, if the review has not been submitted yet -> STATUS_PENDING
-        STATUS_APPROVED = "APPROVED"
-        STATUS_REQUESTED_CHANGES = "CHANGES_REQUESTED"
-        STATUS_COMMENTED = "COMMENTED"
-        STATUS_PENDING = "PENDING"
+        STATUS_APPROVED = "APPROVED".freeze
+        STATUS_REQUESTED_CHANGES = "CHANGES_REQUESTED".freeze
+        STATUS_COMMENTED = "COMMENTED".freeze
+        STATUS_PENDING = "PENDING".freeze
 
         attr_reader :id, :body, :status, :review_json
 
@@ -70,26 +70,26 @@ module Danger
           # If the review resolver says that there is nothing to submit we skip submission
           return unless ReviewResolver.should_submit?(self, submission_event, submission_body)
 
-          self.review_json = @client.create_pull_request_review(@ci_source.repo_slug, @ci_source.pull_request_id, submission_event, submission_body)
+          @review_json = @client.create_pull_request_review(@ci_source.repo_slug, @ci_source.pull_request_id, submission_event, submission_body)
         end
 
         def generated_by_danger?(danger_id = "danger")
           self.review_json["body"].include?("generated_by_#{danger_id}")
         end
 
-        def message(message, sticky=true, file=nil, line=nil)
+        def message(message, sticky = true, file = nil, line = nil)
           @messages << Violation.new(message, sticky, file, line)
         end
 
-        def warn(message, sticky=true, file=nil, line=nil)
+        def warn(message, sticky = true, file = nil, line = nil)
           @warnings << Violation.new(message, sticky, file, line)
         end
 
-        def fail(message, sticky=true, file=nil, line=nil)
+        def fail(message, sticky = true, file = nil, line = nil)
           @errors << Violation.new(message, sticky, file, line)
         end
 
-        def markdown(message, file=nil, line=nil)
+        def markdown(message, file = nil, line = nil)
           @markdowns << Markdown.new(message, file, line)
         end
 

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -14,7 +14,7 @@ module Danger
       class Review
         include Danger::Helpers::CommentsHelper
 
-        # @see https://developer.github.com/v3/pulls/reviews/ for all possbile events
+        # @see https://developer.github.com/v3/pulls/reviews/ for all possible events
         EVENT_APPROVE = "APPROVE".freeze
         EVENT_REQUEST_CHANGES = "REQUEST_CHANGES".freeze
         EVENT_COMMENT = "COMMENT".freeze
@@ -64,13 +64,12 @@ module Danger
           submission_message = generate_description(warnings: general_violations[:warnings], errors: general_violations[:errors])
           markdown submission_message
 
-          submission_event = generate_event(general_violations)
           submission_body = generate_body
 
           # If the review resolver says that there is nothing to submit we skip submission
-          return unless ReviewResolver.should_submit?(self, submission_event, submission_body)
+          return unless ReviewResolver.should_submit?(self, submission_body)
 
-          @review_json = @client.create_pull_request_review(@ci_source.repo_slug, @ci_source.pull_request_id, submission_event, submission_body)
+          @review_json = @client.create_pull_request_review(@ci_source.repo_slug, @ci_source.pull_request_id, generate_event(general_violations), submission_body)
         end
 
         def generated_by_danger?(danger_id = "danger")

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -87,10 +87,6 @@ module Danger
           @markdowns << Markdown.new(message, file, line)
         end
 
-        def should_create_new_review?
-          self.review_json.nil?
-        end
-
         private
 
         # The only reason to request changes for the PR is to have errors from Danger

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -9,118 +9,116 @@ require "danger/helpers/comments_helper"
 require "danger/helpers/comment"
 
 module Danger
-  module GitHub
-    class Review
-      include Danger::Helpers::CommentsHelper
+  module RequestSources
+    module GitHubSource
+      class Review
+        include Danger::Helpers::CommentsHelper
 
-      EVENT_APPROVE = "APPROVE"
-      EVENT_REQUEST_CHANGES = "REQUEST_CHANGES"
-      EVENT_COMMENT = "COMMENT"
+        EVENT_APPROVE = "APPROVE"
+        EVENT_REQUEST_CHANGES = "REQUEST_CHANGES"
+        EVENT_COMMENT = "COMMENT"
 
-      STATUS_APPROVED = "APPROVED"
-      STATUS_REQUESTED_CHANGES = "CHANGES_REQUESTED"
-      STATUS_COMMENTED = "COMMENTED"
-      STATUS_PENDING = "PENDING"
+        STATUS_APPROVED = "APPROVED"
+        STATUS_REQUESTED_CHANGES = "CHANGES_REQUESTED"
+        STATUS_COMMENTED = "COMMENTED"
+        STATUS_PENDING = "PENDING"
 
-      attr_accessor :review_json
-      attr_reader :id, :body, :status
+        attr_accessor :review_json
+        attr_reader :id, :body, :status
 
-      def initialize(client, ci_source, review_json = nil)
-        @ci_source = ci_source
-        @client = client
-        self.review_json = review_json
-      end
-
-      def id
-        self.review_json["id"]
-      end
-
-      def body
-        return "" unless self.review_json
-        self.review_json["body"]
-      end
-
-      def status
-        return STATUS_PENDING unless self.review_json
-        return self.review_json["state"]
-      end
-
-      def start
-        @warnings = []
-        @errors = []
-        @messages = []
-        @markdowns = []
-      end
-
-      def submit
-        # We wanna add final markdown with the pull request review status such as Danger uses for pull request status
-        markdown(generate_description(warnings: @warnings, errors: @errors))
-        resolver = ReviewResolver.new(self)
-        submission_event = generate_event(generate_general_violations)
-        generated_body = generate_body
-        if resolver.should_submit?(submission_event, generated_body)
-          self.review_json = @client.submit_pull_request_review(@ci_source.repo_slug, @ci_source.pull_request_id, id, submission_event, generated_body)
-        elsif resolver.should_create?(submission_event, generated_body)
-          self.review_json = @client.create_pull_request_review(@ci_source.repo_slug, @ci_source.pull_request_id, submission_event, generated_body)
+        def initialize(client, ci_source, review_json = nil)
+          @ci_source = ci_source
+          @client = client
+          self.review_json = review_json
         end
-      end
 
-      def generated_by_danger?(danger_id = "danger")
-        self.review_json["body"].include?("generated_by_#{danger_id}")
-      end
+        def id
+          self.review_json["id"]
+        end
 
-      def message(message, sticky=true, file=nil, line=nil)
-        @messages << Violation.new(message, sticky, file, line)
-      end
+        def body
+          return "" unless self.review_json
+          self.review_json["body"]
+        end
 
-      def warn(message, sticky=true, file=nil, line=nil)
-        @warnings << Violation.new(message, sticky, file, line)
-      end
+        def status
+          return STATUS_PENDING unless self.review_json
+          return self.review_json["state"]
+        end
 
-      def fail(message, sticky=true, file=nil, line=nil)
-        @errors << Violation.new(message, sticky, file, line)
-      end
+        def start
+          @warnings = []
+          @errors = []
+          @messages = []
+          @markdowns = []
+        end
 
-      def markdown(message, file=nil, line=nil)
-        @markdowns << Markdown.new(message, file, line)
-      end
+        def submit
+          # We wanna add final markdown with the pull request review status such as Danger uses for pull request status
+          
+          submission_event = generate_event(generate_general_violations)
+          submission_body = generate_body
+          return unless ReviewResolver.new(self).should_submit?(submission_event, submission_body)
+          self.review_json = @client.create_pull_request_review(@ci_source.repo_slug, @ci_source.pull_request_id, submission_event, submission_body)
+        end
 
-      def should_create_new_review?
-        self.review_json.nil?
-      end
+        def generated_by_danger?(danger_id = "danger")
+          self.review_json["body"].include?("generated_by_#{danger_id}")
+        end
 
-      private
+        def message(message, sticky=true, file=nil, line=nil)
+          @messages << Violation.new(message, sticky, file, line)
+        end
 
-      def generate_event(violations)
-        violations[:errors].empty? ? EVENT_APPROVE : EVENT_REQUEST_CHANGES
-      end
+        def warn(message, sticky=true, file=nil, line=nil)
+          @warnings << Violation.new(message, sticky, file, line)
+        end
 
-      def generate_body(danger_id: "danger")
-        previous_violations = parse_comment(body)
-        puts "Previous violations #{previous_violations} for body #{body}"
+        def fail(message, sticky=true, file=nil, line=nil)
+          @errors << Violation.new(message, sticky, file, line)
+        end
 
-        general_violations = generate_general_violations
-        new_body = generate_comment(warnings: general_violations[:warnings],
-                                    errors: general_violations[:errors],
-                                    messages: general_violations[:messages],
-                                    markdowns: general_violations[:markdowns],
-                                    previous_violations: previous_violations,
-                                    danger_id: danger_id,
-                                    template: "github")
-        return new_body
-      end
+        def markdown(message, file=nil, line=nil)
+          @markdowns << Markdown.new(message, file, line)
+        end
 
-      def generate_general_violations
-        general_warnings = @warnings.reject(&:inline?)
-        general_errors = @errors.reject(&:inline?)
-        general_messages = @messages.reject(&:inline?)
-        general_markdowns = @markdowns.reject(&:inline?)
-        {
-          warnings: general_warnings,
-          markdowns: general_markdowns,
-          errors: general_errors,
-          messages: general_messages
-        }
+        def should_create_new_review?
+          self.review_json.nil?
+        end
+
+        private
+
+        def generate_event(violations)
+          violations[:errors].empty? ? EVENT_APPROVE : EVENT_REQUEST_CHANGES
+        end
+
+        def generate_body(danger_id: "danger")
+          previous_violations = parse_comment(body)
+          puts "Previous violations #{previous_violations} for body #{body}"
+
+          general_violations = generate_general_violations
+          new_body = generate_comment(warnings: general_violations[:warnings],
+                                      errors: general_violations[:errors],
+                                      messages: general_violations[:messages],
+                                      markdowns: general_violations[:markdowns],
+                                      previous_violations: previous_violations,
+                                      danger_id: danger_id,
+                                      template: "github")
+          return new_body
+        end
+
+        def generate_general_violations
+          general_warnings = @warnings.reject(&:inline?)
+          general_errors = @errors.reject(&:inline?)
+          general_messages = @messages.reject(&:inline?)
+          general_markdowns = @markdowns.reject(&:inline?)
+          {
+            warnings: general_warnings,
+            markdowns: general_markdowns,
+            errors: general_errors,
+            messages: general_messages
+          }
+        end
       end
     end
   end

--- a/lib/danger/request_sources/github/github_review.rb
+++ b/lib/danger/request_sources/github/github_review.rb
@@ -33,6 +33,7 @@ module Danger
         end
 
         def id
+          return nil unless self.review_json
           self.review_json["id"]
         end
 
@@ -56,7 +57,8 @@ module Danger
         def submit
           # We wanna add final markdown with the pull request review status such as Danger uses for pull request status
           general_violations = generate_general_violations
-          @markdowns << Markdown.new(message, generate_description(warnings: general_violations[:warnings], errors: general_violations[:errors]))
+          submission_message = generate_description(warnings: general_violations[:warnings], errors: general_violations[:errors])
+          @markdowns << Markdown.new(submission_message)
 
           submission_event = generate_event(general_violations)
           submission_body = generate_body

--- a/lib/danger/request_sources/github/github_review_resolver.rb
+++ b/lib/danger/request_sources/github/github_review_resolver.rb
@@ -8,15 +8,22 @@ module Danger
         @review = review
       end
 
-      def should_submit?(event)
-        return true if @review.status == Review::STATUS_REQUESTED_CHANGES
-        return false
+      def should_submit?(event, body)
+        return false if bodies_same?(@review.body, body) || @review.status != Review::STATUS_REQUESTED_CHANGES
+        return true
       end
 
-      def should_create?(event)
+      def should_create?(event, body)
+        return false if bodies_same?(@review.body, body)
         return true if @review.status == Review::STATUS_PENDING
         return true if @review.status == Review::STATUS_APPROVED && event != Review::EVENT_APPROVE
         return false
+      end
+
+      private
+
+      def bodies_same?(current_body, new_body)
+        return !new_body.nil? && !current_body.nil? && new_body == current_body
       end
     end
   end

--- a/lib/danger/request_sources/github/github_review_resolver.rb
+++ b/lib/danger/request_sources/github/github_review_resolver.rb
@@ -10,8 +10,6 @@ module Danger
           return event_changes_status?(event, review.status)
         end
 
-        private
-
         # @orta @JuanitoFatas to be discussed whether we should submit review with
         # the same status as already submitted by danger before
         def self.event_changes_status?(event, status)

--- a/lib/danger/request_sources/github/github_review_resolver.rb
+++ b/lib/danger/request_sources/github/github_review_resolver.rb
@@ -5,17 +5,8 @@ module Danger
   module RequestSources
     module GitHubSource
       class ReviewResolver
-        def self.should_submit?(review, event, body)
-          return false if same_body?(body, review.body)
-          return event_changes_status?(event, review.status)
-        end
-
-        # @orta @JuanitoFatas to be discussed whether we should submit review with
-        # the same status as already submitted by danger before
-        def self.event_changes_status?(event, status)
-          all_events = [Review::EVENT_APPROVE, Review::EVENT_COMMENT, Review::EVENT_REQUEST_CHANGES]
-          all_statuses = [Review::STATUS_APPROVED, Review::STATUS_COMMENTED, Review::STATUS_REQUESTED_CHANGES, Review::STATUS_PENDING]
-          return all_events.index(event) != all_statuses.index(status)
+        def self.should_submit?(review, body)
+          return !same_body?(body, review.body)
         end
 
         def self.same_body?(body1, body2)

--- a/lib/danger/request_sources/github/github_review_resolver.rb
+++ b/lib/danger/request_sources/github/github_review_resolver.rb
@@ -12,6 +12,8 @@ module Danger
 
         private
 
+        # @orta @JuanitoFatas to be discussed whether we should submit review with
+        # the same status as already submitted by danger before
         def self.event_changes_status?(event, status)
           all_events = [Review::EVENT_APPROVE, Review::EVENT_COMMENT, Review::EVENT_REQUEST_CHANGES]
           all_statuses = [Review::STATUS_APPROVED, Review::STATUS_COMMENTED, Review::STATUS_REQUESTED_CHANGES, Review::STATUS_PENDING]
@@ -19,7 +21,6 @@ module Danger
         end
 
         def self.same_body?(body1, body2)
-          puts "body1 #{body1} body2 #{body2}"
           return !body1.nil? && !body2.nil? && body1 == body2
         end
       end

--- a/lib/danger/request_sources/github/github_review_resolver.rb
+++ b/lib/danger/request_sources/github/github_review_resolver.rb
@@ -5,24 +5,20 @@ module Danger
   module RequestSources
     module GitHubSource
       class ReviewResolver
-        def initialize(review)
-          @review = review
-        end
-
-        def should_submit?(event, body)
-          return false if same_body?(body, @review.body)
-          return event_changes_status?(event, @review.status)
+        def self.should_submit?(review, event, body)
+          return false if same_body?(body, review.body)
+          return event_changes_status?(event, review.status)
         end
 
         private
 
-        def event_changes_status?(event, status)
+        def self.event_changes_status?(event, status)
           all_events = [Review::EVENT_APPROVE, Review::EVENT_COMMENT, Review::EVENT_REQUEST_CHANGES]
           all_statuses = [Review::STATUS_APPROVED, Review::STATUS_COMMENTED, Review::STATUS_REQUESTED_CHANGES, Review::STATUS_PENDING]
           return all_events.index(event) != all_statuses.index(status)
         end
 
-        def same_body?(body1, body2)
+        def self.same_body?(body1, body2)
           puts "body1 #{body1} body2 #{body2}"
           return !body1.nil? && !body2.nil? && body1 == body2
         end

--- a/lib/danger/request_sources/github/github_review_resolver.rb
+++ b/lib/danger/request_sources/github/github_review_resolver.rb
@@ -2,28 +2,30 @@
 require "danger/request_sources/github/github_review"
 
 module Danger
-  module GitHub
-    class ReviewResolver
-      def initialize(review)
-        @review = review
-      end
+  module RequestSources
+    module GitHubSource
+      class ReviewResolver
+        def initialize(review)
+          @review = review
+        end
 
-      def should_submit?(event, body)
-        return false if bodies_same?(@review.body, body) || @review.status != Review::STATUS_REQUESTED_CHANGES
-        return true
-      end
+        def should_submit?(event, body)
+          return false if same_body?(body, @review.body)
+          return event_changes_status?(event, @review.status)
+        end
 
-      def should_create?(event, body)
-        return false if bodies_same?(@review.body, body)
-        return true if @review.status == Review::STATUS_PENDING
-        return true if @review.status == Review::STATUS_APPROVED && event != Review::EVENT_APPROVE
-        return false
-      end
+        private
 
-      private
+        def event_changes_status?(event, status)
+          all_events = [Review::EVENT_APPROVE, Review::EVENT_COMMENT, Review::EVENT_REQUEST_CHANGES]
+          all_statuses = [Review::STATUS_APPROVED, Review::STATUS_COMMENTED, Review::STATUS_REQUESTED_CHANGES, Review::STATUS_PENDING]
+          return all_events.index(event) != all_statuses.index(status)
+        end
 
-      def bodies_same?(current_body, new_body)
-        return !new_body.nil? && !current_body.nil? && new_body == current_body
+        def same_body?(body1, body2)
+          puts "body1 #{body1} body2 #{body2}"
+          return !body1.nil? && !body2.nil? && body1 == body2
+        end
       end
     end
   end

--- a/lib/danger/request_sources/github/github_review_resolver.rb
+++ b/lib/danger/request_sources/github/github_review_resolver.rb
@@ -1,0 +1,23 @@
+# coding: utf-8
+require "danger/request_sources/github/github_review"
+
+module Danger
+  module GitHub
+    class ReviewResolver
+      def initialize(review)
+        @review = review
+      end
+
+      def should_submit?(event)
+        return true if @review.status == Review::STATUS_REQUESTED_CHANGES
+        return false
+      end
+
+      def should_create?(event)
+        return true if @review.status == Review::STATUS_PENDING
+        return true if @review.status == Review::STATUS_APPROVED && event != Review::EVENT_APPROVE
+        return false
+      end
+    end
+  end
+end

--- a/lib/danger/request_sources/github/octokit_pr_review.rb
+++ b/lib/danger/request_sources/github/octokit_pr_review.rb
@@ -1,0 +1,33 @@
+# coding: utf-8
+require "octokit"
+
+module Octokit
+  class Client
+    module PullRequestsReview
+
+      # The Pull Request Review API is currently available for developers to preview.
+      # During the preview period, the API may change without advance notice.
+      # please see the blog post for full details.
+      # To access the API during the preview period, you must provide
+      # a custom media type in the Accept header:
+      CUSTOM_ACCEPT_HEADER = "application/vnd.github.black-cat-preview+json"
+
+      # List pull request reviews for a pull request
+      #
+      # @overload pull_request_reviews(repo, options)
+      #   @param repo [Integer, String, Hash, Repository] A GitHub repository
+      #   @param pull_request_number [Integer] Number of the pull request to fetch reviews for
+      # @return [Array<Sawyer::Resource>] Array of reviews
+      # @see https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
+      # @example
+      #   Octokit.pull_request_reviews('rails/rails', :state => 'closed')
+      def pull_request_reviews(repo, pull_request_number, options = {})
+        accept = {
+          :accept => CUSTOM_ACCEPT_HEADER
+        }
+        paginate "#{Repository.path repo}/pulls/reviews", options.merge(accept)
+      end
+
+    end
+  end
+end

--- a/lib/danger/request_sources/github/octokit_pr_review.rb
+++ b/lib/danger/request_sources/github/octokit_pr_review.rb
@@ -12,20 +12,74 @@ module Octokit
       # a custom media type in the Accept header:
       CUSTOM_ACCEPT_HEADER = "application/vnd.github.black-cat-preview+json"
 
+      # Approve pull request event
+      PULL_REQUEST_REVIEW_EVENT_APPROVE = "APPROVE"
+
+      # Request changes on the pull request event
+      PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES = "REQUEST_CHANGES"
+
+      # Left a gemeneral comment on the pull request event
+      PULL_REQUEST_REVIEW_EVENT_COMMENT = "COMMENT"
+
       # List pull request reviews for a pull request
       #
-      # @overload pull_request_reviews(repo, options)
-      #   @param repo [Integer, String, Hash, Repository] A GitHub repository
-      #   @param pull_request_number [Integer] Number of the pull request to fetch reviews for
-      # @return [Array<Sawyer::Resource>] Array of reviews
       # @see https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param pull_request_number [Integer] Number of the pull request to fetch reviews for
+      # @return [Array<Sawyer::Resource>] Array of reviews
       # @example
       #   Octokit.pull_request_reviews('rails/rails', :state => 'closed')
       def pull_request_reviews(repo, pull_request_number, options = {})
         accept = {
           :accept => CUSTOM_ACCEPT_HEADER
         }
-        paginate "#{Repository.path repo}/pulls/reviews", options.merge(accept)
+        paginate "#{Repository.path repo}/pulls/#{pull_request_number}/reviews", options.merge(accept)
+      end
+
+      # Create a pull request review
+      #
+      # @see https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param pull_request_number [Integer] Number of the pull request to create review for
+      # @param event [String] The review action (event) to perform. Can be one of
+      #                       PULL_REQUEST_REVIEW_EVENT_APPROVE
+      #                       PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES
+      #                       PULL_REQUEST_REVIEW_EVENT_COMMENT
+      # @param body [String] The body for the pull request review (optional). Supports GFM.
+      # @return [Sawyer::Resource] The newly created pull request
+      # @example
+      #   @client.create_pull_request_review("octokit/octokit.rb", "APPROVE", "Thanks for your contribution")
+      def create_pull_request_review(repo, pull_request_number, event, body = nil, options = {})
+        review = {
+          :event  => event,
+          :accept => CUSTOM_ACCEPT_HEADER
+        }
+        review[:body] = body unless body.nil?
+        post "#{Repository.path repo}/pulls/#{pull_request_number}/reviews", options.merge(review)
+      end
+
+      # Submit a pull request review
+      #
+      # @see https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param pull_request_number [Integer] Number of the pull request to create review for
+      # @param review [Integer] ID of the pull request review to submit
+      # @param event [String] The review action (event) to perform. Can be one of
+      #                       PULL_REQUEST_REVIEW_EVENT_APPROVE
+      #                       PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES
+      #                       PULL_REQUEST_REVIEW_EVENT_COMMENT
+      # @param body [String] The body for the pull request review (optional). Supports GFM.
+      # @return [Sawyer::Resource] The newly created pull request
+      # @example
+      #   @client.submit_pull_request_review("octokit/octokit.rb", "REQUEST_CHANGES",
+      #                                      "Nice changes, but please make couple of imrovements")
+      def submit_pull_request_review(repo, pull_request_number, review, event, body = nil, options = {})
+        review = {
+          :event  => event,
+          :accept => CUSTOM_ACCEPT_HEADER
+        }
+        review[:body] = body unless body.nil?
+        post "#{Repository.path repo}/pulls/#{pull_request_number}/reviews/#{review}/events", options.merge(review)
       end
 
     end

--- a/lib/danger/request_sources/github/octokit_pr_review.rb
+++ b/lib/danger/request_sources/github/octokit_pr_review.rb
@@ -3,85 +3,81 @@ require "octokit"
 
 module Octokit
   class Client
-    module PullRequestsReview
+    # The Pull Request Review API is currently available for developers to preview.
+    # During the preview period, the API may change without advance notice.
+    # please see the blog post for full details.
+    # To access the API during the preview period, you must provide
+    # a custom media type in the Accept header:
+    CUSTOM_ACCEPT_HEADER = "application/vnd.github.black-cat-preview+json"
 
-      # The Pull Request Review API is currently available for developers to preview.
-      # During the preview period, the API may change without advance notice.
-      # please see the blog post for full details.
-      # To access the API during the preview period, you must provide
-      # a custom media type in the Accept header:
-      CUSTOM_ACCEPT_HEADER = "application/vnd.github.black-cat-preview+json"
+    # Approve pull request event
+    PULL_REQUEST_REVIEW_EVENT_APPROVE = "APPROVE"
 
-      # Approve pull request event
-      PULL_REQUEST_REVIEW_EVENT_APPROVE = "APPROVE"
+    # Request changes on the pull request event
+    PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES = "REQUEST_CHANGES"
 
-      # Request changes on the pull request event
-      PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES = "REQUEST_CHANGES"
+    # Left a gemeneral comment on the pull request event
+    PULL_REQUEST_REVIEW_EVENT_COMMENT = "COMMENT"
 
-      # Left a gemeneral comment on the pull request event
-      PULL_REQUEST_REVIEW_EVENT_COMMENT = "COMMENT"
+    # List pull request reviews for a pull request
+    #
+    # @see https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
+    # @param repo [Integer, String, Hash, Repository] A GitHub repository
+    # @param pull_request_number [Integer] Number of the pull request to fetch reviews for
+    # @return [Array<Sawyer::Resource>] Array of reviews
+    # @example
+    #   Octokit.pull_request_reviews('rails/rails', :state => 'closed')
+    def pull_request_reviews(repo, pull_request_number, options = {})
+      accept = {
+        :accept => CUSTOM_ACCEPT_HEADER
+      }
+      paginate "#{Repository.path repo}/pulls/#{pull_request_number}/reviews", options.merge(accept)
+    end
 
-      # List pull request reviews for a pull request
-      #
-      # @see https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
-      # @param repo [Integer, String, Hash, Repository] A GitHub repository
-      # @param pull_request_number [Integer] Number of the pull request to fetch reviews for
-      # @return [Array<Sawyer::Resource>] Array of reviews
-      # @example
-      #   Octokit.pull_request_reviews('rails/rails', :state => 'closed')
-      def pull_request_reviews(repo, pull_request_number, options = {})
-        accept = {
-          :accept => CUSTOM_ACCEPT_HEADER
-        }
-        paginate "#{Repository.path repo}/pulls/#{pull_request_number}/reviews", options.merge(accept)
-      end
+    # Create a pull request review
+    #
+    # @see https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
+    # @param repo [Integer, String, Hash, Repository] A GitHub repository
+    # @param pull_request_number [Integer] Number of the pull request to create review for
+    # @param event [String] The review action (event) to perform. Can be one of
+    #                       PULL_REQUEST_REVIEW_EVENT_APPROVE
+    #                       PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES
+    #                       PULL_REQUEST_REVIEW_EVENT_COMMENT
+    # @param body [String] The body for the pull request review (optional). Supports GFM.
+    # @return [Sawyer::Resource] The newly created pull request
+    # @example
+    #   @client.create_pull_request_review("octokit/octokit.rb", "APPROVE", "Thanks for your contribution")
+    def create_pull_request_review(repo, pull_request_number, event, body = nil, options = {})
+      review = {
+        :event  => event,
+        :accept => CUSTOM_ACCEPT_HEADER
+      }
+      review[:body] = body unless body.nil?
+      post "#{Repository.path repo}/pulls/#{pull_request_number}/reviews", options.merge(review)
+    end
 
-      # Create a pull request review
-      #
-      # @see https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
-      # @param repo [Integer, String, Hash, Repository] A GitHub repository
-      # @param pull_request_number [Integer] Number of the pull request to create review for
-      # @param event [String] The review action (event) to perform. Can be one of
-      #                       PULL_REQUEST_REVIEW_EVENT_APPROVE
-      #                       PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES
-      #                       PULL_REQUEST_REVIEW_EVENT_COMMENT
-      # @param body [String] The body for the pull request review (optional). Supports GFM.
-      # @return [Sawyer::Resource] The newly created pull request
-      # @example
-      #   @client.create_pull_request_review("octokit/octokit.rb", "APPROVE", "Thanks for your contribution")
-      def create_pull_request_review(repo, pull_request_number, event, body = nil, options = {})
-        review = {
-          :event  => event,
-          :accept => CUSTOM_ACCEPT_HEADER
-        }
-        review[:body] = body unless body.nil?
-        post "#{Repository.path repo}/pulls/#{pull_request_number}/reviews", options.merge(review)
-      end
-
-      # Submit a pull request review
-      #
-      # @see https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
-      # @param repo [Integer, String, Hash, Repository] A GitHub repository
-      # @param pull_request_number [Integer] Number of the pull request to create review for
-      # @param review [Integer] ID of the pull request review to submit
-      # @param event [String] The review action (event) to perform. Can be one of
-      #                       PULL_REQUEST_REVIEW_EVENT_APPROVE
-      #                       PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES
-      #                       PULL_REQUEST_REVIEW_EVENT_COMMENT
-      # @param body [String] The body for the pull request review (optional). Supports GFM.
-      # @return [Sawyer::Resource] The newly created pull request
-      # @example
-      #   @client.submit_pull_request_review("octokit/octokit.rb", "REQUEST_CHANGES",
-      #                                      "Nice changes, but please make couple of imrovements")
-      def submit_pull_request_review(repo, pull_request_number, review, event, body = nil, options = {})
-        review = {
-          :event  => event,
-          :accept => CUSTOM_ACCEPT_HEADER
-        }
-        review[:body] = body unless body.nil?
-        post "#{Repository.path repo}/pulls/#{pull_request_number}/reviews/#{review}/events", options.merge(review)
-      end
-
+    # Submit a pull request review
+    #
+    # @see https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
+    # @param repo [Integer, String, Hash, Repository] A GitHub repository
+    # @param pull_request_number [Integer] Number of the pull request to create review for
+    # @param review_id [Integer] ID of the pull request review to submit
+    # @param event [String] The review action (event) to perform. Can be one of
+    #                       PULL_REQUEST_REVIEW_EVENT_APPROVE
+    #                       PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES
+    #                       PULL_REQUEST_REVIEW_EVENT_COMMENT
+    # @param body [String] The body for the pull request review (optional). Supports GFM.
+    # @return [Sawyer::Resource] The newly created pull request
+    # @example
+    #   @client.submit_pull_request_review("octokit/octokit.rb", "REQUEST_CHANGES",
+    #                                      "Nice changes, but please make couple of imrovements")
+    def submit_pull_request_review(repo, pull_request_number, review_id, event, body = nil, options = {})
+      review = {
+        :event  => event,
+        :accept => CUSTOM_ACCEPT_HEADER
+      }
+      review[:body] = body unless body.nil?
+      post "#{Repository.path repo}/pulls/#{pull_request_number}/reviews/#{review_id}/events", options.merge(review)
     end
   end
 end

--- a/lib/danger/request_sources/github/octokit_pr_review.rb
+++ b/lib/danger/request_sources/github/octokit_pr_review.rb
@@ -8,16 +8,16 @@ module Octokit
     # please see the blog post for full details.
     # To access the API during the preview period, you must provide
     # a custom media type in the Accept header:
-    CUSTOM_ACCEPT_HEADER = "application/vnd.github.black-cat-preview+json"
+    CUSTOM_ACCEPT_HEADER = "application/vnd.github.black-cat-preview+json".freeze
 
     # Approve pull request event
-    PULL_REQUEST_REVIEW_EVENT_APPROVE = "APPROVE"
+    PULL_REQUEST_REVIEW_EVENT_APPROVE = "APPROVE".freeze
 
     # Request changes on the pull request event
-    PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES = "REQUEST_CHANGES"
+    PULL_REQUEST_REVIEW_EVENT_REQUEST_CHANGES = "REQUEST_CHANGES".freeze
 
     # Left a gemeneral comment on the pull request event
-    PULL_REQUEST_REVIEW_EVENT_COMMENT = "COMMENT"
+    PULL_REQUEST_REVIEW_EVENT_COMMENT = "COMMENT".freeze
 
     # List pull request reviews for a pull request
     #
@@ -29,7 +29,7 @@ module Octokit
     #   Octokit.pull_request_reviews('rails/rails', :state => 'closed')
     def pull_request_reviews(repo, pull_request_number, options = {})
       accept = {
-        :accept => CUSTOM_ACCEPT_HEADER
+        accept: CUSTOM_ACCEPT_HEADER
       }
       paginate "#{Repository.path repo}/pulls/#{pull_request_number}/reviews", options.merge(accept)
     end
@@ -49,8 +49,8 @@ module Octokit
     #   @client.create_pull_request_review("octokit/octokit.rb", "APPROVE", "Thanks for your contribution")
     def create_pull_request_review(repo, pull_request_number, event, body = nil, options = {})
       review = {
-        :event  => event,
-        :accept => CUSTOM_ACCEPT_HEADER
+        event: event,
+        accept: CUSTOM_ACCEPT_HEADER
       }
       review[:body] = body unless body.nil?
       post "#{Repository.path repo}/pulls/#{pull_request_number}/reviews", options.merge(review)
@@ -73,8 +73,8 @@ module Octokit
     #                                      "Nice changes, but please make couple of imrovements")
     def submit_pull_request_review(repo, pull_request_number, review_id, event, body = nil, options = {})
       review = {
-        :event  => event,
-        :accept => CUSTOM_ACCEPT_HEADER
+        event: event,
+        accept: CUSTOM_ACCEPT_HEADER
       }
       review[:body] = body unless body.nil?
       post "#{Repository.path repo}/pulls/#{pull_request_number}/reviews/#{review_id}/events", options.merge(review)

--- a/spec/fixtures/github_api/pr_review_response.json
+++ b/spec/fixtures/github_api/pr_review_response.json
@@ -1,0 +1,36 @@
+{
+  "id": 15629060,
+  "user": {
+    "login": "conichi-ci",
+    "id": 17313329,
+    "avatar_url": "https://avatars3.githubusercontent.com/u/17313329?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/conichi-ci",
+    "html_url": "https://github.com/conichi-ci",
+    "followers_url": "https://api.github.com/users/conichi-ci/followers",
+    "following_url": "https://api.github.com/users/conichi-ci/following{/other_user}",
+    "gists_url": "https://api.github.com/users/conichi-ci/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/conichi-ci/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/conichi-ci/subscriptions",
+    "organizations_url": "https://api.github.com/users/conichi-ci/orgs",
+    "repos_url": "https://api.github.com/users/conichi-ci/repos",
+    "events_url": "https://api.github.com/users/conichi-ci/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/conichi-ci/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "body": "Looks good",
+  "commit_id": "d076f61a9eee9806bd8c272903c4182c033e0e7e",
+  "state": "APPROVED",
+  "html_url": "https://github.com/Antondomashnev/MyAmazingDangerPlayground/pull/2#pullrequestreview-15629060",
+  "pull_request_url": "https://api.github.com/repos/Antondomashnev/MyAmazingDangerPlayground/pulls/2",
+  "_links": {
+    "html": {
+      "href": "https://github.com/Antondomashnev/MyAmazingDangerPlayground/pull/2#pullrequestreview-15629060"
+    },
+    "pull_request": {
+      "href": "https://api.github.com/repos/Antondomashnev/MyAmazingDangerPlayground/pulls/2"
+    }
+  },
+  "submitted_at": "2017-01-08T17:37:23Z"
+}

--- a/spec/fixtures/github_api/pr_reviews_response.json
+++ b/spec/fixtures/github_api/pr_reviews_response.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": 15629060,
+    "user": {
+      "login": "conichi-ci",
+      "id": 17313329,
+      "avatar_url": "https://avatars3.githubusercontent.com/u/17313329?v=3",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/conichi-ci",
+      "html_url": "https://github.com/conichi-ci",
+      "followers_url": "https://api.github.com/users/conichi-ci/followers",
+      "following_url": "https://api.github.com/users/conichi-ci/following{/other_user}",
+      "gists_url": "https://api.github.com/users/conichi-ci/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/conichi-ci/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/conichi-ci/subscriptions",
+      "organizations_url": "https://api.github.com/users/conichi-ci/orgs",
+      "repos_url": "https://api.github.com/users/conichi-ci/repos",
+      "events_url": "https://api.github.com/users/conichi-ci/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/conichi-ci/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "Looks good",
+    "commit_id": "d076f61a9eee9806bd8c272903c4182c033e0e7e",
+    "state": "APPROVED",
+    "html_url": "https://github.com/Antondomashnev/MyAmazingDangerPlayground/pull/2#pullrequestreview-15629060",
+    "pull_request_url": "https://api.github.com/repos/Antondomashnev/MyAmazingDangerPlayground/pulls/2",
+    "_links": {
+      "html": {
+        "href": "https://github.com/Antondomashnev/MyAmazingDangerPlayground/pull/2#pullrequestreview-15629060"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/Antondomashnev/MyAmazingDangerPlayground/pulls/2"
+      }
+    },
+    "submitted_at": "2017-01-08T17:37:23Z"
+  },
+  {
+    "id": 16237194,
+    "user": {
+      "login": "jigitdanger",
+      "id": 23439226,
+      "avatar_url": "https://avatars3.githubusercontent.com/u/23439226?v=3",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/jigitdanger",
+      "html_url": "https://github.com/jigitdanger",
+      "followers_url": "https://api.github.com/users/jigitdanger/followers",
+      "following_url": "https://api.github.com/users/jigitdanger/following{/other_user}",
+      "gists_url": "https://api.github.com/users/jigitdanger/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/jigitdanger/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/jigitdanger/subscriptions",
+      "organizations_url": "https://api.github.com/users/jigitdanger/orgs",
+      "repos_url": "https://api.github.com/users/jigitdanger/repos",
+      "events_url": "https://api.github.com/users/jigitdanger/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/jigitdanger/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "data-meta=\"generated_by_danger\"",
+    "commit_id": "d076f61a9eee9806bd8c272903c4182c033e0e7e",
+    "state": "REQUESTED_CHANGES",
+    "html_url": "https://github.com/Antondomashnev/MyAmazingDangerPlayground/pull/2#pullrequestreview-16237194",
+    "pull_request_url": "https://api.github.com/repos/Antondomashnev/MyAmazingDangerPlayground/pulls/2",
+    "_links": {
+      "html": {
+        "href": "https://github.com/Antondomashnev/MyAmazingDangerPlayground/pull/2#pullrequestreview-16237194"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/Antondomashnev/MyAmazingDangerPlayground/pulls/2"
+      }
+    },
+    "submitted_at": "2017-01-08T17:42:20Z"
+  },
+  {
+    "id": 15629062,
+    "user": {
+      "login": "Antondomashnev",
+      "id": 17313340,
+      "avatar_url": "https://avatars3.githubusercontent.com/u/17313329?v=3",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Antondomashnev",
+      "html_url": "https://github.com/Antondomashnev",
+      "followers_url": "https://api.github.com/users/Antondomashnev/followers",
+      "following_url": "https://api.github.com/users/Antondomashnev/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Antondomashnev/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Antondomashnev/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Antondomashnev/subscriptions",
+      "organizations_url": "https://api.github.com/users/Antondomashnev/orgs",
+      "repos_url": "https://api.github.com/users/Antondomashnev/repos",
+      "events_url": "https://api.github.com/users/Antondomashnev/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Antondomashnev/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "Could you please update tests?",
+    "commit_id": "d076f61a9eee9806bd8c272903c4182c033e0e7e",
+    "state": "REQUESTED_CHANGES",
+    "html_url": "https://github.com/Antondomashnev/MyAmazingDangerPlayground/pull/2#pullrequestreview-15629060",
+    "pull_request_url": "https://api.github.com/repos/Antondomashnev/MyAmazingDangerPlayground/pulls/2",
+    "_links": {
+      "html": {
+        "href": "https://github.com/Antondomashnev/MyAmazingDangerPlayground/pull/2#pullrequestreview-15629060"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/Antondomashnev/MyAmazingDangerPlayground/pulls/2"
+      }
+    },
+    "submitted_at": "2017-01-08T17:47:23Z"
+  }
+]

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
       expect(methods).to eq [
         :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files,
-        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider
+        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :review, :scm_provider
       ]
     end
 

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
       expect(methods).to eq [
         :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files,
-        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :review, :scm_provider
+        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider
       ]
     end
 

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
       expect(methods).to eq [
         :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files,
-        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider
+        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :review, :scm_provider
       ]
     end
 
@@ -162,6 +162,8 @@ RSpec.describe Danger::Dangerfile, host: :github do
         @dm.env.request_source.support_tokenless_auth = true
 
         # Stub out the GitHub stuff
+        pr_reviews_response = JSON.parse(fixture("github_api/pr_reviews_response"))
+        allow(@dm.env.request_source.client).to receive(:pull_request_reviews).with("artsy/eigen", "800").and_return(pr_reviews_response)
         pr_response = JSON.parse(fixture("github_api/pr_response"))
         allow(@dm.env.request_source.client).to receive(:pull_request).with("artsy/eigen", "800").and_return(pr_response)
         issue_response = JSON.parse(fixture("github_api/issue_response"))
@@ -203,7 +205,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
           :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files, :deletions, :head_commit,
           :insertions, :lines_of_code, :modified_files,
           :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title,
-          :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :scm_provider
+          :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :review, :scm_provider
         ]
       end
 

--- a/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
@@ -1,117 +1,156 @@
 require "danger/request_sources/github/github_review_resolver"
 require "danger/request_sources/github/github_review"
 
-RSpec.describe Danger::GitHub::ReviewResolver do
+RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
   let(:review) { double("Danger::GitHub::Review") }
-  subject { Danger::GitHub::ReviewResolver.new(review) }
 
   describe "should_submit?" do
-    context "when review status is pending" do
+    context "when submission body the same as review has" do
       before do
-        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_PENDING }
+        allow(review).to receive(:body).and_return "super body"
       end
 
-      context "when wants to approve" do
-        it "returns false" do
-          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_APPROVE)).to be false
-        end
-      end
-
-      context "when wants to request changes" do
-        it "returns false" do
-          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be false
-        end
+      it "returns false" do
+        expect(described_class.should_submit?(review, Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE, "super body").to be false
       end
     end
 
-    context "when review status is requested changes" do
+    context "when submission body is different to review body" do
+      let (:submissions_body) { "submission body" }
+
       before do
-        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_REQUESTED_CHANGES }
+        allow(review).to receive(:body).and_return "unique body"
       end
 
-      context "when wants to approve" do
-        it "returns true" do
-          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_APPROVE)).to be true
+      context "when want to approve pr" do
+        let (:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE }
+
+        context "when review is pending" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_PENDING }
+          end
+
+          it "returns true" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+          end
+        end
+
+        context "when review is approved" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_APPROVED }
+          end
+
+          it "returns false" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be false
+          end
+        end
+
+        context "when review has request changes" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_REQUESTED_CHANGES }
+          end
+
+          it "returns true" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+          end
+        end
+
+        context "when review is commented" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_COMMENTED }
+          end
+
+          it "returns true" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+          end
         end
       end
 
-      context "when wants to request changes" do
-        it "returns true" do
-          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be true
+      context "when want to request changes for pr" do
+        let (:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_REQUEST_CHANGES }
+
+        context "when review is pending" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_PENDING }
+          end
+
+          it "returns true" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+          end
         end
-      end
-    end
 
-    context "when review status is approved" do
-      before do
-        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_APPROVED }
-      end
+        context "when review is approved" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_APPROVED }
+          end
 
-      context "when wants to approve" do
-        it "returns false" do
-          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_APPROVE)).to be false
+          it "returns true" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+          end
         end
-      end
 
-      context "when wants to request changes" do
-        it "returns false" do
-          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be false
+        context "when review has request changes" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_REQUESTED_CHANGES }
+          end
+
+          it "returns false" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be false
+          end
         end
-      end
-    end
-  end
 
-  describe "should_create?" do
-    context "when review status is pending" do
-      before do
-        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_PENDING }
-      end
+        context "when review is commented" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_COMMENTED }
+          end
 
-      context "when wants to approve" do
-        it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be true
-        end
-      end
-
-      context "when wants to request changes" do
-        it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be true
-        end
-      end
-    end
-
-    context "when review status is requested changes" do
-      before do
-        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_REQUESTED_CHANGES }
-      end
-
-      context "when wants to approve" do
-        it "returns false" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be false
+          it "returns true" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+          end
         end
       end
 
-      context "when wants to request changes" do
-        it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be false
+      context "when want to comment pr" do
+        let (:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_COMMENT }
+
+        context "when review is pending" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_PENDING }
+          end
+
+          it "returns true" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+          end
         end
-      end
-    end
 
-    context "when review status is approved" do
-      before do
-        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_APPROVED }
-      end
+        context "when review is approved" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_APPROVED }
+          end
 
-      context "when wants to approve" do
-        it "returns false" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be false
+          it "returns true" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+          end
         end
-      end
 
-      context "when wants to request changes" do
-        it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be true
+        context "when review has request changes" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_REQUESTED_CHANGES }
+          end
+
+          it "returns true" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+          end
+        end
+
+        context "when review is commented" do
+          before do
+            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_COMMENTED }
+          end
+
+          it "returns false" do
+            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be false
+          end
         end
       end
     end

--- a/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
@@ -2,7 +2,7 @@ require "danger/request_sources/github/github_review_resolver"
 require "danger/request_sources/github/github_review"
 
 RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
-  let(:review) { double("Danger::GitHub::Review") }
+  let(:review) { double(Danger::RequestSources::GitHubSource::Review) }
 
   describe "should_submit?" do
     context "when submission body the same as review has" do
@@ -11,7 +11,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
       end
 
       it "returns false" do
-        expect(described_class.should_submit?(review, Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE, "super body").to be false
+        expect(described_class.should_submit?(review, Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE, "super body")).to be false
       end
     end
 

--- a/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Danger::GitHub::ReviewResolver do
 
       context "when wants to approve" do
         it "returns false" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_false
+          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_APPROVE)).to be false
         end
       end
 
       context "when wants to request changes" do
-        it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_false
+        it "returns false" do
+          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be false
         end
       end
     end
@@ -30,14 +30,14 @@ RSpec.describe Danger::GitHub::ReviewResolver do
       end
 
       context "when wants to approve" do
-        it "returns false" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_true
+        it "returns true" do
+          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_APPROVE)).to be true
         end
       end
 
       context "when wants to request changes" do
         it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_true
+          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be true
         end
       end
     end
@@ -49,13 +49,13 @@ RSpec.describe Danger::GitHub::ReviewResolver do
 
       context "when wants to approve" do
         it "returns false" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_false
+          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_APPROVE)).to be false
         end
       end
 
       context "when wants to request changes" do
-        it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_false
+        it "returns false" do
+          expect(subject.should_submit?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be false
         end
       end
     end
@@ -68,14 +68,14 @@ RSpec.describe Danger::GitHub::ReviewResolver do
       end
 
       context "when wants to approve" do
-        it "returns false" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_true
+        it "returns true" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be true
         end
       end
 
       context "when wants to request changes" do
         it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_true
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be true
         end
       end
     end
@@ -87,13 +87,13 @@ RSpec.describe Danger::GitHub::ReviewResolver do
 
       context "when wants to approve" do
         it "returns false" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_false
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be false
         end
       end
 
       context "when wants to request changes" do
         it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_false
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be false
         end
       end
     end
@@ -105,13 +105,13 @@ RSpec.describe Danger::GitHub::ReviewResolver do
 
       context "when wants to approve" do
         it "returns false" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_false
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be false
         end
       end
 
       context "when wants to request changes" do
         it "returns true" do
-          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_true
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be true
         end
       end
     end

--- a/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
     end
 
     context "when submission body is different to review body" do
-      let (:submissions_body) { "submission body" }
+      let(:submission_body) { "submission body" }
 
       before do
         allow(review).to receive(:body).and_return "unique body"
       end
 
       context "when want to approve pr" do
-        let (:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE }
+        let(:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE }
 
         context "when review is pending" do
           before do
@@ -31,7 +31,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
           end
         end
 
@@ -41,7 +41,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns false" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be false
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be false
           end
         end
 
@@ -51,7 +51,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
           end
         end
 
@@ -61,13 +61,13 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
           end
         end
       end
 
       context "when want to request changes for pr" do
-        let (:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_REQUEST_CHANGES }
+        let(:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_REQUEST_CHANGES }
 
         context "when review is pending" do
           before do
@@ -75,7 +75,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
           end
         end
 
@@ -85,7 +85,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
           end
         end
 
@@ -95,7 +95,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns false" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be false
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be false
           end
         end
 
@@ -105,13 +105,13 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
           end
         end
       end
 
       context "when want to comment pr" do
-        let (:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_COMMENT }
+        let(:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_COMMENT }
 
         context "when review is pending" do
           before do
@@ -119,7 +119,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
           end
         end
 
@@ -129,7 +129,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
           end
         end
 
@@ -139,7 +139,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be true
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
           end
         end
 
@@ -149,7 +149,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
           end
 
           it "returns false" do
-            expect(described_class.should_submit?(review, submission_event, submissions_body)).to be false
+            expect(described_class.should_submit?(review, submission_event, submission_body)).to be false
           end
         end
       end

--- a/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
@@ -1,0 +1,119 @@
+require "danger/request_sources/github/github_review_resolver"
+require "danger/request_sources/github/github_review"
+
+RSpec.describe Danger::GitHub::ReviewResolver do
+  let(:review) { double("Danger::GitHub::Review") }
+  subject { Danger::GitHub::ReviewResolver.new(review) }
+
+  describe "should_submit?" do
+    context "when review status is pending" do
+      before do
+        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_PENDING }
+      end
+
+      context "when wants to approve" do
+        it "returns false" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_false
+        end
+      end
+
+      context "when wants to request changes" do
+        it "returns true" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_false
+        end
+      end
+    end
+
+    context "when review status is requested changes" do
+      before do
+        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_REQUESTED_CHANGES }
+      end
+
+      context "when wants to approve" do
+        it "returns false" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_true
+        end
+      end
+
+      context "when wants to request changes" do
+        it "returns true" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_true
+        end
+      end
+    end
+
+    context "when review status is approved" do
+      before do
+        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_APPROVED }
+      end
+
+      context "when wants to approve" do
+        it "returns false" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_false
+        end
+      end
+
+      context "when wants to request changes" do
+        it "returns true" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_false
+        end
+      end
+    end
+  end
+
+  describe "should_create?" do
+    context "when review status is pending" do
+      before do
+        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_PENDING }
+      end
+
+      context "when wants to approve" do
+        it "returns false" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_true
+        end
+      end
+
+      context "when wants to request changes" do
+        it "returns true" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_true
+        end
+      end
+    end
+
+    context "when review status is requested changes" do
+      before do
+        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_REQUESTED_CHANGES }
+      end
+
+      context "when wants to approve" do
+        it "returns false" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_false
+        end
+      end
+
+      context "when wants to request changes" do
+        it "returns true" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_false
+        end
+      end
+    end
+
+    context "when review status is approved" do
+      before do
+        allow(review).to receive(:status) { Danger::GitHub::Review::STATUS_APPROVED }
+      end
+
+      context "when wants to approve" do
+        it "returns false" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_APPROVE)).to be_false
+        end
+      end
+
+      context "when wants to request changes" do
+        it "returns true" do
+          expect(subject.should_create?(Danger::GitHub::Review::EVENT_REQUEST_CHANGES)).to be_true
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_resolver_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
       end
 
       it "returns false" do
-        expect(described_class.should_submit?(review, Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE, "super body")).to be false
+        expect(described_class.should_submit?(review, "super body")).to be false
       end
     end
 
@@ -22,136 +22,8 @@ RSpec.describe Danger::RequestSources::GitHubSource::ReviewResolver do
         allow(review).to receive(:body).and_return "unique body"
       end
 
-      context "when want to approve pr" do
-        let(:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE }
-
-        context "when review is pending" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_PENDING }
-          end
-
-          it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
-          end
-        end
-
-        context "when review is approved" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_APPROVED }
-          end
-
-          it "returns false" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be false
-          end
-        end
-
-        context "when review has request changes" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_REQUESTED_CHANGES }
-          end
-
-          it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
-          end
-        end
-
-        context "when review is commented" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_COMMENTED }
-          end
-
-          it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
-          end
-        end
-      end
-
-      context "when want to request changes for pr" do
-        let(:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_REQUEST_CHANGES }
-
-        context "when review is pending" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_PENDING }
-          end
-
-          it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
-          end
-        end
-
-        context "when review is approved" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_APPROVED }
-          end
-
-          it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
-          end
-        end
-
-        context "when review has request changes" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_REQUESTED_CHANGES }
-          end
-
-          it "returns false" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be false
-          end
-        end
-
-        context "when review is commented" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_COMMENTED }
-          end
-
-          it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
-          end
-        end
-      end
-
-      context "when want to comment pr" do
-        let(:submission_event) { Danger::RequestSources::GitHubSource::Review::EVENT_COMMENT }
-
-        context "when review is pending" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_PENDING }
-          end
-
-          it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
-          end
-        end
-
-        context "when review is approved" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_APPROVED }
-          end
-
-          it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
-          end
-        end
-
-        context "when review has request changes" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_REQUESTED_CHANGES }
-          end
-
-          it "returns true" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be true
-          end
-        end
-
-        context "when review is commented" do
-          before do
-            allow(review).to receive(:status) { Danger::RequestSources::GitHubSource::Review::STATUS_COMMENTED }
-          end
-
-          it "returns false" do
-            expect(described_class.should_submit?(review, submission_event, submission_body)).to be false
-          end
-        end
+      it "returns true" do
+        expect(described_class.should_submit?(review, "super body")).to be true
       end
     end
   end

--- a/spec/lib/danger/request_sources/github/github_review_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::Review, host: :github do
       messages = [Danger::Violation.new("Hi", true)]
       warnings = [Danger::Violation.new("I warn you", true)]
       errors = [Danger::Violation.new("This is bad, really bad", true)]
-      markdowns = [Danger::Markdown.new("Yo", true), Danger::Markdown.new(generate_description(warnings: warnings, errors: errors), true)]
+      markdowns = [Danger::Markdown.new("Yo", true)]
       expected_body = generate_comment(warnings: warnings,
                                        errors: errors,
                                        messages: messages,

--- a/spec/lib/danger/request_sources/github/github_review_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_spec.rb
@@ -1,6 +1,6 @@
 require "danger/request_sources/github/github_review"
 
-RSpec.describe Danger::RequestSources::GitHubSource::Review do
+RSpec.describe Danger::RequestSources::GitHubSource::Review, host: :github do
   let(:client) { double(Octokit::Client) }
 
   describe "submit" do
@@ -15,7 +15,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::Review do
       end
 
       it "approves the pr" do
-        expect(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, anger::RequestSources::GitHubSource::Review::EVENT_APPROVE, anything)
+        expect(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE, anything)
         subject.submit
       end
     end
@@ -44,7 +44,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::Review do
 
     describe "body" do
       it "returns an empty string" do
-        expect(subject.status).to eq ""
+        expect(subject.body).to eq ""
       end
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::Review do
 
     describe "body" do
       it "returns a body from request review json" do
-        expect(subject.status).to eq "Looks good"
+        expect(subject.body).to eq "Looks good"
       end
     end
   end

--- a/spec/lib/danger/request_sources/github/github_review_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Danger::RequestSources::GitHubSource::Review, host: :github do
 
     describe "id" do
       it "returns an id of request review" do
-        expect(subject.id).to eq 15629060
+        expect(subject.id).to eq 15_629_060
       end
     end
 

--- a/spec/lib/danger/request_sources/github/github_review_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_spec.rb
@@ -1,6 +1,10 @@
 require "danger/request_sources/github/github_review"
+require "danger/helpers/comments_helper"
+require "danger/helpers/comment"
 
 RSpec.describe Danger::RequestSources::GitHubSource::Review, host: :github do
+  include Danger::Helpers::CommentsHelper
+
   let(:client) { double(Octokit::Client) }
 
   describe "submit" do
@@ -8,9 +12,34 @@ RSpec.describe Danger::RequestSources::GitHubSource::Review, host: :github do
       Danger::RequestSources::GitHubSource::Review.new(client, stub_ci)
     end
 
-    context "when there are messages" do
+    before do
+      subject.start
+    end
+
+    it "submits review request with correct body" do
+      subject.message("Hi")
+      subject.markdown("Yo")
+      subject.warn("I warn you")
+      subject.fail("This is bad, really bad")
+
+      messages = [Danger::Violation.new("Hi", true)]
+      warnings = [Danger::Violation.new("I warn you", true)]
+      errors = [Danger::Violation.new("This is bad, really bad", true)]
+      markdowns = [Danger::Markdown.new("Yo", true), Danger::Markdown.new(generate_description(warnings: warnings, errors: errors), true)]
+      expected_body = generate_comment(warnings: warnings,
+                                       errors: errors,
+                                       messages: messages,
+                                       markdowns: markdowns,
+                                       previous_violations: parse_comment(""),
+                                       danger_id: "danger",
+                                       template: "github")
+
+      expect(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, Danger::RequestSources::GitHubSource::Review::EVENT_REQUEST_CHANGES, expected_body)
+      subject.submit
+    end
+
+    context "when there are only messages" do
       before do
-        subject.start
         subject.message("Hi")
       end
 
@@ -20,8 +49,64 @@ RSpec.describe Danger::RequestSources::GitHubSource::Review, host: :github do
       end
     end
 
-    it "suggests changes to the pr" do
-      allow(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, )
+    context "when there are only markdowns" do
+      before do
+        subject.markdown("Hi")
+      end
+
+      it "approves the pr" do
+        expect(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE, anything)
+        subject.submit
+      end
+    end
+
+    context "when there are only warnings" do
+      before do
+        subject.warn("Hi")
+      end
+
+      it "approves the pr" do
+        expect(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE, anything)
+        subject.submit
+      end
+    end
+
+    context "when there are only errors" do
+      before do
+        subject.fail("Yo")
+      end
+
+      it "suggests changes to the pr" do
+        expect(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, Danger::RequestSources::GitHubSource::Review::EVENT_REQUEST_CHANGES, anything)
+        subject.submit
+      end
+    end
+
+    context "when there are errors" do
+      before do
+        subject.message("Hi")
+        subject.markdown("Yo")
+        subject.warn("I warn you")
+        subject.fail("This is bad, really bad")
+      end
+
+      it "suggests changes to the pr" do
+        expect(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, Danger::RequestSources::GitHubSource::Review::EVENT_REQUEST_CHANGES, anything)
+        subject.submit
+      end
+    end
+
+    context "when there are no errors" do
+      before do
+        subject.message("Hi")
+        subject.markdown("Yo")
+        subject.warn("I warn you")
+      end
+
+      it "sapproves the pr" do
+        expect(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, Danger::RequestSources::GitHubSource::Review::EVENT_APPROVE, anything)
+        subject.submit
+      end
     end
   end
 

--- a/spec/lib/danger/request_sources/github/github_review_spec.rb
+++ b/spec/lib/danger/request_sources/github/github_review_spec.rb
@@ -1,0 +1,77 @@
+require "danger/request_sources/github/github_review"
+
+RSpec.describe Danger::RequestSources::GitHubSource::Review do
+  let(:client) { double(Octokit::Client) }
+
+  describe "submit" do
+    subject do
+      Danger::RequestSources::GitHubSource::Review.new(client, stub_ci)
+    end
+
+    context "when there are messages" do
+      before do
+        subject.start
+        subject.message("Hi")
+      end
+
+      it "approves the pr" do
+        expect(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, anger::RequestSources::GitHubSource::Review::EVENT_APPROVE, anything)
+        subject.submit
+      end
+    end
+
+    it "suggests changes to the pr" do
+      allow(client).to receive(:create_pull_request_review).with(stub_ci.repo_slug, stub_ci.pull_request_id, )
+    end
+  end
+
+  context "when initialized without review json" do
+    subject do
+      Danger::RequestSources::GitHubSource::Review.new(client, stub_ci)
+    end
+
+    describe "id" do
+      it "nil" do
+        expect(subject.id).to be nil
+      end
+    end
+
+    describe "status" do
+      it "returns a pending status" do
+        expect(subject.status).to eq Danger::RequestSources::GitHubSource::Review::STATUS_PENDING
+      end
+    end
+
+    describe "body" do
+      it "returns an empty string" do
+        expect(subject.status).to eq ""
+      end
+    end
+  end
+
+  context "when initialized with review json" do
+    let(:review_json) { JSON.parse(fixture("github_api/pr_review_response")) }
+
+    subject do
+      Danger::RequestSources::GitHubSource::Review.new(client, stub_ci, review_json)
+    end
+
+    describe "id" do
+      it "returns an id of request review" do
+        expect(subject.id).to eq 15629060
+      end
+    end
+
+    describe "status" do
+      it "returns a status from request review json" do
+        expect(subject.status).to eq Danger::RequestSources::GitHubSource::Review::STATUS_APPROVED
+      end
+    end
+
+    describe "body" do
+      it "returns a body from request review json" do
+        expect(subject.status).to eq "Looks good"
+      end
+    end
+  end
+end

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 require "danger/request_sources/github/github"
+require "danger/request_sources/github/octokit_pr_review"
 require "danger/ci_source/circle"
 require "danger/ci_source/travis"
 require "danger/danger_core/messages/violation"
@@ -108,6 +109,45 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
                               branch: "yolo_branch",
                                 path: "path/Dangerfile")
         expect(url).to eq("https://raw.githubusercontent.com/org_yo/danger/yolo_branch/path/Dangerfile")
+      end
+    end
+
+    describe "review" do
+      context "when already asked for review" do
+        before do
+          allow(@g.client).to receive(:pull_request_reviews).with("artsy/eigen", "800").and_return([])
+          @created_review = @g.review
+        end
+
+        it "returns the same review" do
+          expect(@g.review).to eq(@created_review)
+        end
+      end
+
+      context "when ask for review first time" do
+        context "when there are no danger review for PR" do
+          before do
+            allow(@g.client).to receive(:pull_request_reviews).with("artsy/eigen", "800").and_return([])
+          end
+
+          it "returns a newly created review" do
+            @review = @g.review
+            expect(@review.review_json).to be_nil
+          end
+        end
+
+        context "when there are danger review for PR" do
+          before do
+            pr_reviews_response = JSON.parse(fixture("github_api/pr_reviews_response"))
+            allow(@g.client).to receive(:pull_request_reviews).with("artsy/eigen", "800").and_return(pr_reviews_response)
+          end
+
+          it "returns the last review from danger" do
+            @review = @g.review
+            expect(@review.review_json).to_not be_nil
+            expect(@review.id).to eq(16237194)
+          end
+        end
       end
     end
 

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
           it "returns the last review from danger" do
             @review = @g.review
             expect(@review.review_json).to_not be_nil
-            expect(@review.id).to eq(16237194)
+            expect(@review.id).to eq(16_237_194)
           end
         end
       end

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 require "danger/ci_source/circle"
 require "danger/ci_source/travis"
 require "danger/danger_core/messages/violation"

--- a/spec/lib/danger/request_sources/request_source_spec.rb
+++ b/spec/lib/danger/request_sources/request_source_spec.rb
@@ -1,4 +1,4 @@
-require "danger/request_sources/github"
+require "danger/request_sources/github/github"
 
 RSpec.describe Danger::RequestSources::RequestSource, host: :github do
   describe "the base request source" do


### PR DESCRIPTION
Hi, there this PR addresses an issue I opened a while ago #684. 
The status is kinda work in progress, but there is already functionality that can be potentially used.

The changes in this PR:
* new module `GitHubSource` to combine the only GitHub related features;
* new class `Review` under the `GitHubSource` module, which represents the pull request review object;
* extension to `octokit` which I think will be used until the API is not final and then I will create a PR to octokit itself with extension for pr reviews;
 
Here is an example of how it looks like in `Dangerfile`:
```ruby
github.review.start
github.review.fail("I can fail your PR in a moment")
github.review.warn("I'm warning yo")
github.review.message("100 message")
github.review.submit
```

You can check how it looks in a PR [here](https://github.com/Antondomashnev/MyAmazingDangerPlayground/pull/7)

The open points I want to discuss:
1. The overall design approach
2. Do we need the summary message in review? My intention to create it was to write something if the PR is well done and danger approves it without any comment.
3. Do you think it could be used without inline comments as a first step or you prefer the feature with inline comments?

P.S. the changelog is not modified yet and I haven't cleaned the commit history yet.