### PR TITLE
Fix broken violations order for github

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,7 +71,7 @@ Style/AndOr:
 
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 320
+  Max: 350
 
 Metrics/CyclomaticComplexity:
   Max: 17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
+* Fix broken violations order for github - [@sleekybadger](https://github.com/sleekybadger)
+
 ## 5.2.1
 
 * Add ability to get list of renamed files - [@sleekybadger](https://github.com/sleekybadger)

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -426,6 +426,41 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
         v = Danger::Violation.new("Sure thing", true, "CHANGELOG.md", 4)
         @g.update_pull_request!(warnings: [], errors: [], messages: [v])
       end
+
+      it "keeps initial messages order" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return([])
+        allow(@g.client).to receive(:add_comment).and_return({})
+        allow(@g).to receive(:submit_pull_request_status!).and_return(true)
+        allow(@g.client).to receive(:create_pull_request_comment).and_return({})
+        allow(@g.client).to receive(:delete_comment).and_return(true)
+        allow(@g.client).to receive(:delete_comment).and_return(true)
+
+        messages = [
+          Danger::Violation.new("1", false, nil, nil),
+          Danger::Violation.new("2", false, nil, nil),
+          Danger::Violation.new("3", false, nil, nil),
+          Danger::Violation.new("4", false, nil, nil),
+          Danger::Violation.new("5", false, nil, nil),
+          Danger::Violation.new("6", false, nil, nil),
+          Danger::Violation.new("7", false, nil, nil),
+          Danger::Violation.new("8", false, nil, nil),
+          Danger::Violation.new("9", false, nil, nil),
+          Danger::Violation.new("10", false, nil, nil)
+        ]
+
+        expect(@g).to receive(:generate_comment).with(
+          template: "github",
+          danger_id: "danger",
+          previous_violations: {},
+          warnings: [],
+          errors: [],
+          messages: messages,
+          markdowns: []
+        )
+
+        @g.update_pull_request!(messages: messages)
+      end
     end
 
     describe "branch setup" do


### PR DESCRIPTION
## Summary

This should fix https://github.com/danger/danger/issues/703. I rewrite `update_pull_request!`, `submit_inline_comments!`, `submit_inline_comments_for_kind!` to not mutate violations and to apply sort only for inline comments.

## Notes

### About sort proc:
Root of evil was in sort proc:
```
cmp = proc do |a, b|
  next -1 unless a.file
  next 1 unless b.file

  next a.line <=> b.line if a.file == b.file
  next a.file <=> b.file
end
```
Ruby uses [Quicksort](https://en.wikipedia.org/wiki/Quicksort) algorithm, which is pretty fast but can be unstable with not correct usage as ruby doc [says](https://ruby-doc.org/core-2.2.0/Array.html#method-i-sort). For example:
```
:001 > [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].sort { -1 }
 => [10, 2, 3, 4, 5, 1, 7, 8, 9, 6]
```
So when sort proc receives array where all comments not inline, order blew to hell. 

### About inline comments detection:
I think we can simply remove:
```
next -1 unless a.file
next 1 unless b.file
```
from sort proc, cause in `submit_inline_comments_for_kind!` we are skipping such files `next false unless m.file && m.line`. Also [here](https://github.com/sleekybadger/danger/blob/2d0ff0905a59650a17c88d202d413236d0400fc6/lib/danger/danger_core/messages/violation.rb#L23-L25) we have quite opposite logic, so I wonder can we change this condition to `file && line`?