### PR TITLE
[Gitlab] Fetch all MR comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
+* Consider all comments when looking for existing danger comments in Gitlab MRs.
 
 ## 5.1.0
 

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -67,6 +67,7 @@ module Danger
       def mr_comments
         @comments ||= begin
           client.merge_request_comments(ci_source.repo_slug, ci_source.pull_request_id)
+            .auto_paginate
             .map { |comment| Comment.from_gitlab(comment) }
         end
       end

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -94,7 +94,9 @@ module Danger
 
       def fetch_details
         self.mr_json = client.merge_request(ci_source.repo_slug, self.ci_source.pull_request_id)
-        self.commits_json = client.merge_request_commits(ci_source.repo_slug, self.ci_source.pull_request_id)
+        self.commits_json = client.merge_request_commits(
+          ci_source.repo_slug, self.ci_source.pull_request_id
+        ).auto_paginate
         self.ignored_violations = ignored_violations_from_pr
       end
 

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -66,7 +66,7 @@ module Danger
 
       def mr_comments
         @comments ||= begin
-          client.merge_request_comments(ci_source.repo_slug, ci_source.pull_request_id)
+          client.merge_request_comments(ci_source.repo_slug, ci_source.pull_request_id, per_page: 100)
             .auto_paginate
             .map { |comment| Comment.from_gitlab(comment) }
         end

--- a/spec/support/gitlab_helper.rb
+++ b/spec/support/gitlab_helper.rb
@@ -46,7 +46,7 @@ module Danger
 
       def stub_merge_request_comments(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}/notes"
+        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}/notes?per_page=100"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
     end


### PR DESCRIPTION
Previously we only fetched the first page which means
that when the danger comment is not on the first page it
adds new comments instead of updating the existing one.