### PR TITLE
Fix support for github enterprise, no review possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 -* Add your own contribution below
 * Improved support for [Bitbucket Branch Source Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+Branch+Source+Plugin) - bartoszj
 * Refactoring of `danger local` and `danger pr` commands - hanneskaeufler
+* Fixes crash of `danger local` with github enterprise hosts - hanneskaeufler
 
 ## 4.2.1
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -3,7 +3,8 @@ require "octokit"
 require "danger/helpers/comments_helper"
 require "danger/helpers/comment"
 require "danger/request_sources/github/github_review"
-require "danger/request_sources/github/octokit_pr_review.rb"
+require "danger/request_sources/github/github_review_unsupported"
+require "danger/request_sources/github/octokit_pr_review"
 require "danger/request_sources/support/get_ignored_violation"
 
 module Danger
@@ -66,12 +67,17 @@ module Danger
 
       def review
         return @review unless @review.nil?
-        @review = client.pull_request_reviews(ci_source.repo_slug, ci_source.pull_request_id)
-          .map { |review_json| Danger::RequestSources::GitHubSource::Review.new(client, ci_source, review_json) }
-          .select(&:generated_by_danger?)
-          .last
-        @review ||= Danger::RequestSources::GitHubSource::Review.new(client, ci_source)
-        @review
+        begin
+          @review = client.pull_request_reviews(ci_source.repo_slug, ci_source.pull_request_id)
+            .map { |review_json| Danger::RequestSources::GitHubSource::Review.new(client, ci_source, review_json) }
+            .select(&:generated_by_danger?)
+            .last
+          @review ||= Danger::RequestSources::GitHubSource::Review.new(client, ci_source)
+          @review
+        rescue Octokit::NotFound
+          @review = Danger::RequestSources::GitHubSource::ReviewUnsupported.new
+          @review
+        end
       end
 
       def setup_danger_branches

--- a/lib/danger/request_sources/github/github_review_unsupported.rb
+++ b/lib/danger/request_sources/github/github_review_unsupported.rb
@@ -1,0 +1,24 @@
+# coding: utf-8
+module Danger
+  module RequestSources
+    module GitHubSource
+      class ReviewUnsupported
+        attr_reader :id, :body, :status, :review_json
+
+        def initialize; end
+
+        def start; end
+
+        def submit; end
+
+        def message(message, sticky = true, file = nil, line = nil); end
+
+        def warn(message, sticky = true, file = nil, line = nil); end
+
+        def fail(message, sticky = true, file = nil, line = nil); end
+
+        def markdown(message, file = nil, line = nil); end
+      end
+    end
+  end
+end

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -149,6 +149,18 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
           end
         end
       end
+
+      context "when running against github enterprise which doesn't support reviews" do
+        it "returns an unsupported review instance" do
+          allow(@g.client).to receive(:pull_request_reviews).with("artsy/eigen", "800").and_raise(Octokit::NotFound)
+
+          review = @g.review
+          expect(review).to respond_to(
+            :id, :body, :status, :review_json, :start, :submit, :message, :warn,
+            :fail, :markdown
+          )
+        end
+      end
     end
 
     describe "status message" do


### PR DESCRIPTION
The review api is in beta and only available on github.com. As all of a
request sources methods are called once in danger local, this would try
to make a request to the review api which would fail. This pr provides a noop
review object incase the call to the review api fails with a 404.
Fixes #725
