### PR TITLE
fix inline comment's fall back bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 * Fix find wrong diff position for inline comment - leonhartX 
 * gitlab project names dont need to be urlencoded anymore - hanneskaeufler
+* Fix inline comment failed to fall back when there is only inline comments - leonhartX
+* Fix only inline markdown comments will fall back to main comment even in diff's range - leonhartX
 
 ## 4.2.2
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -134,12 +134,6 @@ module Danger
           previous_violations = parse_comment(last_comment.body)
         end
 
-        main_violations = (warnings + errors + messages + markdowns).reject(&:inline?)
-        if previous_violations.empty? && main_violations.empty?
-          # Just remove the comment, if there's nothing to say.
-          delete_old_comments!(danger_id: danger_id)
-        end
-
         cmp = proc do |a, b|
           next -1 unless a.file
           next 1 unless b.file
@@ -161,6 +155,12 @@ module Danger
                                 markdowns: comment_markdowns,
                       previous_violations: previous_violations,
                                 danger_id: danger_id)
+
+        main_violations = comment_warnings + comment_errors + comment_messages + comment_markdowns
+        if previous_violations.empty? && main_violations.empty?
+          # Just remove the comment, if there's nothing to say.
+          delete_old_comments!(danger_id: danger_id)
+        end
 
         # If there are still violations to show
         unless main_violations.empty?
@@ -232,7 +232,7 @@ module Danger
 
       def submit_inline_comments!(warnings: [], errors: [], messages: [], markdowns: [], previous_violations: [], danger_id: "danger")
         # Avoid doing any fetchs if there's no inline comments
-        return if (warnings + errors + messages).select(&:inline?).empty?
+        return if (warnings + errors + messages + markdowns).select(&:inline?).empty?
 
         diff_lines = self.pr_diff.lines
         pr_comments = client.pull_request_comments(ci_source.repo_slug, ci_source.pull_request_id)

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       it "adds new comments inline" do
         allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
 
-        allow(@g.client).to receive(:create_pull_request_comment).with("artsy/eigen", "800", anything, "561827e46167077b5e53515b4b7349b8ae04610b", "CHANGELOG.md", 4)
+        expect(@g.client).to receive(:create_pull_request_comment).with("artsy/eigen", "800", anything, "561827e46167077b5e53515b4b7349b8ae04610b", "CHANGELOG.md", 4)
 
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_1).and_return({})
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_2).and_return({})
@@ -367,10 +367,23 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
         @g.update_pull_request!(warnings: [], errors: [], messages: [v])
       end
 
+      it "adds main comment when inline out of range" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return([])
+
+        v = Danger::Violation.new("Sure thing", true, "CHANGELOG.md", 10)
+        body = @g.generate_comment(warnings: [], errors: [], messages: [v])
+
+        expect(@g.client).not_to receive(:create_pull_request_comment).with("artsy/eigen", "800", anything, "561827e46167077b5e53515b4b7349b8ae04610b", "CHANGELOG.md", 10)
+        expect(@g.client).to receive(:add_comment).with("artsy/eigen", "800", body).and_return({})
+
+        @g.update_pull_request!(warnings: [], errors: [], messages: [v])
+      end
+
       it "crosses out sticky comments" do
         allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
 
-        allow(@g.client).to receive(:create_pull_request_comment).with("artsy/eigen", "800", anything, "561827e46167077b5e53515b4b7349b8ae04610b", "CHANGELOG.md", 4)
+        expect(@g.client).to receive(:create_pull_request_comment).with("artsy/eigen", "800", anything, "561827e46167077b5e53515b4b7349b8ae04610b", "CHANGELOG.md", 4)
 
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_1).and_return({})
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_2).and_return({})


### PR DESCRIPTION
Fix two bugs with inline comment:

- when violations is all inline comment, those message which is out of range will not shown  in main comment due to the wrong check of `main_violations`
- when there is only makrdowns inline comment, it won't be post as inline.