### PR TITLE
Make danger pr & local commands recognize -h to print help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 * Minor changes to the danger Gemfile - orta
 
-* Fix inline comment url when using github enterprise - leonhartX 
+* Make danger pr & local commands recognize -h to print help - Juanito Fatas
+* Fix inline comment url when using github enterprise - leonhartX
 * Fix repo slug `nil` when using a GitHub repo that contains dot in name - johnlinvc
 
-* Fix find wrong diff position for inline comment - leonhartX 
+* Fix find wrong diff position for inline comment - leonhartX
 * gitlab project names dont need to be urlencoded anymore - hanneskaeufler
 * Fix inline comment failed to fall back when there is only inline comments - leonhartX
 * Fix only inline markdown comments will fall back to main comment even in diff's range - leonhartX

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -20,8 +20,14 @@ module Danger
     end
 
     def initialize(argv)
+      show_help = true if argv.arguments == ["-h"]
+
       @pr_num = argv.option("use-merged-pr")
       @clear_http_cache = argv.flag?("clear-http-cache", false)
+
+      # Currently CLAide doesn't support short option like -h https://github.com/CocoaPods/CLAide/pull/60
+      # when user pass in -h, mimic the behavior of passing in --help.
+      argv = CLAide::ARGV.new ["--help"] if show_help
 
       super
 

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -19,9 +19,15 @@ module Danger
     end
 
     def initialize(argv)
+      show_help = true if argv.arguments == ["-h"]
+
       @pr_url = argv.shift_argument
       @clear_http_cache = argv.flag?("clear-http-cache", false)
       dangerfile = argv.option("dangerfile", "Dangerfile")
+
+      # Currently CLAide doesn't support short option like -h https://github.com/CocoaPods/CLAide/pull/60
+      # when user pass in -h, mimic the behavior of passing in --help.
+      argv = CLAide::ARGV.new ["--help"] if show_help
 
       super
 

--- a/spec/lib/danger/commands/local_spec.rb
+++ b/spec/lib/danger/commands/local_spec.rb
@@ -1,6 +1,19 @@
 require "danger/commands/local"
+require "open3"
 
 RSpec.describe Danger::Local do
+  context "prints help" do
+    it "danger local --help flag prints help" do
+      stdout, = Open3.capture3("danger local -h")
+      expect(stdout).to include "Usage"
+    end
+
+    it "danger local -h prints help" do
+      stdout, = Open3.capture3("danger local -h")
+      expect(stdout).to include "Usage"
+    end
+  end
+
   describe ".options" do
     it "contains extra options for local command" do
       result = described_class.options

--- a/spec/lib/danger/commands/pr_spec.rb
+++ b/spec/lib/danger/commands/pr_spec.rb
@@ -1,6 +1,19 @@
 require "danger/commands/pr"
+require "open3"
 
 RSpec.describe Danger::PR do
+  context "prints help" do
+    it "danger pr --help flag prints help" do
+      stdout, = Open3.capture3("danger pr -h")
+      expect(stdout).to include "Usage"
+    end
+
+    it "danger pr -h prints help" do
+      stdout, = Open3.capture3("danger pr -h")
+      expect(stdout).to include "Usage"
+    end
+  end
+
   describe ".summary" do
     it "returns the summary for PR command" do
       result = described_class.summary


### PR DESCRIPTION
Because CLAide doesn't support short switch at the moment (https://github.com/CocoaPods/CLAide/pull/60), so `danger pr -h` errors out. This PR fixes part of https://github.com/danger/danger/issues/744. `danger pr -h` will now print help text instead of error out. Also add this for `danger local`.

Before


```
$ danger pr -h
/Users/juanito-fatas/.gem/ruby/2.3.2/gems/danger-4.2.2/lib/danger/ci_source/local_git_repo.rb:61:in `raise_error_for_missing_remote': danger cannot find your git remote, please set a remote. And the repository must host on GitHub.com or GitHub Enterprise. (RuntimeError)
	from /Users/juanito-fatas/.gem/ruby/2.3.2/gems/danger-4.2.2/lib/danger/ci_source/local_git_repo.rb:43:in `initialize'
	from /Users/juanito-fatas/.gem/ruby/2.3.2/gems/danger-4.2.2/lib/danger/danger_core/environment_manager.rb:30:in `new'
	from /Users/juanito-fatas/.gem/ruby/2.3.2/gems/danger-4.2.2/lib/danger/danger_core/environment_manager.rb:30:in `initialize'
	from /Users/juanito-fatas/.gem/ruby/2.3.2/gems/danger-4.2.2/lib/danger/commands/pr.rb:49:in `new'
	from /Users/juanito-fatas/.gem/ruby/2.3.2/gems/danger-4.2.2/lib/danger/commands/pr.rb:49:in `run'
	from /Users/juanito-fatas/.gem/ruby/2.3.2/gems/claide-1.0.1/lib/claide/command.rb:334:in `run'
	from /Users/juanito-fatas/.gem/ruby/2.3.2/gems/danger-4.2.2/bin/danger:5:in `<top (required)>'
	from /Users/juanito-fatas/.gem/ruby/2.3.2/bin/danger:22:in `load'
	from /Users/juanito-fatas/.gem/ruby/2.3.2/bin/danger:22:in `<main>'


$ danger local -h
[!] Unknown command: `-h`

Usage:

    $ danger local

      Run the Dangerfile locally.

Options:

    --use-merged-pr=[#id]   The ID of an already merged PR inside your history to use
                            as a reference for the local run.
    --clear-http-cache      Clear the local http cache before running Danger locally.
    --pry                   Drop into a Pry shell after evaluating the Dangerfile.
```

After

```
$ danger pr -h
Usage:

    $ danger pr

      Run the Dangerfile against Pull Requests (works with forks, too).

Options:

    --clear-http-cache                  Clear the local http cache before running
                                        Danger locally.
    --pry                               Drop into a Pry shell after evaluating the
                                        Dangerfile.
    --dangerfile=<path/to/dangerfile>   The location of your Dangerfile

$ danger local -h
Usage:

    $ danger local

      Run the Dangerfile locally.

Options:

    --use-merged-pr=[#id]   The ID of an already merged PR inside your history to use
                            as a reference for the local run.
    --clear-http-cache      Clear the local http cache before running Danger locally.
    --pry                   Drop into a Pry shell after evaluating the Dangerfile.
```

Now will print help text instead of error out.

