### PR TITLE
Hk danger pr remove duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 -* Add your own contribution below
 * Improved support for [Bitbucket Branch Source Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+Branch+Source+Plugin) - bartoszj
-* Refactoring of `danger local` command - hanneskaeufler
+* Refactoring of `danger local` and `danger pr` commands - hanneskaeufler
 
 ## 4.2.1
 

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -1,5 +1,6 @@
 require "danger/commands/local_helpers/http_cache"
 require "danger/commands/local_helpers/local_setup"
+require "danger/commands/local_helpers/pry_setup"
 require "faraday/http_cache"
 require "fileutils"
 require "octokit"
@@ -24,28 +25,9 @@ module Danger
 
       super
 
-      setup_pry if should_pry?(argv)
-    end
-
-    def should_pry?(argv)
-      argv.flag?("pry", false) && !@dangerfile_path.empty? && validate_pry_available
-    end
-
-    def setup_pry
-      File.delete "_Dangerfile.tmp" if File.exist? "_Dangerfile.tmp"
-      FileUtils.cp @dangerfile_path, "_Dangerfile.tmp"
-      File.open("_Dangerfile.tmp", "a") do |f|
-        f.write("binding.pry; File.delete(\"_Dangerfile.tmp\")")
+      if argv.flag?("pry", false)
+        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path)
       end
-      @dangerfile_path = "_Dangerfile.tmp"
-    end
-
-    def validate_pry_available
-      require "pry"
-    rescue LoadError
-      cork.warn "Pry was not found, and is required for 'danger local --pry'."
-      cork.print_warnings
-      abort
     end
 
     def validate!

--- a/lib/danger/commands/local_helpers/pry_setup.rb
+++ b/lib/danger/commands/local_helpers/pry_setup.rb
@@ -1,0 +1,31 @@
+module Danger
+  class PrySetup
+    def initialize(cork)
+      @cork = cork
+    end
+
+    def setup_pry(dangerfile_path)
+      return dangerfile_path if dangerfile_path.empty?
+      validate_pry_available
+      FileUtils.cp dangerfile_path, DANGERFILE_COPY
+      File.open(DANGERFILE_COPY, "a") do |f|
+        f.write("binding.pry; File.delete(\"#{DANGERFILE_COPY}\")")
+      end
+      DANGERFILE_COPY
+    end
+
+    private
+
+    attr_reader :cork
+
+    DANGERFILE_COPY = "_Dangerfile.tmp".freeze
+
+    def validate_pry_available
+      Kernel.require "pry"
+    rescue LoadError
+      cork.warn "Pry was not found, and is required for 'danger pr --pry'."
+      cork.print_warnings
+      abort
+    end
+  end
+end

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -1,4 +1,5 @@
 require "danger/commands/local_helpers/http_cache"
+require "danger/commands/local_helpers/pry_setup"
 require "faraday/http_cache"
 require "fileutils"
 require "octokit"
@@ -26,28 +27,9 @@ module Danger
 
       @dangerfile_path = dangerfile if File.exist?(dangerfile)
 
-      setup_pry if should_pry?(argv)
-    end
-
-    def should_pry?(argv)
-      argv.flag?("pry", false) && !@dangerfile_path.empty? && validate_pry_available
-    end
-
-    def setup_pry
-      File.delete "_Dangerfile.tmp" if File.exist? "_Dangerfile.tmp"
-      FileUtils.cp @dangerfile_path, "_Dangerfile.tmp"
-      File.open("_Dangerfile.tmp", "a") do |f|
-        f.write("binding.pry; File.delete(\"_Dangerfile.tmp\")")
+      if argv.flag?("pry", false)
+        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path)
       end
-      @dangerfile_path = "_Dangerfile.tmp"
-    end
-
-    def validate_pry_available
-      require "pry"
-    rescue LoadError
-      cork.warn "Pry was not found, and is required for 'danger pr --pry'."
-      cork.print_warnings
-      abort
     end
 
     def validate!

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -61,58 +61,32 @@ module Danger
       ENV["DANGER_USE_LOCAL_GIT"] = "YES"
       ENV["LOCAL_GIT_PR_URL"] = @pr_url if @pr_url
 
+      configure_octokit(ENV["DANGER_TMPDIR"] || Dir.tmpdir)
+
+      env = EnvironmentManager.new(ENV, cork)
+      dm = Dangerfile.new(env, cork)
+
+      LocalSetup.new(dm, cork).setup(verbose: verbose) do
+        dm.run(
+          Danger::EnvironmentManager.danger_base_branch,
+          Danger::EnvironmentManager.danger_head_branch,
+          @dangerfile_path,
+          nil,
+          nil
+        )
+      end
+    end
+
+    private
+
+    def configure_octokit(cache_dir)
       # setup caching for Github calls to hitting the API rate limit too quickly
-      cache_file = File.join(ENV["DANGER_TMPDIR"] || Dir.tmpdir, "danger_local_cache")
+      cache_file = File.join(cache_dir, "danger_local_cache")
       cache = HTTPCache.new(cache_file, clear_cache: @clear_http_cache)
       Octokit.middleware = Faraday::RackBuilder.new do |builder|
         builder.use Faraday::HttpCache, store: cache, serializer: Marshal, shared_cache: false
         builder.use Octokit::Response::RaiseError
         builder.adapter Faraday.default_adapter
-      end
-
-      env = EnvironmentManager.new(ENV, cork)
-      dm = Dangerfile.new(env, cork)
-      dm.init_plugins
-
-      source = dm.env.ci_source
-      if source.nil? or source.repo_slug.empty?
-        cork.puts "danger pr failed because it only works with GitHub projects at the moment. Sorry.".red
-        exit 0
-      end
-
-      gh = dm.env.request_source
-
-      cork.puts "Running your Dangerfile against this PR - https://#{gh.host}/#{source.repo_slug}/pull/#{source.pull_request_id}"
-
-      if verbose != true
-        cork.puts "Turning on --verbose"
-        dm.verbose = true
-      end
-
-      cork.puts
-
-      # We can use tokenless here, as it's running on someone's computer
-      # and is IP locked, as opposed to on the CI.
-      gh.support_tokenless_auth = true
-
-      begin
-        gh.fetch_details
-      rescue Octokit::NotFound
-        cork.puts "Local repository was not found on GitHub. If you're trying to test a private repository please provide a valid API token through " + "DANGER_GITHUB_API_TOKEN".yellow + " environment variable."
-        return
-      end
-
-      dm.env.request_source = gh
-
-      begin
-        dm.env.fill_environment_vars
-        dm.env.ensure_danger_branches_are_setup
-        dm.env.scm.diff_for_folder(".", from: Danger::EnvironmentManager.danger_base_branch, to: Danger::EnvironmentManager.danger_head_branch)
-
-        dm.parse(Pathname.new(@dangerfile_path))
-        dm.print_results
-      ensure
-        dm.env.clean_up
       end
     end
   end

--- a/spec/lib/danger/commands/local_helpers/pry_setup_spec.rb
+++ b/spec/lib/danger/commands/local_helpers/pry_setup_spec.rb
@@ -1,0 +1,42 @@
+require "danger/commands/local_helpers/pry_setup"
+
+RSpec.describe Danger::PrySetup do
+  before { cleanup }
+  after { cleanup }
+
+  describe "#setup_pry" do
+    it "copies the Dangerfile and appends bindings.pry" do
+      Dir.mktmpdir do |dir|
+        dangerfile_path = "#{dir}/Dangerfile"
+        File.write(dangerfile_path, "")
+
+        dangerfile_copy = described_class
+          .new(testing_ui)
+          .setup_pry(dangerfile_path)
+
+        expect(File).to exist(dangerfile_copy)
+        expect(File.read(dangerfile_copy)).to include("binding.pry; File.delete(\"_Dangerfile.tmp\")")
+      end
+    end
+
+    it "doesn't copy a nonexistant Dangerfile" do
+      described_class.new(testing_ui).setup_pry("")
+
+      expect(File).not_to exist("_Dangerfile.tmp")
+    end
+
+    it "warns when the pry gem is not installed" do
+      ui = testing_ui
+      expect(Kernel).to receive(:require).with("pry").and_raise(LoadError)
+
+      expect do
+        described_class.new(ui).setup_pry("Dangerfile")
+      end.to raise_error(SystemExit)
+      expect(ui.err_string).to include("Pry was not found")
+    end
+
+    def cleanup
+      File.delete "_Dangerfile.tmp" if File.exist? "_Dangerfile.tmp"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,14 +51,21 @@ end
 # rubocop:disable Lint/NestedMethodDefinition
 def testing_ui
   @output = StringIO.new
+  @err = StringIO.new
+
   def @output.winsize
     [20, 9999]
   end
 
-  cork = Cork::Board.new(out: @output)
+  cork = Cork::Board.new(out: @output, err: @err)
   def cork.string
     out.string.gsub(/\e\[([;\d]+)?m/, "")
   end
+
+  def cork.err_string
+    err.string.gsub(/\e\[([;\d]+)?m/, "")
+  end
+
   cork
 end
 # rubocop:enable Lint/NestedMethodDefinition


### PR DESCRIPTION
Well after #729 I learned that `dange pr` and `danger local` do basically exactly the same thing except for setting one ENV var differently. This means I could apply the same refactoring to `danger pr` as well as remove further duplication in both those commands by extracting the `PrySetup` stuff.

The code is extracted with only those two changes I believe:

* I removed the following line, it appears `FileUtils.cp` does not care if the file exists already.
```ruby
File.delete "_Dangerfile.tmp" if File.exist? "_Dangerfile.tmp"
```

* I went from `require "pry"` to `Kernel.require "pry"` so I could stub it in the unit test.

*this branch*
2231 / 2777 LOC (80.34%) covered
*master*
2218 / 2799 LOC (79.24%) covered