### PR TITLE
Added feature to set dismiss_out_of_range_messages per kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Improve remotes parsing for init command - [@sleekybadger](https://github.com/sleekybadger)
 * Adds ability to get the whole diff object at `git.diff` - This lets you do
   more fine grained checks on the raw changes. - [@sleekybadger](https://github.com/sleekybadger)
+* Add ability to set dismiss_out_of_range_messages per each message kinds. - [@giginet](https://github.com/giginet)
 
 ## 5.2.2
 

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -226,12 +226,17 @@ module Danger
 
     # @!group GitHub Misc
     # Use to ignore inline messages which lay outside a diff's range, thereby not posting them in the main comment.
-    # @param    [Bool] dismiss
+    # You can set hash to change behavior per each kinds. (ex. `{warning: true, error: false}`)
+    # @param    [Bool] or [Hash<Symbol, Bool>] dismiss
     #           Ignore out of range inline messages, defaults to `true`
     #
     # @return   [void]
     def dismiss_out_of_range_messages(dismiss: true)
-      @github.dismiss_out_of_range_messages = dismiss == true
+      if dismiss.kind_of?(Hash)
+        @github.dismiss_out_of_range_messages = dismiss
+      elsif dismiss.kind_of?(TrueClass)
+        @github.dismiss_out_of_range_messages = true
+      end
     end
 
     %i(title body author labels json).each do |suffix|

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -245,18 +245,10 @@ module Danger
         danger_comments = pr_comments.select { |comment| Comment.from_github(comment).generated_by_danger?(danger_id) }
         non_danger_comments = pr_comments - danger_comments
 
-        warnings = submit_inline_comments_for_kind!(
-          "warning", warnings, diff_lines, danger_comments, previous_violations["warning"], danger_id: danger_id
-        )
-        errors = submit_inline_comments_for_kind!(
-          "no_entry_sign", errors, diff_lines, danger_comments, previous_violations["error"], danger_id: danger_id
-        )
-        messages = submit_inline_comments_for_kind!(
-          "book", messages, diff_lines, danger_comments, previous_violations["message"], danger_id: danger_id
-        )
-        markdowns = submit_inline_comments_for_kind!(
-          nil, markdowns, diff_lines, danger_comments, [], danger_id: danger_id
-        )
+        warnings = submit_inline_comments_for_kind!(:warning, warnings, diff_lines, danger_comments, previous_violations["warning"], danger_id: danger_id)
+        errors = submit_inline_comments_for_kind!(:error, errors, diff_lines, danger_comments, previous_violations["error"], danger_id: danger_id)
+        messages = submit_inline_comments_for_kind!(:message, messages, diff_lines, danger_comments, previous_violations["message"], danger_id: danger_id)
+        markdowns = submit_inline_comments_for_kind!(:markdown, markdowns, diff_lines, danger_comments, [], danger_id: danger_id)
 
         # submit removes from the array all comments that are still in force
         # so we strike out all remaining ones
@@ -293,18 +285,19 @@ module Danger
           m1.message.sub(blob_regexp, "") == m2.message.sub(blob_regexp, "")
       end
 
-      def submit_inline_comments_for_kind!(emoji, messages, diff_lines, danger_comments, previous_violations, danger_id: "danger")
+      def submit_inline_comments_for_kind!(kind, messages, diff_lines, danger_comments, previous_violations, danger_id: "danger")
         head_ref = pr_json["head"]["sha"]
         previous_violations ||= []
-        is_markdown_content = emoji.nil?
+        is_markdown_content = kind == :markdown
+        emoji = {warning: "warning", error: "no_entry_sign", message: "book"}[kind]
 
         messages.reject do |m|
           next false unless m.file && m.line
 
-          position = find_position_in_diff diff_lines, m
+          position = find_position_in_diff diff_lines, m, kind
 
           # Keep the change if it's line is not in the diff and not in dismiss mode
-          next self.dismiss_out_of_range_messages if position.nil?
+          next dismiss_out_of_range_messages_for(kind) if position.nil?
 
           # Once we know we're gonna submit it, we format it
           if is_markdown_content
@@ -349,7 +342,7 @@ module Danger
         end
       end
 
-      def find_position_in_diff(diff_lines, message)
+      def find_position_in_diff(diff_lines, message, kind)
         range_header_regexp = /@@ -([0-9]+),([0-9]+) \+(?<start>[0-9]+)(,(?<end>[0-9]+))? @@.*/
         file_header_regexp = %r{^diff --git a/.*}
 
@@ -372,7 +365,7 @@ module Danger
           # so we do it one by one ignoring the deleted lines
           if !file_line.nil? && !line.start_with?("-")
             if file_line == message.line
-              file_line = nil if dismiss_out_of_range_messages && !line.start_with?("+")
+              file_line = nil if dismiss_out_of_range_messages_for(kind) && !line.start_with?("+")
               break
             end
             file_line += 1
@@ -430,6 +423,16 @@ module Danger
         return matched[1] if matched && matched[1]
       rescue
         nil
+      end
+
+      def dismiss_out_of_range_messages_for(kind)
+        if self.dismiss_out_of_range_messages.kind_of?(Hash) && self.dismiss_out_of_range_messages[kind]
+          self.dismiss_out_of_range_messages[kind]
+        elsif self.dismiss_out_of_range_messages == true
+          self.dismiss_out_of_range_messages
+        else
+          false
+        end
       end
 
       # @return [String] A URL to the specific file, ready to be downloaded

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -289,7 +289,7 @@ module Danger
         head_ref = pr_json["head"]["sha"]
         previous_violations ||= []
         is_markdown_content = kind == :markdown
-        emoji = {warning: "warning", error: "no_entry_sign", message: "book"}[kind]
+        emoji = { warning: "warning", error: "no_entry_sign", message: "book" }[kind]
 
         messages.reject do |m|
           next false unless m.file && m.line

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -396,6 +396,26 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
         @g.update_pull_request!(warnings: [], errors: [], messages: [v])
       end
 
+      it "ingores out of range inline comments when in dismiss mode per kind" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
+        expect(@g.client).to receive(:create_pull_request_comment).with("artsy/eigen", "800", anything, "561827e46167077b5e53515b4b7349b8ae04610b", "CHANGELOG.md", 4)
+
+        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_1).and_return({})
+        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_2).and_return({})
+        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", main_issue_id).and_return({})
+
+        v = Danger::Violation.new("Sure thing", true, "CHANGELOG.md", 4)
+        m = Danger::Markdown.new("Sure thing", "CHANGELOG.md", 4)
+        @g.dismiss_out_of_range_messages = {
+          warning: false,
+          error: false,
+          message: false,
+          markdown: true
+        }
+        @g.update_pull_request!(warnings: [], errors: [], messages: [v], markdowns: [m])
+      end
+
       it "crosses out sticky comments" do
         allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
 


### PR DESCRIPTION
issue : [Add ability to set dismiss\_out\_of\_range\_messages per each message kinds · Issue \#831 · danger/danger](https://github.com/danger/danger/issues/831)

Added the feature to set dismiss_out_of_range_messages per kind.

```ruby
dismiss_out_of_range_messages({
  error: false,
  warning: true,
  message: true,
  markdown: true
})
```

If it is set as above, all errors are commented and warnings out of ranges are dismissed.


Also, you can set boolean. it works same with prior.

```ruby
dismiss_out_of_range_messages(true)
```