### PR TITLE
Add ability to get list of renamed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
+* Add ability to get list of renamed files - [@sleekybadger](https://github.com/sleekybadger)
+
 ## 5.2.0
 
 

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -76,6 +76,14 @@ module Danger
     end
 
     # @!group Git Metadata
+    # List of renamed files
+    # @return [Array<Hash>] with keys `:before` and `:after`
+    #
+    def renamed_files
+      @git.renamed_files
+    end
+
+    # @!group Git Metadata
     # The overall lines of code added/removed in the diff
     # @return [Fixnum]
     #

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -19,6 +19,32 @@ module Danger
       self.log = repo.log.between(from, to)
     end
 
+    def renamed_files
+      # Get raw diff with --find-renames --diff-filter
+      # We need to pass --find-renames cause
+      # older versions of git don't use this flag as default
+      diff = exec(
+        "diff #{self.diff.from} #{self.diff.to} --find-renames --diff-filter=R"
+      ).lines.map { |line| line.tr("\n", "") }
+
+      before_name_regexp = /^rename from (.*)$/
+      after_name_regexp = /^rename to (.*)$/
+
+      # Extract old and new paths via regexp
+      diff.each_with_index.map do |line, index|
+        before_match = line.match(before_name_regexp)
+        next unless before_match
+
+        after_match = diff.fetch(index + 1, "").match(after_name_regexp)
+        next unless after_match
+
+        {
+          before: before_match.captures.first,
+          after: after_match.captures.first
+        }
+      end.compact
+    end
+
     def exec(string)
       require "open3"
       Dir.chdir(self.folder || ".") do

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -131,8 +131,12 @@ RSpec.describe Danger::Dangerfile, host: :github do
       dm = testing_dangerfile
       methods = dm.external_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
       expect(methods).to eq %i[
-        added_files api base_commit branch_for_base branch_for_head commits deleted_files
-        deletions diff_for_file dismiss_out_of_range_messages head_commit html_link import_dangerfile import_plugin info_for_file insertions lines_of_code modified_files mr_author mr_body mr_json mr_labels mr_title pr_author pr_body pr_diff pr_json pr_labels pr_title review scm_provider
+        added_files api base_commit branch_for_base branch_for_head commits
+        deleted_files deletions diff_for_file dismiss_out_of_range_messages
+        head_commit html_link import_dangerfile import_plugin info_for_file
+        insertions lines_of_code modified_files mr_author mr_body mr_json
+        mr_labels mr_title pr_author pr_body pr_diff pr_json pr_labels
+        pr_title renamed_files review scm_provider
       ]
     end
 
@@ -202,16 +206,17 @@ RSpec.describe Danger::Dangerfile, host: :github do
         data = sort_data(data).map { |d| d.first.to_sym }
 
         expect(data).to eq %i[
-          added_files api base_commit branch_for_base branch_for_head commits deleted_files deletions head_commit
-          insertions lines_of_code modified_files
-          mr_author mr_body mr_json mr_labels mr_title
-          pr_author pr_body pr_diff pr_json pr_labels pr_title review scm_provider
+          added_files api base_commit branch_for_base branch_for_head commits
+          deleted_files deletions head_commit insertions lines_of_code
+          modified_files mr_author mr_body mr_json mr_labels mr_title
+          pr_author pr_body pr_diff pr_json pr_labels pr_title
+          renamed_files review scm_provider
         ]
       end
 
       it "skips raw PR/MR JSON, and diffs" do
         data = @dm.method_values_for_plugin_hashes(@dm.external_dsl_attributes)
-        data_hash = Hash[*data.collect { |v| [v.first, v.last] }.flatten]
+        data_hash = Hash[*data.collect { |v| [v.first, v.last] }.flatten(1)]
 
         expect(data_hash["pr_json"]).to eq("[Skipped JSON]")
         expect(data_hash["mr_json"]).to eq("[Skipped JSON]")

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -121,5 +121,17 @@ RSpec.describe Danger::DangerfileGitPlugin, host: :github do
         end
       end
     end
+
+    describe "#renamed_files" do
+      it "delegates to scm" do
+        renamed_files = [{
+          before: "some/path/old",
+          after: "some/path/new"
+        }]
+
+        allow(@repo).to receive(:renamed_files).and_return(renamed_files)
+        expect(@dsl.renamed_files).to eq(renamed_files)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Hi. This add ability to access list of renamed files via `git.renamed_files`.

## Example

`git.renamed_files` will return Array with Hashes that have keys `:before` and `:after`.
```
[
  { before: "README", after: "README.MD" },
  { before: "some/path/file", after: "some/other/path/file" }
]
```

## Notes

Unfortunately [git gem](https://github.com/schacon/ruby-git) that we are using, has tough limited api which don't provide ability to pass some options for diff output customization. 

So I decided to use `git diff  --diff-filter=R`, which returns something like this:

```
[
  "diff --git a/README b/README.MD\n", 
  "similarity index 100%\n", 
  "rename from README\n", 
  "rename to README.MD\n", 

  "diff --git a/hello1 b/hello1_renamed\n", 
  "similarity index 100%\n", 
  "rename from hello1\n", 
  "rename to hello1_renamed\n", 

  "diff --git a/hello3 b/hello3_renamed\n", 
  "similarity index 100%\n", 
  "rename from hello3\n", 
  "rename to hello3_renamed\n", 

  "diff --git a/hello5 b/hello5/some_folder/hello5_renamed\n", 
  "similarity index 100%\n", 
  "rename from hello5\n", 
  "rename to hello5/some_folder/hello5_renamed"
]
```

Maybe it makes sense to move from [git gem](https://github.com/schacon/ruby-git) to [rugged gem](https://github.com/libgit2/rugged), cause it better maintained and looks much more flexible?