### PR TITLE
Use underlined instead of underline

### DIFF
--- a/lib/danger/commands/init_helpers/interviewer.rb
+++ b/lib/danger/commands/init_helpers/interviewer.rb
@@ -33,7 +33,7 @@ module Danger
     end
 
     def link(url)
-      say " -> " + url.underline + "\n"
+      say " -> " + url.underlined + "\n"
     end
 
     def pause(time)
@@ -57,7 +57,7 @@ module Danger
 
       print_info = proc do
         possible_answers.each_with_index do |answer, i|
-          the_answer = i.zero? ? answer.underline : answer
+          the_answer = i.zero? ? answer.underlined : answer
           ui.print " " + the_answer
           ui.print(" /") if i != possible_answers.length - 1
         end

--- a/spec/lib/danger/commands/init_helpers/interviewer_spec.rb
+++ b/spec/lib/danger/commands/init_helpers/interviewer_spec.rb
@@ -1,0 +1,18 @@
+require 'rspec'
+require 'danger/commands/init_helpers/interviewer'
+
+RSpec.describe Danger::Interviewer do
+  let(:cork) { double('cork') }
+  let(:interviewer) { Danger::Interviewer.new(cork) }
+
+  describe '#link' do
+    before do
+      allow(interviewer).to receive(:say)
+    end
+
+    it 'link URL is decorated' do
+      interviewer.link('http://danger.systems/')
+      expect(interviewer).to have_received(:say).with(" -> \e[4mhttp://danger.systems/\e[0m\n")
+    end
+  end
+end


### PR DESCRIPTION
#trivial

## Context 

I executed `danger init` on latest danger. So this error was raised.

```
Step 2: Creating a GitHub account

In order to get the most out of Danger, I'd recommend giving her the ability to post in
the code-review comment section.

IMO, it's best to do this by using the private mode of your browser. Create an account like
DangerplaygroundBot, and don't forget a cool robot avatar.

Here are great resources for creative commons images of robots:
bundler: failed to load command: danger (/Users/giginet/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/bin/danger)
NoMethodError: undefined method `underline' for #<String:0x007fcf0ead95a0>
Did you mean?  underlined
               underlined!
  /Users/giginet/.ghq/github.com/danger/danger/lib/danger/commands/init_helpers/interviewer.rb:36:in `link'
  /Users/giginet/.ghq/github.com/danger/danger/lib/danger/commands/init.rb:91:in `setup_github_account'
  /Users/giginet/.ghq/github.com/danger/danger/lib/danger/commands/init.rb:36:in `run'
  /Users/giginet/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/claide-1.0.1/lib/claide/command.rb:334:in `run'
  /Users/giginet/.ghq/github.com/danger/danger/bin/danger:5:in `<top (required)>'
  /Users/giginet/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/bin/danger:22:in `load'
  /Users/giginet/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/bin/danger:22:in `<top (required)>'
```

## Why

In `colored2`, String extension renamed to `underscored`.

https://github.com/kigster/colored2/blob/master/lib/colored2/codes.rb#L19

When dependencies were migrated, this calling hadn't been modified.