### PR TITLE
only find diff position in current file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 -* Add your own contribution below
+* Fix find wrong diff position for inline comment
 
 ## 4.2.2
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -332,7 +332,7 @@ module Danger
 
       def find_position_in_diff(diff_lines, message)
         range_header_regexp = /@@ -([0-9]+),([0-9]+) \+(?<start>[0-9]+)(,(?<end>[0-9]+))? @@.*/
-        file_header_regexp = %r{ a/.*}
+        file_header_regexp = %r{^diff --git a/.*}
 
         pattern = "+++ b/" + message.file + "\n"
         file_start = diff_lines.index(pattern)
@@ -343,6 +343,9 @@ module Danger
         file_line = nil
 
         diff_lines.drop(file_start).each do |line|
+          # If we found the start of another file diff, we went too far
+          break if line.match file_header_regexp
+
           match = line.match range_header_regexp
 
           # file_line is set once we find the hunk the line is in
@@ -358,9 +361,6 @@ module Danger
           position += 1
 
           next unless match
-
-          # If we found the start of another file diff, we went too far
-          break if line.match file_header_regexp
 
           range_start = match[:start].to_i
           if match[:end]


### PR DESCRIPTION
what did i do:
- move `file_header_regexp` check to the beginning of `each` block. 
- make `file_header_regexp` more strict to avoid unexpected match.


For the following code:
https://github.com/danger/danger/blob/master/lib/danger/request_sources/github/github.rb#L360-L364

` line.match file_header_regexp` will never be matched since the `line`  must match to `range_header_regexp `. to reach this line of code.
And then `find_position_in_diff` will fall down to other files to find the diff line. when the other files happened to has a range just match the message's line number, a wrong inline comment will be created and finally caught an error from github.

