### PR TITLE
Add inline comments to changed lines only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add your own contribution below
 * Fix find inline comment position at the last line of diff - leonhartX
+* Add inline comments to changed lines only when `dismiss_out_of_range_message` is enabled - leonhartX
 
 ## 4.3.0
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -353,7 +353,10 @@ module Danger
           # we need to count how many lines in new file we have
           # so we do it one by one ignoring the deleted lines
           if !file_line.nil? && !line.start_with?("-")
-            break if file_line == message.line
+            if file_line == message.line
+              file_line = nil if dismiss_out_of_range_messages && !line.start_with("+")
+              break
+            end
             file_line += 1
           end
 


### PR DESCRIPTION
With the `dismiss_out_of_range_messages` options, only comment within the diff's range will shown as inline comment.
But in diff's range does not mean it's a change since diff contains unchanged lines. so also ignore those comments at unchanged line too when `dismiss_out_of_range_messages` is enabled.