### PR TITLE
fix nil repo_slug when repo name contains dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 -* Add your own contribution below
+* Fix repo slug `nil` when using a GitHub repo that contains dot in name - johnlinvc
 
 ## 4.2.2
 

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -67,7 +67,7 @@ module Danger
         self.repo_slug = "#{repo_matches[1]}/#{repo_matches[2]}"
       else
         repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/]+)$})
-        self.repo_slug = repo_matches[2].gsub(%r{\.git$}, "") unless repo_matches.nil?
+        self.repo_slug = repo_matches[2].gsub(/\.git$/, "") unless repo_matches.nil?
       end
     end
 

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -66,8 +66,8 @@ module Danger
       if repo_matches
         self.repo_slug = "#{repo_matches[1]}/#{repo_matches[2]}"
       else
-        repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
-        self.repo_slug = repo_matches[2] unless repo_matches.nil?
+        repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/]+)$})
+        self.repo_slug = repo_matches[2].gsub(%r{\.git$}, "") unless repo_matches.nil?
       end
     end
 

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -210,7 +210,21 @@ RSpec.describe Danger::Jenkins do
         valid_env["GIT_URL"] = "https://gitlab.com/danger/danger.git"
 
         expect(source.repo_slug).to eq("danger/danger")
+
       end
+
+      it "get out a repo slug from a repo with dot in name" do
+        valid_env["GIT_URL"] = "https://gitlab.com/danger/danger.test.git"
+
+        expect(source.repo_slug).to eq("danger/danger.test")
+      end
+
+      it "get out a repo slug from a repo with .git in name" do
+        valid_env["GIT_URL"] = "https://gitlab.com/danger/danger.git.git"
+
+        expect(source.repo_slug).to eq("danger/danger.git")
+      end
+
 
       it "gets out a repo slug from a BitBucket Server" do
         valid_env["CHANGE_URL"] = "https://bitbucket.example.com/projects/DANGER/repos/danger/pull-requests/1/overview"

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -210,7 +210,6 @@ RSpec.describe Danger::Jenkins do
         valid_env["GIT_URL"] = "https://gitlab.com/danger/danger.git"
 
         expect(source.repo_slug).to eq("danger/danger")
-
       end
 
       it "get out a repo slug from a repo with dot in name" do
@@ -224,7 +223,6 @@ RSpec.describe Danger::Jenkins do
 
         expect(source.repo_slug).to eq("danger/danger.git")
       end
-
 
       it "gets out a repo slug from a BitBucket Server" do
         valid_env["CHANGE_URL"] = "https://bitbucket.example.com/projects/DANGER/repos/danger/pull-requests/1/overview"


### PR DESCRIPTION
## Purpose

Fix Issue when GitHub repo's name contains dot.
`repo_slug` became `nil` when the repo's name has a dot in it. (e.g.  johnlinvc/test-2.0)

## Changes

Handle repo name with dot correctly in `CISource::Jenkins#initialize`