### PR TITLE
Send DSLError to pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 * Add support for DotCi - Daniel Beard
+* Send Dangerfile eval exceptions to PR - [@sleekybadger](https://github.com/sleekybadger)
 
 ## 5.1.1
 

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -278,6 +278,10 @@ module Danger
 
         # Print results in the terminal
         print_results
+      rescue DSLError => ex
+        # Push exception to the API and re-raise
+        post_exception(ex, danger_id, new_comment) unless danger_id.nil?
+        raise
       ensure
         # Makes sure that Danger specific git branches are cleaned
         env.clean_up
@@ -309,6 +313,14 @@ module Danger
         line.strip!
         "#{line}\n"
       end
+    end
+
+    def post_exception(ex, danger_id, new_comment)
+      env.request_source.update_pull_request!(
+        danger_id: danger_id,
+        new_comment: new_comment,
+        markdowns: [ex.to_markdown]
+      )
     end
   end
 end

--- a/spec/fixtures/dangerfile_with_error
+++ b/spec/fixtures/dangerfile_with_error
@@ -1,0 +1,2 @@
+# This will fail
+abc

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -253,4 +253,37 @@ RSpec.describe Danger::Dangerfile, host: :github do
       dm.setup_for_running("custom_danger_base", "custom_danger_head")
     end
   end
+
+  describe "#run" do
+    context "when exception occured" do
+      before { allow(Danger).to receive(:danger_outdated?).and_return(false) }
+
+      it "updates PR with an error" do
+        path = Pathname.new(File.join("spec", "fixtures", "dangerfile_with_error"))
+        env_manager = double("Danger::EnvironmentManager", {
+          pr?: false,
+          clean_up: true,
+          fill_environment_vars: true,
+          ensure_danger_branches_are_setup: false
+        })
+        scm = double("Danger::GitRepo", {
+          class: Danger::GitRepo,
+          diff_for_folder: true
+        })
+        request_source = double("Danger::RequestSources::GitHub")
+        dm = Danger::Dangerfile.new(env_manager, testing_ui)
+
+        allow(env_manager).to receive(:scm) { scm }
+        allow(env_manager).to receive(:request_source) { request_source }
+
+        expect(request_source).to receive(:update_pull_request!)
+
+        expect do
+          dm.run("custom_danger_base", "custom_danger_head", path, 1, false)
+        end.to raise_error(Danger::DSLError)
+      end
+
+      after { allow(Danger).to receive(:danger_outdated?).and_call_original }
+    end
+  end
 end

--- a/spec/lib/danger/danger_core/standard_error_spec.rb
+++ b/spec/lib/danger/danger_core/standard_error_spec.rb
@@ -1,0 +1,128 @@
+RSpec.describe Danger::DSLError do
+  let(:file_path) do
+    Pathname.new(File.join("spec", "fixtures", "dangerfile_with_error"))
+  end
+  let(:description) do
+    "Invalid `#{file_path.basename}` file: undefined local "\
+    "variable or method `abc' for #<Danger::Dangerfile:1>"
+  end
+  let(:backtrace) do
+    [
+      "#{File.join('fake', 'path', 'dangerfile.rb')}:68:in `method_missing",
+      "#{File.join('spec', 'fixtures', 'dangerfile_with_error')}:2:in `block in parse'",
+      "#{File.join('fake', 'path', 'dangerfile.rb')}:199:in `eval"
+    ]
+  end
+
+  subject { Danger::DSLError.new(description, file_path, backtrace) }
+
+  describe "#message" do
+    context "when danger version outdated" do
+      before { allow(Danger).to receive(:danger_outdated?).and_return(0) }
+
+      it "returns colored description with Dangerfile trace" do
+        description =
+          "[!] Invalid `dangerfile_with_error` file: undefined "\
+          "local variable or method `abc' for #<Danger::Dangerfile:1>"\
+          ". Updating the Danger gem might fix the issue. "\
+          "Your Danger version: #{Danger::VERSION}, "\
+          "latest Danger version: 0"
+
+        expectation = [
+          "\e[31m",
+          description,
+          "\e[0m",
+          " #  from spec/fixtures/dangerfile_with_error:2",
+          " #  -------------------------------------------",
+          " #  # This will fail",
+          " >  abc",
+          " #  -------------------------------------------"
+        ]
+
+        expect(subject.message.split("\n")).to eq expectation
+      end
+    end
+
+    context "when danger version latest" do
+      before { allow(Danger).to receive(:danger_outdated?).and_return(false) }
+
+      it "returns colored description with Dangerfile trace" do
+        description =
+          "[!] Invalid `dangerfile_with_error` file: undefined " \
+          "local variable or method `abc' for #<Danger::Dangerfile:1>\e[0m"
+
+        expectation = [
+          "\e[31m",
+          description,
+          " #  from spec/fixtures/dangerfile_with_error:2",
+          " #  -------------------------------------------",
+          " #  # This will fail",
+          " >  abc",
+          " #  -------------------------------------------"
+        ]
+
+        expect(subject.message.split("\n")).to eq expectation
+      end
+    end
+  end
+
+  describe "#to_markdown" do
+    context "when danger version outdated" do
+      before { allow(Danger).to receive(:danger_outdated?).and_return(0) }
+
+      it "returns description with Dangerfile trace as a escaped markdown" do
+        description =
+          "[!] Invalid `dangerfile_with_error` file: undefined " \
+          "local variable or method `abc` for #\\<Danger::Dangerfile:1\\>" \
+          ". Updating the Danger gem might fix the issue. "\
+          "Your Danger version: #{Danger::VERSION}, "\
+          "latest Danger version: 0"
+
+        expectation = [
+          "## Danger has errored",
+          description,
+          "",
+          "```",
+          " #  from spec/fixtures/dangerfile_with_error:2",
+          " #  -------------------------------------------",
+          " #  # This will fail",
+          " >  abc",
+          " #  -------------------------------------------",
+          "```"
+        ]
+
+        subject.to_markdown.message.split("\n").each_with_index do |chunk, index|
+          expect(chunk).to eq expectation[index]
+        end
+
+        expect(subject.to_markdown.message.split("\n")).to eq expectation
+      end
+    end
+
+    context "when danger version latest" do
+      before { allow(Danger).to receive(:danger_outdated?).and_return(false) }
+
+      it "returns description with Dangerfile trace as a escaped markdown" do
+        description =
+          "[!] Invalid `dangerfile_with_error` file: undefined " \
+          "local variable or method `abc` for #\\<Danger::Dangerfile:1\\>"
+
+        expectation = [
+          "## Danger has errored",
+          description,
+          "```",
+          " #  from spec/fixtures/dangerfile_with_error:2",
+          " #  -------------------------------------------",
+          " #  # This will fail",
+          " >  abc",
+          " #  -------------------------------------------",
+          "```"
+        ]
+
+        expect(subject.to_markdown.message.split("\n")).to eq expectation
+      end
+    end
+  end
+
+  after { allow(Danger).to receive(:danger_outdated?).and_call_original }
+end


### PR DESCRIPTION
## Summary 

Hi! These changes send errors occurred in `Dangerfile` to PR. Also I add specs for `DSLError` class.

## Example 
![Error example](https://monosnap.com/file/VVx3yqbpEr5o8oT8sjC82RVyFJvrjd.png)