### PR TITLE
[WIP] Add inline comment feature for BBS

### DIFF
--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -78,6 +78,7 @@ module Danger
                                    template: "bitbucket_server")
 
         @api.post_comment(comment)
+        # @api.post_inline_comment(comment)
       end
 
       def delete_old_comments(danger_id: "danger")

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -52,20 +52,20 @@ module Danger
         post(uri, body)
       end
 
-      def post_inline_comment(text, line, fromHash, path, srcPath, toHash)
+      def post_inline_comment(text, line, from_hash, path, src_path, to_hash)
         uri = URI("#{pr_api_endpoint}/comments")
-        body = { 
-          text: text, 
-          anchor: { 
-            diffType: 'Commit',
+        body = {
+          text: text,
+          anchor: {
+            diffType: "Commit",
             line: line,
-            lineType: 'CONTEXT',
-            fileType: 'FROM',
-            fromHash: fromHash,
+            lineType: "CONTEXT",
+            fileType: "FROM",
+            fromHash: from_hash,
             path: path,
-            srcPath: srcPath,
-            toHash: toHash
-            } 
+            srcPath: src_path,
+            toHash: to_hash
+            }
           }.to_json
         post(uri, body)
       end

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -52,6 +52,24 @@ module Danger
         post(uri, body)
       end
 
+      def post_inline_comment(text, line, fromHash, path, srcPath, toHash)
+        uri = URI("#{pr_api_endpoint}/comments")
+        body = { 
+          text: text, 
+          anchor: { 
+            diffType: 'Commit',
+            line: line,
+            lineType: 'CONTEXT',
+            fileType: 'FROM',
+            fromHash: fromHash,
+            path: path,
+            srcPath: srcPath,
+            toHash: toHash
+            } 
+          }.to_json
+        post(uri, body)
+      end
+
       private
 
       def use_ssl


### PR DESCRIPTION
This PR is work in progress for implementing inline comment for Bitbucket Server. There is an [issue](https://github.com/danger/danger/issues/806) opened to track this PR.

Need help from other contributors to implement this. I am not a ruby expert but I think I can start somewhere.

Here are some of the answers I need to understand the workflow if someone can help.

- [ ] Figure out when to call `post_comment` and when to call `post_inline_comment` methods.
- [ ] Get values for `line`, `lineType`, `fromHash`, `path`, `srcPath`, `toHash` in order to call the bitbucket API ([Reference](https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659055842560)).
- [ ] Update [danger.systems](danger.systems) website to reflect this feature implementation.
