### PR TITLE
DroneCI 0.4+ support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
+* Improved DroneCI support for versions 0.4+ - [@fmartingr](https://github.com/fmartingr)
 
 ## 5.0.3
 

--- a/lib/danger/ci_source/drone.rb
+++ b/lib/danger/ci_source/drone.rb
@@ -47,7 +47,7 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_slug = env["DRONE_REPO_OWNER"] + "/" + env["DRONE_REPO_NAME"]
+      self.repo_slug = "#{env['DRONE_REPO_OWNER']}/#{env['DRONE_REPO_NAME']}"
       self.pull_request_id = env["DRONE_PULL_REQUEST"]
       self.repo_url = env["DRONE_REPO_LINK"]
     end

--- a/lib/danger/ci_source/drone.rb
+++ b/lib/danger/ci_source/drone.rb
@@ -11,19 +11,31 @@ module Danger
   #  ``` shell
   #   build:
   #     image: golang
-  #       commands:
-  #         - ...
-  #         - bundle exec danger
+  #     commands:
+  #       - ...
+  #       - bundle exec danger
   #  ```
   #
   # ### Token Setup
   #
-  # As this is self-hosted, you will need to add the `DANGER_GITHUB_API_TOKEN` to your build user's ENV. The alternative
-  # is to pass in the token as a prefix to the command `DANGER_GITHUB_API_TOKEN="123" bundle exec danger`.
+  # As this is self-hosted, you will need to expose the `DANGER_GITHUB_API_TOKEN` as a secret to your
+  # builds as having the API Token in plain text is a security issue.
   #
+  # Drone secrets: http://readme.drone.io/usage/secret-guide/
+  # NOTE: This is a new syntax in DroneCI 0.6+
+  #
+  # ```
+  #   build:
+  #     image: golang
+  #     secrets:
+  #       - DANGER_GITHUB_API_TOKEN
+  #     commands:
+  #       - ...
+  #       - bundle exec danger
+  # ```
   class Drone < CI
     def self.validates_as_ci?(env)
-      env.key? "DRONE_REPO"
+      env.key? "DRONE_REPO_OWNER" and env.key? "DRONE_REPO_NAME"
     end
 
     def self.validates_as_pr?(env)
@@ -35,9 +47,9 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_slug = env["DRONE_REPO"]
+      self.repo_slug = env["DRONE_REPO_OWNER"] + "/" + env["DRONE_REPO_NAME"]
       self.pull_request_id = env["DRONE_PULL_REQUEST"]
-      self.repo_url = GitRepo.new.origins # Drone doesn't provide a repo url env variable :/
+      self.repo_url = GitRepo.new.origins
     end
   end
 end

--- a/lib/danger/ci_source/drone.rb
+++ b/lib/danger/ci_source/drone.rb
@@ -19,7 +19,7 @@ module Danger
   # ### Token Setup
   #
   # As this is self-hosted, you will need to expose the `DANGER_GITHUB_API_TOKEN` as a secret to your
-  # builds as having the API Token in plain text is a security issue.
+  # builds:
   #
   # Drone secrets: http://readme.drone.io/usage/secret-guide/
   # NOTE: This is a new syntax in DroneCI 0.6+

--- a/lib/danger/ci_source/drone.rb
+++ b/lib/danger/ci_source/drone.rb
@@ -49,7 +49,7 @@ module Danger
     def initialize(env)
       self.repo_slug = env["DRONE_REPO_OWNER"] + "/" + env["DRONE_REPO_NAME"]
       self.pull_request_id = env["DRONE_PULL_REQUEST"]
-      self.repo_url = GitRepo.new.origins
+      self.repo_url = env["DRONE_REPO_LINK"]
     end
   end
 end

--- a/spec/lib/danger/ci_sources/drone_spec.rb
+++ b/spec/lib/danger/ci_sources/drone_spec.rb
@@ -3,7 +3,8 @@ require "danger/ci_source/drone"
 RSpec.describe Danger::Drone do
   it "validates when DRONE variable is set" do
     env = { "DRONE" => "true",
-            "DRONE_REPO" => "danger/danger",
+            "DRONE_REPO_NAME" => "danger",
+            "DRONE_REPO_OWNER" => "danger",
             "DRONE_PULL_REQUEST" => 1 }
     expect(Danger::Drone.validates_as_ci?(env)).to be true
   end
@@ -15,14 +16,16 @@ RSpec.describe Danger::Drone do
 
   it "does not validate PR when DRONE_PULL_REQUEST is set to non int value" do
     env = { "CIRCLE" => "true",
-            "DRONE_REPO" => "danger/danger",
+            "DRONE_REPO_NAME" => "danger",
+            "DRONE_REPO_OWNER" => "danger",
             "DRONE_PULL_REQUEST" => "maku" }
     expect(Danger::Drone.validates_as_pr?(env)).to be false
   end
 
   it "does not validate  PRwhen DRONE_PULL_REQUEST is set to non positive int value" do
     env = { "CIRCLE" => "true",
-            "DRONE_REPO" => "danger/danger",
+            "DRONE_REPO_NAME" => "danger",
+            "DRONE_REPO_OWNER" => "danger",
             "DRONE_PULL_REQUEST" => -1 }
     expect(Danger::Drone.validates_as_pr?(env)).to be false
   end
@@ -36,7 +39,10 @@ RSpec.describe Danger::Drone do
   end
 
   it "gets the repo address" do
-    env = { "DRONE_REPO" => "orta/danger" }
+    env = {
+      "DRONE_REPO_NAME" => "danger",
+      "DRONE_REPO_OWNER" => "orta"
+    }
 
     result = Danger::Drone.new(env)
 
@@ -47,7 +53,8 @@ RSpec.describe Danger::Drone do
     env = {
       "DRONE" => "true",
       "DRONE_PULL_REQUEST" => "800",
-      "DRONE_REPO" => "artsy/eigen"
+      "DRONE_REPO_NAME" => "eigen",
+      "DRONE_REPO_OWNER" => "artsy"
     }
     result = Danger::Drone.new(env)
 

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -1,6 +1,6 @@
 require "danger/danger_core/executor"
 
-# If you cannot find a method, please check spec/support/executor_helper.rb.
+# If you cannot find a method, please check spec/support/ci_helper.rb.
 RSpec.describe Danger::Executor, use: :ci_helper do
   describe "#validate!" do
     context "with CI + is a PR" do

--- a/spec/support/ci_helper.rb
+++ b/spec/support/ci_helper.rb
@@ -40,7 +40,8 @@ module Danger
 
       def with_drone_setup_and_is_a_pull_request
         system_env = {
-          "DRONE_REPO" => "true",
+          "DRONE_REPO_NAME" => "danger",
+          "DRONE_REPO_OWNER" => "danger",
           "DRONE_PULL_REQUEST" => "42"
         }
 

--- a/spec/support/gitlab_helper.rb
+++ b/spec/support/gitlab_helper.rb
@@ -11,7 +11,8 @@ module Danger
       def stub_env
         {
           "DRONE" => true,
-          "DRONE_REPO" => "k0nserv/danger-test",
+          "DRONE_REPO_OWNER" => "k0nserv",
+          "DRONE_REPO_NAME" => "danger-test",
           "DRONE_PULL_REQUEST" => "593728",
           "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
         }


### PR DESCRIPTION
## Summary
Updating the drone CI source library to support versions 0.4+ because some syntax seems to have changed and more environment parameters are available.

## Comments
- `spec/support/gitlab_helpers.rb` depends on DroneCI parameters. I think this is not a good practice. Maybe using a dedicated CI source for testing?
- There are 20 tests failing (both on master and my branch) from gitlab. Not sure if they are like that on purpose, but I think all of them were failed mock requests.
- I'm new to Ruby, if there's something that is not good practice or can be improved please tell me.
- It seems that DroneCI changes stuff on every minor release, so having backwards compatibility is going to be a pain.

## TODO
- [x] Environment variables differ from 0.5: `DRONE_REPO` is only the name of the repository, using `DRONE_REPO_OWNER/DRONE_REPO_NAME` is better.
- [x] Check if 0.5 have `DRONE_REPO_OWNER`/`DRONE_REPO_NAME`.
- [x] Update documentation to encourage users to pass the `DANGER_GITHUB_API_TOKEN` via a secret instead of plain text in the `.drone.yml` file.
- [x] Danger doesn't seem to find the pull request properly in 0.6, clones the origin repository. Maybe something related to `repo_url`?
- [x] Fix all tests
- [x] Rebase

Is there any gitter/irc channel to talk/ask questions about danger?
