### PR TITLE
Fix danger_id and new_comment flag not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
+* Fix danger_id and new_comment flag not being set for pr checks [@4oby](https://github.com/4oby)
 * Add support for DotCi - Daniel Beard
 
 ## 5.1.1

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -24,15 +24,18 @@ module Danger
       @pr_url = argv.shift_argument
       @clear_http_cache = argv.flag?("clear-http-cache", false)
       dangerfile = argv.option("dangerfile", "Dangerfile")
-
+      danger_id = argv.option("danger_id", "danger")
+      new_comment = argv.flag?("new-comment")
       # Currently CLAide doesn't support short option like -h https://github.com/CocoaPods/CLAide/pull/60
       # when user pass in -h, mimic the behavior of passing in --help.
       argv = CLAide::ARGV.new ["--help"] if show_help
 
       super
-
+      @danger_id = danger_id
+      @new_comment = new_comment
       @dangerfile_path = dangerfile if File.exist?(dangerfile)
-
+      #@danger_id = danger_id
+      #@new_comment = new_comment
       if argv.flag?("pry", false)
         @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path)
       end
@@ -59,8 +62,8 @@ module Danger
           Danger::EnvironmentManager.danger_base_branch,
           Danger::EnvironmentManager.danger_head_branch,
           @dangerfile_path,
-          nil,
-          nil
+          @danger_id,
+          @new_comment
         )
       end
     end

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -243,7 +243,6 @@ module Danger
 
     def post_results(danger_id, new_comment)
       violations = violation_report
-
       env.request_source.update_pull_request!(
         warnings: violations[:warnings],
         errors: violations[:errors],
@@ -274,6 +273,7 @@ module Danger
         # Push results to the API
         # Pass along the details of the run to the request source
         # to send back to the code review site.
+
         post_results(danger_id, new_comment) unless danger_id.nil?
 
         # Print results in the terminal


### PR DESCRIPTION
Fix when running `danger --new-comment --danger_id="id" pr <link>`
the flags `--new-comment` and `--danger_id` where set to `nil`