### PR TITLE
Fix inline comment url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 -* Add your own contribution below
+* Fix inline comment url when using github enterprise
 
 ## 4.2.2
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -381,7 +381,7 @@ module Danger
 
       # See the tests for examples of data coming in looks like
       def parse_message_from_row(row)
-        message_regexp = %r{(<(a |span data-)href="https://github.com/#{ci_source.repo_slug}/blob/[0-9a-z]+/(?<file>[^#]+)#L(?<line>[0-9]+)"(>[^<]*</a> - |/>))?(?<message>.*?)}im
+        message_regexp = %r{(<(a |span data-)href="https://#{host}/#{ci_source.repo_slug}/blob/[0-9a-z]+/(?<file>[^#]+)#L(?<line>[0-9]+)"(>[^<]*</a> - |/>))?(?<message>.*?)}im
         match = message_regexp.match(row)
 
         if match[:line]
@@ -393,7 +393,7 @@ module Danger
       end
 
       def markdown_link_to_message(message, hide_link)
-        url = "https://github.com/#{ci_source.repo_slug}/blob/#{pr_json['head']['sha']}/#{message.file}#L#{message.line}"
+        url = "https://#{host}/#{ci_source.repo_slug}/blob/#{pr_json['head']['sha']}/#{message.file}#L#{message.line}"
 
         if hide_link
           "<span data-href=\"#{url}\"/>"


### PR DESCRIPTION
The inline comment seems to use a fixed `https://github.com/` url regardless the `DANGER_GITHUB_HOST` setting, when using github enterprise, the inline comment fails and the link in comment is broken.

Try to use `host` in the url instead of `https://github.com/` 
