### PR TITLE
fix wrong inline comment position at last line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contribution below
+* Fix find inline comment position at the last line of diff - leonhartX
 
 ## 4.3.0
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -372,7 +372,7 @@ module Danger
 
           # We are past the line position, just abort
           break if message.line.to_i < range_start
-          next unless message.line.to_i >= range_start && message.line.to_i <= range_end
+          next unless message.line.to_i >= range_start && message.line.to_i < range_end
 
           file_line = range_start
         end


### PR DESCRIPTION
in `find_position_in_diff`, the diff hunk's `range_end` should not contain the last line.
when a inline comment happened to be found at the `range_end` line, it get an invalid position which is out of the diff.

like this:
![diff](https://cloud.githubusercontent.com/assets/3993518/23390004/bc3a73ba-fdae-11e6-81f4-830b30290102.png)

the range is 9 - 15, not 9 - 16(which is `match[:start] + match[:end]`).
