### PR TITLE
#trivial Fix the issue dismiss_out_of_range_messages

### DIFF
--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -231,11 +231,11 @@ module Danger
     #           Ignore out of range inline messages, defaults to `true`
     #
     # @return   [void]
-    def dismiss_out_of_range_messages(dismiss: true)
+    def dismiss_out_of_range_messages(dismiss = true)
       if dismiss.kind_of?(Hash)
         @github.dismiss_out_of_range_messages = dismiss
-      elsif dismiss.kind_of?(TrueClass)
-        @github.dismiss_out_of_range_messages = true
+      else
+        @github.dismiss_out_of_range_messages = !!dismiss
       end
     end
 

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -234,8 +234,10 @@ module Danger
     def dismiss_out_of_range_messages(dismiss = true)
       if dismiss.kind_of?(Hash)
         @github.dismiss_out_of_range_messages = dismiss
-      else
-        @github.dismiss_out_of_range_messages = !!dismiss
+      elsif dismiss.kind_of?(TrueClass)
+        @github.dismiss_out_of_range_messages = true
+      elsif dismiss.kind_of?(FalseClass)
+        @github.dismiss_out_of_range_messages = false
       end
     end
 

--- a/spec/lib/danger/danger_core/plugins/dangerfile_github_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_github_plugin_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe Danger::DangerfileGitHubPlugin, host: :github do
                            "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/example.json'>example.json</a> & " \
                            "<a href='https://github.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/script.rb#L30'>script.rb#L30</a>")
       end
+
+      describe "#dismiss_out_of_range_messages" do
+        context "without argument" do
+          it { expect(@dsl.dismiss_out_of_range_messages).not_to be_nil }
+        end
+
+        context "with bool" do
+          it { expect(@dsl.dismiss_out_of_range_messages(false)).not_to be_nil }
+        end
+
+        context "with Hash" do
+          it { expect(@dsl.dismiss_out_of_range_messages({ error: true, warning: false })).not_to be_nil }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fix the problem of #832

#832 doesn't work fine. So I fixed in this PR. 🙇 

You can set like following on `Dangerfile`.
I tried this feature, it works fine for me.

```ruby
dismiss_out_of_range_messages({
  error: false,
  warning: true,
  message: true,
  markdown: true
})
```

I added tests for `Dangerfile`. 