### PR TITLE
Improved support for Bitbucket Branch Source Plugin (Jenkins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 -* Add your own contribution below
+* Improved support for [Bitbucket Branch Source Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+Branch+Source+Plugin) - bartoszj
 
 ## 4.2.1
 

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -62,8 +62,13 @@ module Danger
       self.repo_url = self.class.repo_url(env)
       self.pull_request_id = self.class.pull_request_id(env)
 
-      repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
-      self.repo_slug = repo_matches[2] unless repo_matches.nil?
+      repo_matches = self.repo_url.match(%r{(?:[\/:])projects\/([^\/.]+)\/repos\/([^\/.]+)}) # Bitbucket Server
+      if repo_matches
+        self.repo_slug = "#{repo_matches[1]}/#{repo_matches[2]}"
+      else
+        repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
+        self.repo_slug = repo_matches[2] unless repo_matches.nil?
+      end
     end
 
     def self.pull_request_id(env)

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -172,6 +172,11 @@ RSpec.describe Danger::Jenkins do
         valid_env["CHANGE_URL"] = "https://bitbucket.org/danger/danger/pull-requests/1"
         expect(described_class.repo_url(valid_env)).to eq("https://bitbucket.org/danger/danger")
       end
+
+      it "gets the BitBucket Server url" do
+        valid_env["CHANGE_URL"] = "https://bitbucket.example.com/projects/DANGER/repos/danger/pull-requests/1/overview"
+        expect(described_class.repo_url(valid_env)).to eq("https://bitbucket.example.com/projects/DANGER/repos/danger")
+      end
     end
 
     describe "#new" do
@@ -206,6 +211,12 @@ RSpec.describe Danger::Jenkins do
 
         expect(source.repo_slug).to eq("danger/danger")
       end
+
+      it "gets out a repo slug from a BitBucket Server" do
+        valid_env["CHANGE_URL"] = "https://bitbucket.example.com/projects/DANGER/repos/danger/pull-requests/1/overview"
+
+        expect(source.repo_slug).to eq("DANGER/danger")
+      end
     end
   end
 
@@ -216,6 +227,14 @@ RSpec.describe Danger::Jenkins do
 
     it "supports GitLab" do
       expect(source.supported_request_sources).to include(Danger::RequestSources::GitLab)
+    end
+
+    it "supports BitBucket Cloud" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::BitbucketCloud)
+    end
+
+    it "supports BitBucket Server" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::BitbucketServer)
     end
   end
 end


### PR DESCRIPTION
The [Bitbucket Branch Source Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+Branch+Source+Plugin) for Jenkins returns `CHANGE_URL` in format:
```
https://bitbucket.example.com/projects/PROJECT_NAME/repos/REPO_NAME/pull-requests/1/overview
```

Currently this url generates repo slug as `repos/REPO_NAME` which is incorrect and produce an issue with Bitbucket Server API because it cannot find project `repos`. This PR should fix this behaviour.