### PR TITLE
Gitlab gem update + Make chandler run on `rake release`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,3 @@ script:
   - bundle exec danger --verbose
   - bundle exec danger init --mousey --impatient
 
-deploy:
-  provider: script
-  script: bin/chandler
-  on:
-    branch: "master"
-    tag: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
-*
+* Automates the add GitHub release notes when we release via [chandler](https://github.com/mattbrictson/chandler) - orta
+* Updates Danger's tests to use the gitlab 4.0 gem - orta
 
 ## 5.0.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,8 @@
 source "https://rubygems.org"
 
 gemspec
+gem "chandler"
 gem "danger-gitlab"
-
-if RUBY_VERSION == "2.3.1"
-  gem "chandler"
-end
-
-gem "gitlab", "~> 3.7.0"
 
 gem "danger-junit", "~> 0.5"
 gem "rspec_junit_formatter", git: "https://github.com/JuanitoFatas/rspec_junit_formatter.git", branch: "dump-rspec_junit_formatter-failed-examples"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source "https://rubygems.org"
 
 gemspec
-gem "chandler"
+
+gem "chandler" if RUBY_VERSION != "2.0.0"
 gem "danger-gitlab"
 
 gem "danger-junit", "~> 0.5"

--- a/Rakefile
+++ b/Rakefile
@@ -25,3 +25,21 @@ desc "I do this so often now, better to just handle it here"
 task :guard do |task|
   sh "bundle exec guard"
 end
+
+desc "Runs chandler for current version"
+task :chandler do
+  lib = File.expand_path("../lib", __FILE__)
+  $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+  require "danger/version"
+  if ENV["CHANDLER_GITHUB_API_TOKEN"]
+    sh "bundle exec chandler #{Danger::VERSION}"
+  elsif ENV["DANGER_GITHUB_API_TOKEN"]
+    sh "CHANDLER_GITHUB_API_TOKEN=#{ENV['DANGER_GITHUB_API_TOKEN']} bundle exec chandler #{Danger::VERSION}"
+  else
+    puts "Skipping chandler due to no `CHANDLER_GITHUB_API_TOKEN` or `DANGER_GITHUB_API_TOKEN` in the ENV."
+  end
+end
+
+Rake::Task["release"].enhance do
+  Rake::Task["chandler"].invoke
+end

--- a/bin/chandler
+++ b/bin/chandler
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-if !ENV["TRAVIS_TAG"].empty? && ENV["TRAVIS_RUBY_VERSION"] == "2.3.1"
-  `bundle exec chandler push $TRAVIS_TAG`
-end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
   before do
     stub_merge_request(
       "merge_request_593728_response",
-      "k0nserv/danger-test",
+      "k0nserv%2Fdanger-test",
       593_728
     )
     stub_merge_request_commits(
       "merge_request_593728_commits_response",
-      "k0nserv/danger-test",
+      "k0nserv%2Fdanger-test",
       593_728
     )
   end
@@ -40,7 +40,7 @@ RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
     before do
       stub_merge_request_changes(
         "merge_request_593728_changes_response",
-        "k0nserv/danger-test",
+        "k0nserv\%2Fdanger-test",
         593_728
       )
     end
@@ -90,3 +90,4 @@ RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
     end
   end
 end
+

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -84,17 +84,17 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
     before do
       stub_merge_request(
         "merge_request_593728_response",
-        "k0nserv/danger-test",
+        "k0nserv%2Fdanger-test",
         593_728
       )
       stub_merge_request_commits(
         "merge_request_593728_commits_response",
-        "k0nserv/danger-test",
+        "k0nserv%2Fdanger-test",
         593_728
       )
       @comments_stub = stub_merge_request_comments(
         "merge_request_593728_comments_response",
-        "k0nserv/danger-test",
+        "k0nserv%2Fdanger-test",
         593_728
       )
     end
@@ -161,7 +161,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
           messages: violations(["Test message"]),
           template: "gitlab"
         )
-        stub_request(:post, "https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes").with(
+        stub_request(:post, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes").with(
           body: "body=#{ERB::Util.url_encode(body)}",
           headers: expected_headers
         ).to_return(status: 200, body: "", headers: {})
@@ -178,7 +178,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
 
           @comments_stub = stub_merge_request_comments(
             "merge_request_593728_comments_existing_danger_comment_response",
-            "k0nserv/danger-test",
+            "k0nserv%2Fdanger-test",
             593_728
           )
         end
@@ -196,7 +196,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
             },
             template: "gitlab"
           )
-          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes/13471894").with(
+          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
             body: "body=#{ERB::Util.url_encode(body)}",
             headers: expected_headers
           ).to_return(status: 200, body: "", headers: {})
@@ -215,7 +215,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
             messages: violations(["Test message"]),
             template: "gitlab"
           )
-          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes/13471894").with(
+          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
             body: "body=#{ERB::Util.url_encode(body)}",
             headers: expected_headers
           ).to_return(status: 200, body: "", headers: {})
@@ -234,13 +234,13 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
 
           @comments_stub = stub_merge_request_comments(
             "merge_request_593728_comments_no_stickies_response",
-            "k0nserv/danger-test",
+            "k0nserv%2Fdanger-test",
             593_728
           )
         end
 
         it "removes the previous danger comment if there are no new messages" do
-          stub_request(:delete, "https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes/13471894").with(
+          stub_request(:delete, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
             headers: expected_headers
           )
 

--- a/spec/support/gitlab_helper.rb
+++ b/spec/support/gitlab_helper.rb
@@ -27,19 +27,19 @@ module Danger
 
       def stub_merge_request(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_request/#{merge_request_id}"
+        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 
       def stub_merge_request_changes(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_request/#{merge_request_id}/changes"
+        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}/changes"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 
       def stub_merge_request_commits(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_request/#{merge_request_id}/commits"
+        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}/commits"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 


### PR DESCRIPTION
Somehow the travis deploy script wasn't working, so now I've improved the `rake release` task to also run chandler if you have either one of those ENV vars in your shell.