### PR TITLE
Hk misc cleanups #trivial

### DIFF
--- a/lib/danger/ci_source/support/local_pull_request.rb
+++ b/lib/danger/ci_source/support/local_pull_request.rb
@@ -3,8 +3,6 @@ module Danger
     attr_reader :pull_request_id, :sha
 
     def initialize(log_line)
-      @log_line = log_line
-
       @pull_request_id = log_line.match(/#(?<id>[0-9]+)/)[:id]
       @sha = log_line.split(" ".freeze).first
     end
@@ -12,9 +10,5 @@ module Danger
     def valid?
       pull_request_id && sha
     end
-
-    private
-
-    attr_reader :log_line
   end
 end

--- a/lib/danger/ci_source/support/pull_request_finder.rb
+++ b/lib/danger/ci_source/support/pull_request_finder.rb
@@ -22,11 +22,7 @@ module Danger
     attr_reader :specific_pull_request_id, :git_logs, :repo_slug, :remote
 
     def to_boolean(maybe_string)
-      if ["true", "1", "yes", "y", true].include?(maybe_string)
-        true
-      else
-        false
-      end
+      ["true", "1", "yes", "y", true].include?(maybe_string)
     end
 
     def check_if_any_pull_request!

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -3,8 +3,6 @@ require "danger/helpers/comments_parsing_helper"
 require "danger/helpers/emoji_mapper"
 require "danger/helpers/find_max_num_violations"
 
-# rubocop:disable Metrics/ModuleLength
-
 module Danger
   module Helpers
     module CommentsHelper
@@ -54,22 +52,6 @@ module Danger
         # Remove the outer `<p>`, the -5 represents a newline + `</p>`
         html = html[3...-5] if html.start_with? "<p>"
         Violation.new(html, violation.sticky, violation.file, violation.line)
-      end
-
-      def parse_comment(comment)
-        tables = parse_tables_from_comment(comment)
-        violations = {}
-        tables.each do |table|
-          match = danger_table?(table)
-          next unless match
-          title = match[1]
-          kind = table_kind_from_title(title)
-          next unless kind
-
-          violations[kind] = violations_from_table(table)
-        end
-
-        violations.reject { |_, v| v.empty? }
       end
 
       def table(name, emoji, violations, all_previous_violations, template: "github")
@@ -156,21 +138,6 @@ module Danger
       end
 
       private
-
-      GITHUB_OLD_REGEX = %r{<th width="100%"(.*?)</th>}im
-      NEW_REGEX = %r{<th.*data-danger-table="true"(.*?)</th>}im
-
-      def danger_table?(table)
-        # The old GitHub specific method relied on
-        # the width of a `th` element to find the table
-        # title and determine if it was a danger table.
-        # The new method uses a more robust data-danger-table
-        # tag instead.
-        match = GITHUB_OLD_REGEX.match(table)
-        return match if match
-
-        return NEW_REGEX.match(table)
-      end
 
       def pluralize(string, count)
         string.danger_pluralize(count)

--- a/lib/danger/helpers/comments_parsing_helper.rb
+++ b/lib/danger/helpers/comments_parsing_helper.rb
@@ -27,8 +27,9 @@ module Danger
         tables = parse_tables_from_comment(comment)
         violations = {}
         tables.each do |table|
-          next unless table =~ %r{<th width="100%"(.*?)</th>}im
-          title = Regexp.last_match(1)
+          match = danger_table?(table)
+          next unless match
+          title = match[1]
           kind = table_kind_from_title(title)
           next unless kind
 
@@ -46,6 +47,23 @@ module Danger
         elsif title =~ /message/i
           :message
         end
+      end
+
+      private
+
+      GITHUB_OLD_REGEX = %r{<th width="100%"(.*?)</th>}im
+      NEW_REGEX = %r{<th.*data-danger-table="true"(.*?)</th>}im
+
+      def danger_table?(table)
+        # The old GitHub specific method relied on
+        # the width of a `th` element to find the table
+        # title and determine if it was a danger table.
+        # The new method uses a more robust data-danger-table
+        # tag instead.
+        match = GITHUB_OLD_REGEX.match(table)
+        return match if match
+
+        return NEW_REGEX.match(table)
       end
     end
   end

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -138,6 +138,34 @@ RSpec.describe Danger::Helpers::CommentsHelper do
 
       expect(violations[:error].first.message).to include("Please include a CHANGELOG")
     end
+
+    it "parses a comment with error" do
+      comment = comment_fixture("comment_with_error")
+      results = dummy.parse_comment(comment)
+      expect(results[:error].map(&:message)).to eq(["Some error"])
+    end
+
+    it "parses a comment with error and warnings" do
+      comment = comment_fixture("comment_with_error_and_warnings")
+      results = dummy.parse_comment(comment)
+
+      expect(results[:error].map(&:message)).to eq(["Some error"])
+      expect(results[:warning].map(&:message)).to eq(["First warning", "Second warning"])
+    end
+
+    it "ignores non-sticky violations when parsing a comment" do
+      comment = comment_fixture("comment_with_non_sticky")
+      results = dummy.parse_comment(comment)
+      expect(results[:warning].map(&:message)).to eq(["First warning"])
+    end
+
+    it "parses a comment with error and warnings removing strike tag" do
+      comment = comment_fixture("comment_with_resolved_violation")
+      results = dummy.parse_comment(comment)
+
+      expect(results[:error].map(&:message)).to eq(["Some error"])
+      expect(results[:warning].map(&:message)).to eq(["First warning", "Second warning"])
+    end
   end
 
   describe "#table" do
@@ -420,51 +448,6 @@ COMMENT
       expect(message).to include("Errors")
       expect(message).to include("Warnings")
       expect(message).to include("Don't worry, everything is fixable.")
-    end
-  end
-
-  describe "comment parsing" do
-    it "detects the warning kind" do
-      expect(dummy.table_kind_from_title("1 Warning")).to eq(:warning)
-      expect(dummy.table_kind_from_title("2 Warnings")).to eq(:warning)
-    end
-
-    it "detects the error kind" do
-      expect(dummy.table_kind_from_title("1 Error")).to eq(:error)
-      expect(dummy.table_kind_from_title("2 Errors")).to eq(:error)
-    end
-
-    it "detects the warning kind" do
-      expect(dummy.table_kind_from_title("1 Message")).to eq(:message)
-      expect(dummy.table_kind_from_title("2 Messages")).to eq(:message)
-    end
-
-    it "parses a comment with error" do
-      comment = comment_fixture("comment_with_error")
-      results = dummy.parse_comment(comment)
-      expect(results[:error].map(&:message)).to eq(["Some error"])
-    end
-
-    it "parses a comment with error and warnings" do
-      comment = comment_fixture("comment_with_error_and_warnings")
-      results = dummy.parse_comment(comment)
-
-      expect(results[:error].map(&:message)).to eq(["Some error"])
-      expect(results[:warning].map(&:message)).to eq(["First warning", "Second warning"])
-    end
-
-    it "ignores non-sticky violations when parsing a comment" do
-      comment = comment_fixture("comment_with_non_sticky")
-      results = dummy.parse_comment(comment)
-      expect(results[:warning].map(&:message)).to eq(["First warning"])
-    end
-
-    it "parses a comment with error and warnings removing strike tag" do
-      comment = comment_fixture("comment_with_resolved_violation")
-      results = dummy.parse_comment(comment)
-
-      expect(results[:error].map(&:message)).to eq(["Some error"])
-      expect(results[:warning].map(&:message)).to eq(["First warning", "Second warning"])
     end
   end
 end


### PR DESCRIPTION
More feature-irrelevant cleanup. Looks like a bad merge long time ago duplicated the `parse_comment` method, which should really only live in the `comments_parsing_helper.rb`. Funny enough the methods diverged by now :)

This should sort things out. Rucocop is kinda awesome btw and told me we can now re-enable the ModuleLength check, ha! I am kinda confident in the test suite to delete rigorously, I think thats good, right ❓ 🎲 