### PR TITLE
Add support for DotCi CI source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
+* Add support for DotCi - Daniel Beard
 
 ## 5.1.1
 

--- a/lib/danger/ci_source/dotci.rb
+++ b/lib/danger/ci_source/dotci.rb
@@ -1,0 +1,52 @@
+require "danger/request_sources/github/github"
+
+module Danger
+  # https://groupon.github.io/DotCi
+
+  # ### CI Setup
+  # DotCi is a layer on top of jenkins. So, if you're using DotCi, you're hosting your own environment.
+  #
+  # ### Token Setup
+  #
+  # #### GitHub
+  # As you own the machine, it's up to you to add the environment variable for the `DANGER_GITHUB_API_TOKEN`.
+  #
+  class DotCi < CI
+    def self.validates_as_ci?(env)
+      env.key? "DOTCI"
+    end
+
+    def self.validates_as_pr?(env)
+      !env["DOTCI_PULL_REQUEST"].nil? && !env["DOTCI_PULL_REQUEST"].match(/^[0-9]+$/).nil?
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= begin
+        [
+          Danger::RequestSources::GitHub
+        ]
+      end
+    end
+
+    def initialize(env)
+      self.repo_url = self.class.repo_url(env)
+      self.pull_request_id = self.class.pull_request_id(env)
+      repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/]+)$})
+      self.repo_slug = repo_matches[2].gsub(/\.git$/, "") unless repo_matches.nil?
+    end
+
+    def self.pull_request_id(env)
+      env["DOTCI_PULL_REQUEST"]
+    end
+
+    def self.repo_url(env)
+      if env["DOTCI_INSTALL_PACKAGES_GIT_CLONE_URL"]
+        env["DOTCI_INSTALL_PACKAGES_GIT_CLONE_URL"]
+      elsif env["DOTCI_DOCKER_COMPOSE_GIT_CLONE_URL"]
+        env["DOTCI_DOCKER_COMPOSE_GIT_CLONE_URL"]
+      else
+        env["GIT_URL"]
+      end
+    end
+  end
+end

--- a/spec/lib/danger/ci_sources/ci_source_spec.rb
+++ b/spec/lib/danger/ci_sources/ci_source_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Danger::CI do
           "Danger::Buddybuild",
           "Danger::Buildkite",
           "Danger::CircleCI",
+          "Danger::DotCi",
           "Danger::Drone",
           "Danger::GitLabCI",
           "Danger::Jenkins",

--- a/spec/lib/danger/ci_sources/dotci_spec.rb
+++ b/spec/lib/danger/ci_sources/dotci_spec.rb
@@ -1,0 +1,89 @@
+require "danger/ci_source/circle"
+
+RSpec.describe Danger::DotCi do
+  let(:valid_env) do
+    {
+      "DOTCI" => "true",
+      "DOTCI_INSTALL_PACKAGES_GIT_CLONE_URL" => "git@github.com:danger/danger.git",
+      "DOTCI_PULL_REQUEST" => "1234"
+    }
+  end
+
+  let(:invalid_env) do
+    {
+      "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true"
+    }
+  end
+
+  let(:source) { described_class.new(valid_env) }
+
+  context "with GitHub" do
+    before do
+      valid_env["DOTCI_PULL_REQUEST"] = "1234"
+    end
+
+    describe ".validates_as_ci?" do
+      it "validates when requierd env variables are set" do
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "validates even when `DOTCI_PULL_REQUEST` is missing" do
+        valid_env["DOTCI_PULL_REQUEST"] = nil
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "validates even when `DOTCI_PULL_REQUEST` is empty" do
+        valid_env["DOTCI_PULL_REQUEST"] = ""
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "doesn't validate when require env variables are not set" do
+        expect(described_class.validates_as_ci?(invalid_env)).to be false
+      end
+    end
+
+    describe ".validates_as_pr?" do
+      it "validates when the required variables are set" do
+        valid_env["DOTCI_PULL_REQUEST"] = "1234"
+        expect(described_class.validates_as_pr?(valid_env)).to be true
+      end
+
+      it "doesn't validate if `DOTCI_PULL_REQUEST` is missing" do
+        valid_env["DOTCI_PULL_REQUEST"] = nil
+        expect(described_class.validates_as_pr?(valid_env)).to be false
+      end
+    end
+  end
+
+  describe "#new" do
+    describe "repo slug" do
+      it "gets out a repo slug from a git+ssh repo" do
+        expect(source.repo_slug).to eq("danger/danger")
+      end
+
+      it "gets out a repo slug from a https repo" do
+        valid_env["DOTCI_INSTALL_PACKAGES_GIT_CLONE_URL"] = "https://gitlab.com/danger/danger.git"
+
+        expect(source.repo_slug).to eq("danger/danger")
+      end
+
+      it "get out a repo slug from a repo with dot in name" do
+        valid_env["DOTCI_INSTALL_PACKAGES_GIT_CLONE_URL"] = "https://gitlab.com/danger/danger.test.git"
+
+        expect(source.repo_slug).to eq("danger/danger.test")
+      end
+
+      it "get out a repo slug from a repo with .git in name" do
+        valid_env["DOTCI_INSTALL_PACKAGES_GIT_CLONE_URL"] = "https://gitlab.com/danger/danger.git.git"
+
+        expect(source.repo_slug).to eq("danger/danger.git")
+      end
+    end
+  end
+
+  describe "#supported_request_sources" do
+    it "supports GitHub" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::GitHub)
+    end
+  end
+end


### PR DESCRIPTION
- Used the Jenkins source as a starting point and went from there.
- Adds support for DotCi: https://github.com/groupon/dotci
- I've validated on a DotCi build.