### PR TITLE
Fix diff_for_file for added files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too.
 
-* #788 Fix `diff_for_file` for added files - Allen Wu
+* #788 Fix `diff_for_file` for added files - allewun
 
 
 ## 5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## master
 
-* Add your own contributions to the next release  on the line below this, please include your name too.
+* Add your own contributions to the next release on the line below this, please include your name too.
 
-*
+* #788 Fix `diff_for_file` for added files - Allen Wu
 
 
 ## 5.0.1

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -112,7 +112,7 @@ module Danger
     # @return [Git::Diff::DiffFile] from the gem `git`
     #
     def diff_for_file(file)
-      modified_files.include?(file) ? @git.diff[file] : nil
+      (added_files + modified_files).include?(file) ? @git.diff[file] : nil
     end
 
     # @!group Git Metadata

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm.env.scm.diff_for_folder(dir, from: "master", to: "new")
 
         expect(@dm.git.added_files).to eq(["file2"])
+        expect(@dm.git.diff_for_file("file2")).not_to be_nil
       end
     end
 


### PR DESCRIPTION
Looks like a previous change caused `git.diff_for_file(file)` to return `nil` if the file was an _added file_.