### PR TITLE
Fix a wrong doc in dangerfile_danger_plugin

### DIFF
--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -19,7 +19,7 @@ module Danger
   #
   # @example Run a Dangerfile from inside a sub-folder
   #
-  #          danger.import_dangerfile(file: "danger/Dangerfile.private")
+  #          danger.import_dangerfile(path: "path/to/Dangerfile")
   #
   # @example Run a Dangerfile from inside a gem
   #


### PR DESCRIPTION
In import_dangerfile, opts `file:` does not work, but `path:` works. 