### PR TITLE
Hk comment preview summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add your own contribution below
 
 * Use the colored2 gem instead of colored - orta
+* Add summary to dangers comment to show in e.g. slack - hanneskaeufler
 
 ## 4.1.1
 

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -1,8 +1,8 @@
 <!--
   <%- @tables.each do |table| -%>
-  <%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %><%= ": #{table[:content].first.message}" if table[:count] > 0 %>
+  <%= pluralize(table[:name], table[:count]) %><%= ": #{truncate(table[:content].first.message)}" if table[:count] > 0 %>
   <%- end -%>
-  <%= "#{@markdowns.size}" %> Markdown<%= "s" unless @markdowns.size == 1 %>
+  <%= pluralize("Markdown", @markdowns.size) %>
 --!>
 <%- @tables.each do |table| -%>
   <%- if table[:content].any? || table[:resolved].any? -%>
@@ -12,7 +12,7 @@
       <th width="50"></th>
       <th width="100%" data-danger-table="true" data-kind="<%= table[:name] %>">
         <%- if table[:count] > 0 -%>
-          <%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %>
+          <%= pluralize(table[:name], table[:count]) %>
         <%- else -%>
           :white_check_mark: <%= random_compliment %>
         <%- end -%>

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -1,3 +1,9 @@
+<!--
+  <%- @tables.each do |table| -%>
+  <%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %>
+  <%- end -%>
+  <%= "#{@markdowns.size}" %> Markdown<%= "s" unless @markdowns.size == 1 %>
+--!>
 <%- @tables.each do |table| -%>
   <%- if table[:content].any? || table[:resolved].any? -%>
 <table>

--- a/lib/danger/comment_generators/github.md.erb
+++ b/lib/danger/comment_generators/github.md.erb
@@ -1,6 +1,6 @@
 <!--
   <%- @tables.each do |table| -%>
-  <%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %>
+  <%= table[:count] %> <%= table[:name] %><%= "s" unless table[:count] == 1 %><%= ": #{table[:content].first.message}" if table[:count] > 0 %>
   <%- end -%>
   <%= "#{@markdowns.size}" %> Markdown<%= "s" unless @markdowns.size == 1 %>
 --!>

--- a/lib/danger/core_ext/string.rb
+++ b/lib/danger/core_ext/string.rb
@@ -12,4 +12,9 @@ class String
       tr("-".freeze, "_".freeze).
       downcase
   end
+
+  # @return [String] truncates string with ellipsis when exceeding the limit
+  def danger_truncate(limit)
+    length > limit ? "#{self[0...limit]}..." : self
+  end
 end

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -171,6 +171,15 @@ module Danger
 
         return NEW_REGEX.match(table)
       end
+
+      def pluralize(string, count)
+        string.danger_pluralize(count)
+      end
+
+      def truncate(string)
+        max_message_length = 30
+        string.danger_truncate(max_message_length)
+      end
     end
   end
 end

--- a/spec/lib/danger/core_ext/string_spec.rb
+++ b/spec/lib/danger/core_ext/string_spec.rb
@@ -18,4 +18,18 @@ RSpec.describe String do
       expect("ExampleClass".danger_underscore).to eq("example_class")
     end
   end
+
+  describe "#danger_truncate" do
+    it "truncates strings exceeding the limit" do
+      expect("super long string".danger_truncate(5)).to eq("super...")
+    end
+
+    it "does not truncate strings that are on the limit" do
+      expect("12345".danger_truncate(5)).to eq("12345")
+    end
+
+    it "does not truncate strings that are within the limit" do
+      expect("123".danger_truncate(5)).to eq("123")
+    end
+  end
 end

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -379,7 +379,8 @@ COMMENT
         warnings: [],
         errors: violations(["an error"]),
         messages: [],
-        previous_violations: previous_violations)
+        previous_violations: previous_violations
+      )
 
       expect(result.gsub(/\s+/, "")).to end_with(
         '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">anerror</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       summary = <<COMMENT
 <!--
   1 Error: This is an error
-  1 Warning: Violations that are very very very very long should be truncated
+  1 Warning: Violations that are very very ...
   1 Message: This is a message
   1 Markdown
 --!>

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -245,6 +245,28 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       expect(comment).to include("<td data-sticky=\"false\">This is a warning<br />\nin two lines</td>")
       expect(comment).to include("<td>:warning:</td>")
     end
+
+    it "produces a comment containing a summary" do
+      comment = dummy.generate_comment(
+        warnings: [violation("This is a warning")],
+        errors: [violation("This is an error", sticky: true)],
+        messages: [violation("This is a message")],
+        markdowns: [markdown("*Raw markdown*")],
+        danger_id: "my_danger_id",
+        template: "github"
+      )
+
+      summary = <<COMMENT
+<!--
+  1 Error
+  1 Warning
+  1 Message
+  1 Markdown
+--!>
+COMMENT
+
+      expect(comment).to include(summary)
+    end
   end
 
   describe "#generate_description" do
@@ -276,21 +298,21 @@ RSpec.describe Danger::Helpers::CommentsHelper do
     it "no warnings, no errors, no messages" do
       result = dummy.generate_comment(warnings: [], errors: [], messages: [])
       expect(result.gsub(/\s+/, "")).to eq(
-        '<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+        '<!--0Errors0Warnings0Messages0Markdowns--!><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
     end
 
     it "supports markdown code below the summary table" do
       result = dummy.generate_comment(warnings: violations(["ups"]), markdowns: violations(["### h3"]))
       expect(result.gsub(/\s+/, "")).to eq(
-        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">ups</td></tr></tbody></table>###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+        '<!--0Errors1Warning0Messages1Markdown--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">ups</td></tr></tbody></table>###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
     end
 
     it "supports markdown only without a table" do
       result = dummy.generate_comment(markdowns: violations(["### h3"]))
       expect(result.gsub(/\s+/, "")).to eq(
-        '###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+        '<!--0Errors0Warnings0Messages1Markdown--!>###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
     end
 
@@ -298,7 +320,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       result = dummy.generate_comment(warnings: violations(["my warning", "second warning"]), errors: [], messages: [])
       # rubocop:disable Metrics/LineLength
       expect(result.gsub(/\s+/, "")).to eq(
-        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky="false">secondwarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+        '<!--0Errors2Warnings0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky="false">secondwarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
       # rubocop:enable Metrics/LineLength
     end
@@ -308,7 +330,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       result = dummy.generate_comment(warnings: warnings, errors: [], messages: [])
       # rubocop:disable Metrics/LineLength
       expect(result.gsub(/\s+/, "")).to eq(
-        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></td></tr><tr><td>:warning:</td><tddata-sticky="false">second<strong>warning</strong></td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+        '<!--0Errors2Warnings0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></td></tr><tr><td>:warning:</td><tddata-sticky="false">second<strong>warning</strong></td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
       # rubocop:enable Metrics/LineLength
     end
@@ -318,7 +340,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       result = dummy.generate_comment(warnings: warnings, errors: [], messages: [])
       # rubocop:disable Metrics/LineLength
       expect(result.gsub(/\s+/, "")).to eq(
-        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></p><pre><code>something</code></pre><p>Hello</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+        '<!--0Errors1Warning0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></p><pre><code>something</code></pre><p>Hello</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
       # rubocop:enable Metrics/LineLength
     end
@@ -327,7 +349,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       result = dummy.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]), messages: [])
       # rubocop:disable Metrics/LineLength
       expect(result.gsub(/\s+/, "")).to eq(
-        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">someerror</td></tr></tbody></table><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+        '<!--1Error1Warning0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">someerror</td></tr></tbody></table><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
       # rubocop:enable Metrics/LineLength
     end
@@ -353,9 +375,14 @@ RSpec.describe Danger::Helpers::CommentsHelper do
 
     it "uncrosses violations that were on the list and happened again" do
       previous_violations = { error: violations(["an error"]) }
-      result = dummy.generate_comment(warnings: [], errors: violations(["an error"]), messages: [], previous_violations: previous_violations)
+      result = dummy.generate_comment(
+        warnings: [],
+        errors: violations(["an error"]),
+        messages: [],
+        previous_violations: previous_violations)
+
       expect(result.gsub(/\s+/, "")).to eq(
-        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">anerror</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+        '<!--1Error0Warnings0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">anerror</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
     end
 

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -297,30 +297,30 @@ COMMENT
   describe "#generate_comment" do
     it "no warnings, no errors, no messages" do
       result = dummy.generate_comment(warnings: [], errors: [], messages: [])
-      expect(result.gsub(/\s+/, "")).to eq(
-        '<!--0Errors0Warnings0Messages0Markdowns--!><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+      expect(result.gsub(/\s+/, "")).to end_with(
+        '<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
     end
 
     it "supports markdown code below the summary table" do
       result = dummy.generate_comment(warnings: violations(["ups"]), markdowns: violations(["### h3"]))
-      expect(result.gsub(/\s+/, "")).to eq(
-        '<!--0Errors1Warning0Messages1Markdown--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">ups</td></tr></tbody></table>###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+      expect(result.gsub(/\s+/, "")).to end_with(
+        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">ups</td></tr></tbody></table>###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
     end
 
     it "supports markdown only without a table" do
       result = dummy.generate_comment(markdowns: violations(["### h3"]))
-      expect(result.gsub(/\s+/, "")).to eq(
-        '<!--0Errors0Warnings0Messages1Markdown--!>###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+      expect(result.gsub(/\s+/, "")).to end_with(
+        '###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
     end
 
     it "some warnings, no errors" do
       result = dummy.generate_comment(warnings: violations(["my warning", "second warning"]), errors: [], messages: [])
       # rubocop:disable Metrics/LineLength
-      expect(result.gsub(/\s+/, "")).to eq(
-        '<!--0Errors2Warnings0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky="false">secondwarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+      expect(result.gsub(/\s+/, "")).to end_with(
+        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky="false">secondwarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
       # rubocop:enable Metrics/LineLength
     end
@@ -329,8 +329,8 @@ COMMENT
       warnings = violations(["a markdown [link to danger](https://github.com/danger/danger)", "second **warning**"])
       result = dummy.generate_comment(warnings: warnings, errors: [], messages: [])
       # rubocop:disable Metrics/LineLength
-      expect(result.gsub(/\s+/, "")).to eq(
-        '<!--0Errors2Warnings0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></td></tr><tr><td>:warning:</td><tddata-sticky="false">second<strong>warning</strong></td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+      expect(result.gsub(/\s+/, "")).to end_with(
+        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></td></tr><tr><td>:warning:</td><tddata-sticky="false">second<strong>warning</strong></td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
       # rubocop:enable Metrics/LineLength
     end
@@ -339,8 +339,8 @@ COMMENT
       warnings = violations(["a markdown [link to danger](https://github.com/danger/danger)\n\n```\nsomething\n```\n\nHello"])
       result = dummy.generate_comment(warnings: warnings, errors: [], messages: [])
       # rubocop:disable Metrics/LineLength
-      expect(result.gsub(/\s+/, "")).to eq(
-        '<!--0Errors1Warning0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></p><pre><code>something</code></pre><p>Hello</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+      expect(result.gsub(/\s+/, "")).to end_with(
+        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></p><pre><code>something</code></pre><p>Hello</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
       # rubocop:enable Metrics/LineLength
     end
@@ -348,8 +348,8 @@ COMMENT
     it "some warnings, some errors" do
       result = dummy.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]), messages: [])
       # rubocop:disable Metrics/LineLength
-      expect(result.gsub(/\s+/, "")).to eq(
-        '<!--1Error1Warning0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">someerror</td></tr></tbody></table><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+      expect(result.gsub(/\s+/, "")).to end_with(
+        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">someerror</td></tr></tbody></table><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
       # rubocop:enable Metrics/LineLength
     end
@@ -381,8 +381,8 @@ COMMENT
         messages: [],
         previous_violations: previous_violations)
 
-      expect(result.gsub(/\s+/, "")).to eq(
-        '<!--1Error0Warnings0Messages0Markdowns--!><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">anerror</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
+      expect(result.gsub(/\s+/, "")).to end_with(
+        '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">anerror</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">danger</a></p>'
       )
     end
 

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
 
     it "produces a comment containing a summary" do
       comment = dummy.generate_comment(
-        warnings: [violation("This is a warning")],
+        warnings: [violation("Violations that are very very very very long should be truncated")],
         errors: [violation("This is an error", sticky: true)],
         messages: [violation("This is a message")],
         markdowns: [markdown("*Raw markdown*")],
@@ -258,9 +258,9 @@ RSpec.describe Danger::Helpers::CommentsHelper do
 
       summary = <<COMMENT
 <!--
-  1 Error
-  1 Warning
-  1 Message
+  1 Error: This is an error
+  1 Warning: Violations that are very very very very long should be truncated
+  1 Message: This is a message
   1 Markdown
 --!>
 COMMENT


### PR DESCRIPTION
I totally like the idea of this html comment summary to show up in for example slack. As proposed in #701 and available in danger/danger-js#101.  This PR will add a 

```html
<!--
  1 Error: This is an error
  1 Warning: Violations that are very very ...
  1 Message: This is a message
  1 Markdown
--!>
```

comment to the top of dangers comment. What do you guys think?
