### PR TITLE
Improve remotes parsing for init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
+* Improve remotes parsing for init command - [@sleekybadger](https://github.com/sleekybadger)
+
 ## 5.2.2
 
 * Fix FileList returning arrays - [@sleekybadger](https://github.com/sleekybadger)

--- a/lib/danger/commands/init.rb
+++ b/lib/danger/commands/init.rb
@@ -143,9 +143,14 @@ module Danger
     end
 
     def current_repo_slug
-      @git = GitRepo.new
-      repo_matches = @git.origins.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
-      (repo_matches[2] || "[Your/Repo]").strip
+      git = GitRepo.new
+
+      author_repo_regexp = %r{(?:[\/:])([^\/]+\/[^\/]+)(?:.git)?$}
+      last_git_regexp = /.git$/
+
+      matches = git.origins.match(author_repo_regexp)
+
+      matches ? matches[1].gsub(last_git_regexp, "").strip : "[Your/Repo]"
     end
 
     def setup_danger_ci

--- a/spec/lib/danger/commands/init_spec.rb
+++ b/spec/lib/danger/commands/init_spec.rb
@@ -1,0 +1,37 @@
+require "danger/commands/init"
+
+RSpec.describe Danger::Init do
+  describe "#current_repo_slug" do
+    let(:command) { Danger::Init.new CLAide::ARGV.new([]) }
+
+    context "with git url" do
+      it "returns correct results" do
+        url = "git@github.com:author/repo.git"
+
+        allow_any_instance_of(Danger::GitRepo).to receive(:origins).and_return(url)
+
+        expect(command.current_repo_slug).to eq "author/repo"
+      end
+    end
+
+    context "with github pages url" do
+      it "returns correct results" do
+        url = "https://github.com/author/repo.github.io.git"
+
+        allow_any_instance_of(Danger::GitRepo).to receive(:origins).and_return(url)
+
+        expect(command.current_repo_slug).to eq "author/repo.github.io"
+      end
+    end
+
+    context "with other url" do
+      it "returns [Your/Repo]" do
+        url = "http://example.com"
+
+        allow_any_instance_of(Danger::GitRepo).to receive(:origins).and_return(url)
+
+        expect(command.current_repo_slug).to eq "[Your/Repo]"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This improves remotes parsing for init command and resolves #821 .

### Examples
```
git@github.com:author/repo.git => author/repo
https://github.com/author/repo.github.io.git => author/repo.github.io
http://example.com => [Your/Repo]
```