### PR TITLE
Add buddybuild documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add your own contribution below
 * Fix find inline comment position at the last line of diff - leonhartX
 * Add inline comments to changed lines only when `dismiss_out_of_range_message` is enabled - leonhartX
+* Add documentation for [buddybuild](https://www.buddybuild.com) - sunshinejr
 
 ## 4.3.0
 

--- a/lib/danger/ci_source/buddybuild.rb
+++ b/lib/danger/ci_source/buddybuild.rb
@@ -1,6 +1,22 @@
 module Danger
   # ### CI Setup
+  #
+  # Buddybuild has an integration for Danger already built-in. 
+  # What you need to do is to upload your `Gemfile` and `Dangerfile` to 
+  # the server and you should be all set-up. However, if you want to use 
+  # different bot for Danger, you can do it with token setup described below.
+  #
   # ### Token Setup
+  #
+  # Login to buddybuild and select your app. Go to your *App Settings* and 
+  # in the *Build Settings* menu on the left, choose *Environment Variables*. 
+  #
+  # #### GitHub
+  # Add the `DANGER_GITHUB_API_TOKEN` to your build user's ENV.
+  #
+  # #### GitLab
+  # Add the `DANGER_GITLAB_API_TOKEN` to your build user's ENV.
+
   class Buddybuild < CI
     def self.validates_as_ci?(env)
       false

--- a/lib/danger/ci_source/buddybuild.rb
+++ b/lib/danger/ci_source/buddybuild.rb
@@ -1,0 +1,20 @@
+module Danger
+  # ### CI Setup
+  # ### Token Setup
+  class Buddybuild < CI
+    def self.validates_as_ci?(env)
+      false
+    end
+
+    def self.validates_as_pr?(env)
+      false
+    end
+
+    def initialize(env)
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= []
+    end
+  end
+end

--- a/lib/danger/ci_source/buddybuild.rb
+++ b/lib/danger/ci_source/buddybuild.rb
@@ -1,15 +1,15 @@
 module Danger
   # ### CI Setup
   #
-  # Buddybuild has an integration for Danger already built-in. 
-  # What you need to do is to upload your `Gemfile` and `Dangerfile` to 
-  # the server and you should be all set-up. However, if you want to use 
+  # Buddybuild has an integration for Danger already built-in.
+  # What you need to do is to upload your `Gemfile` and `Dangerfile` to
+  # the server and you should be all set-up. However, if you want to use
   # different bot for Danger, you can do it with token setup described below.
   #
   # ### Token Setup
   #
-  # Login to buddybuild and select your app. Go to your *App Settings* and 
-  # in the *Build Settings* menu on the left, choose *Environment Variables*. 
+  # Login to buddybuild and select your app. Go to your *App Settings* and
+  # in the *Build Settings* menu on the left, choose *Environment Variables*.
   #
   # #### GitHub
   # Add the `DANGER_GITHUB_API_TOKEN` to your build user's ENV.
@@ -18,16 +18,15 @@ module Danger
   # Add the `DANGER_GITLAB_API_TOKEN` to your build user's ENV.
 
   class Buddybuild < CI
-    def self.validates_as_ci?(env)
+    def self.validates_as_ci?(_)
       false
     end
 
-    def self.validates_as_pr?(env)
+    def self.validates_as_pr?(_)
       false
     end
 
-    def initialize(env)
-    end
+    def initialize(_) end
 
     def supported_request_sources
       @supported_request_sources ||= []

--- a/spec/lib/danger/ci_sources/ci_source_spec.rb
+++ b/spec/lib/danger/ci_sources/ci_source_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Danger::CI do
         [
           "Danger::LocalGitRepo",
           "Danger::Bitrise",
+          "Danger::Buddybuild",
           "Danger::Buildkite",
           "Danger::CircleCI",
           "Danger::Drone",


### PR DESCRIPTION
Hey guys! 🎉

So this is my first PR here, and first in ruby, so I'm sorry for everything wrong here :D

Basically, Danger can be used with buddybuild and it is pretty easy! But on the website there was no info about it, so I've decided to make a new `ci_source` just with documentation. Dunno if the ruby code is correct here, so I'd love a review for that. I've also added a caveat that you can change the bot that is used by Danger (simply by adding a new token to the ENV vars), but I had the chance of testing it only using GitHub project - but you can also create projects using GitLab and Bitbucket. If anyone has any info about these two, it would be awesome as well.

Cheers! 

**Edit:** Also I'm not sure, should I write test spec for this class?