### PR TITLE
Only show inline in diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * gitlab project names dont need to be urlencoded anymore - hanneskaeufler
 * Fix inline comment failed to fall back when there is only inline comments - leonhartX
 * Fix only inline markdown comments will fall back to main comment even in diff's range - leonhartX
+* Add `dismiss_out_of_range_messages` option to `github` plugin to support inline comment only - leonhartX
 
 ## 4.2.2
 

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -224,10 +224,10 @@ module Danger
       paths.first(paths.count - 1).join(", ") + " & " + paths.last
     end
 
-    # @!group Github Misc
-    # Tell github to ingore any inline message whihc is not in diff's range, not post as main comment.
+    # @!group GitHub Misc
+    # Use to ignore inline messages which lay outside a diff's range, thereby not posting them in the main comment.
     # @param    [Bool] dismiss
-    #           Ingore out of range inline messages, defaults to `true`
+    #           Ignore out of range inline messages, defaults to `true`
     #
     # @return   [void]
     def dismiss_out_of_range_messages(dismiss: true)

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -224,6 +224,16 @@ module Danger
       paths.first(paths.count - 1).join(", ") + " & " + paths.last
     end
 
+    # @!group Github Misc
+    # Tell github to ingore any inline message whihc is not in diff's range, not post as main comment.
+    # @param    [Bool] dismiss
+    #           Ingore out of range inline messages, defaults to `true`
+    #
+    # @return   [void]
+    def dismiss_out_of_range_messages(dismiss: true)
+      @github.dismiss_out_of_range_messages = dismiss == true
+    end
+
     [:title, :body, :author, :labels, :json].each do |suffix|
       alias_method "mr_#{suffix}".to_sym, "pr_#{suffix}".to_sym
     end

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -12,7 +12,7 @@ module Danger
     class GitHub < RequestSource
       include Danger::Helpers::CommentsHelper
 
-      attr_accessor :pr_json, :issue_json, :support_tokenless_auth
+      attr_accessor :pr_json, :issue_json, :support_tokenless_auth, :dismiss_out_of_range_messages
 
       def self.env_vars
         ["DANGER_GITHUB_API_TOKEN"]
@@ -282,8 +282,8 @@ module Danger
 
           position = find_position_in_diff diff_lines, m
 
-          # Keep the change if it's line is not in the diff
-          next false if position.nil?
+          # Keep the change if it's line is not in the diff and not in dismiss mode
+          next self.dismiss_out_of_range_messages if position.nil?
 
           # Once we know we're gonna submit it, we format it
           if is_markdown_content

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -26,6 +26,7 @@ module Danger
         self.ci_source = ci_source
         self.environment = environment
         self.support_tokenless_auth = false
+        self.dismiss_out_of_range_messages = false
 
         @token = @environment["DANGER_GITHUB_API_TOKEN"]
       end

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
       expect(methods).to eq [
         :added_files, :api, :base_commit, :branch_for_base, :branch_for_head, :commits, :deleted_files,
-        :deletions, :diff_for_file, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :review, :scm_provider
+        :deletions, :diff_for_file, :dismiss_out_of_range_messages, :head_commit, :html_link, :import_dangerfile, :import_plugin, :info_for_file, :insertions, :lines_of_code, :modified_files, :mr_author, :mr_body, :mr_json, :mr_labels, :mr_title, :pr_author, :pr_body, :pr_diff, :pr_json, :pr_labels, :pr_title, :review, :scm_provider
       ]
     end
 

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -380,6 +380,21 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
         @g.update_pull_request!(warnings: [], errors: [], messages: [v])
       end
 
+      it "ingores out of range inline comments when in dismiss mode" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
+        expect(@g.client).not_to receive(:create_pull_request_comment).with("artsy/eigen", "800", anything, "561827e46167077b5e53515b4b7349b8ae04610b", "CHANGELOG.md", 10)
+        expect(@g.client).not_to receive(:add_comment).with("artsy/eigen", "800", anything)
+
+        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_1).and_return({})
+        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_2).and_return({})
+        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", main_issue_id).and_return({})
+
+        v = Danger::Violation.new("Sure thing", true, "CHANGELOG.md", 10)
+        @g.dismiss_out_of_range_messages = true
+        @g.update_pull_request!(warnings: [], errors: [], messages: [v])
+      end
+
       it "crosses out sticky comments" do
         allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
 


### PR DESCRIPTION
a simple approach for #742.
since the inline message is currently only available in github, add an property for `github request_source` and an interface in `github plugin` to set it.
