### PR TITLE
Fix build: The slug of gitlab url no need to be escaped now #trivial

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ if RUBY_VERSION == "2.3.1"
   gem "chandler", git: "https://github.com/orta/chandler.git", branch: "token"
 end
 
-# This should get removed when > 3.7.0 comes out
-gem "gitlab", git: "https://github.com/NARKOZ/gitlab.git", branch: "master"
+gem "gitlab", "~> 3.7.0"
 
 gem "danger-junit", "~> 0.5"
 gem "rspec_junit_formatter", git: "https://github.com/JuanitoFatas/rspec_junit_formatter.git", branch: "dump-rspec_junit_formatter-failed-examples"

--- a/spec/fixtures/gitlab_api/merge_request_593728_comments_existing_danger_comment_response.json
+++ b/spec/fixtures/gitlab_api/merge_request_593728_comments_existing_danger_comment_response.json
@@ -5,13 +5,13 @@ Content-Type: application/json
 Content-Length: 4268
 Cache-Control: max-age=0, private, must-revalidate
 Etag: W/"96ab78e8b2a9877ef87a8949b18be8a6"
-Link: <https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes?id=k0nserv%2Fdanger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes?id=k0nserv%2Fdanger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
+Link: <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
 Status: 200 OK
 Vary: Origin
-X-Next-Page: 
+X-Next-Page:
 X-Page: 1
 X-Per-Page: 20
-X-Prev-Page: 
+X-Prev-Page:
 X-Request-Id: 57261818-cb24-48c9-b059-f94b73e04369
 X-Runtime: 0.244369
 X-Total: 5

--- a/spec/fixtures/gitlab_api/merge_request_593728_comments_no_stickies_response.json
+++ b/spec/fixtures/gitlab_api/merge_request_593728_comments_no_stickies_response.json
@@ -5,13 +5,13 @@ Content-Type: application/json
 Content-Length: 4269
 Cache-Control: max-age=0, private, must-revalidate
 Etag: W/"523873940d3665b9a0193652c6e8c578"
-Link: <https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes?id=k0nserv%2Fdanger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes?id=k0nserv%2Fdanger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
+Link: <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
 Status: 200 OK
 Vary: Origin
-X-Next-Page: 
+X-Next-Page:
 X-Page: 1
 X-Per-Page: 20
-X-Prev-Page: 
+X-Prev-Page:
 X-Request-Id: 4a069d3e-d12f-4b20-abcb-809e2a5bd35c
 X-Runtime: 0.310023
 X-Total: 5

--- a/spec/fixtures/gitlab_api/merge_request_593728_comments_response.json
+++ b/spec/fixtures/gitlab_api/merge_request_593728_comments_response.json
@@ -5,13 +5,13 @@ Content-Type: application/json
 Content-Length: 1507
 Cache-Control: max-age=0, private, must-revalidate
 Etag: W/"e810a3b50890dd0a5823597abbbf9fc9"
-Link: <https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes?id=k0nserv%2Fdanger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes?id=k0nserv%2Fdanger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
+Link: <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
 Status: 200 OK
 Vary: Origin
-X-Next-Page: 
+X-Next-Page:
 X-Page: 1
 X-Per-Page: 20
-X-Prev-Page: 
+X-Prev-Page:
 X-Request-Id: dee4a515-c1dd-4fec-8665-e6ce44bc6c41
 X-Runtime: 0.079596
 X-Total: 3

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
           messages: violations(["Test message"]),
           template: "gitlab"
         )
-        stub_request(:post, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes").with(
+        stub_request(:post, "https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes").with(
           body: "body=#{ERB::Util.url_encode(body)}",
           headers: expected_headers
         ).to_return(status: 200, body: "", headers: {})
@@ -195,7 +195,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
             },
             template: "gitlab"
           )
-          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
+          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes/13471894").with(
             body: "body=#{ERB::Util.url_encode(body)}",
             headers: expected_headers
           ).to_return(status: 200, body: "", headers: {})
@@ -214,7 +214,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
             messages: violations(["Test message"]),
             template: "gitlab"
           )
-          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
+          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes/13471894").with(
             body: "body=#{ERB::Util.url_encode(body)}",
             headers: expected_headers
           ).to_return(status: 200, body: "", headers: {})
@@ -239,7 +239,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
         end
 
         it "removes the previous danger comment if there are no new messages" do
-          stub_request(:delete, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
+          stub_request(:delete, "https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes/13471894").with(
             headers: expected_headers
           )
 

--- a/spec/support/gitlab_helper.rb
+++ b/spec/support/gitlab_helper.rb
@@ -27,29 +27,25 @@ module Danger
 
       def stub_merge_request(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        escaped_slug = CGI.escape(slug)
-        url = "https://gitlab.com/api/v3/projects/#{escaped_slug}/merge_request/#{merge_request_id}"
+        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_request/#{merge_request_id}"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 
       def stub_merge_request_changes(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        escaped_slug = CGI.escape(slug)
-        url = "https://gitlab.com/api/v3/projects/#{escaped_slug}/merge_request/#{merge_request_id}/changes"
+        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_request/#{merge_request_id}/changes"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 
       def stub_merge_request_commits(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        escaped_slug = CGI.escape(slug)
-        url = "https://gitlab.com/api/v3/projects/#{escaped_slug}/merge_request/#{merge_request_id}/commits"
+        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_request/#{merge_request_id}/commits"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 
       def stub_merge_request_comments(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        escaped_slug = CGI.escape(slug)
-        url = "https://gitlab.com/api/v3/projects/#{escaped_slug}/merge_requests/#{merge_request_id}/notes"
+        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}/notes"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
     end


### PR DESCRIPTION
This PR fixes the build (Follow up of https://github.com/danger/danger/pull/738).

- There are some more places no need to be escaped slug

  <details>
  <summary>Error</summary>
  ```
  WebMock::NetConnectNotAllowedError:
          Real HTTP connections are disabled. Unregistered request: GET https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes with headers {'Accept'=>'application/json', 'Private-Token'=>'a86e56d46ac78b'}

          You can stub this request with the following snippet:

          stub_request(:get, "https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes").
            with(:headers => {'Accept'=>'application/json', 'Private-Token'=>'a86e56d46ac78b'}).
            to_return(:status => 200, :body => "", :headers => {})

          registered request stubs:

          stub_request(:delete, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").
            with(:headers => {'Accept'=>'application/json', 'Private-Token'=>'a86e56d46ac78b'})
          stub_request(:get, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes").
            with(:headers => {'Accept'=>'application/json', 'Private-Token'=>'a86e56d46ac78b'})
          stub_request(:get, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_request/593728/commits").
            with(:headers => {'Accept'=>'application/json', 'Private-Token'=>'a86e56d46ac78b'})
          stub_request(:get, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_request/593728").
            with(:headers => {'Accept'=>'application/json', 'Private-Token'=>'a86e56d46ac78b'})
  ```
  </details>

- Use released gitlab gem 3.7.0
