### PR TITLE
Fix wrong commits count for PR's that have more than 30 commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
 * Fixes for duplicated GitHub inline comments - [@litmon](https://github.com/litmon)
+* Fix wrong commits count for PR's that have more than 30 commits - [@sleekybadger](https://github.com/sleekybadger)
 
 ## 5.3.0
 

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -14,9 +14,10 @@ module Danger
       ensure_commitish_exists!(to)
 
       merge_base = find_merge_base(repo, from, to)
+      commits_in_branch_count = commits_in_branch_count(from, to)
 
       self.diff = repo.diff(merge_base, to)
-      self.log = repo.log.between(from, to)
+      self.log = repo.log(commits_in_branch_count).between(from, to)
     end
 
     def renamed_files
@@ -107,6 +108,10 @@ module Danger
 
     def possible_merge_base(repo, from, to)
       [repo.merge_base(from, to)].find { |base| commit_exists?(base) }
+    end
+
+    def commits_in_branch_count(from, to)
+      exec("rev-list #{from}..#{to} --count").to_i
     end
   end
 end

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe Danger::GitRepo, host: :github do
         end.to raise_error(RuntimeError, /doesn't exist/)
       end
     end
+
+    it "passes commits count in branch to git log" do
+      with_git_repo do |dir|
+        @dm = testing_dangerfile
+
+        expect_any_instance_of(Git::Base).to(
+          receive(:log).with(1).and_call_original
+        )
+
+        @dm.env.scm.diff_for_folder(dir)
+      end
+    end
   end
 
   describe "Return Types" do


### PR DESCRIPTION
Resolves #838 . It turned out that `git.log` has implicit commits count param. Which [equal 30 by default](https://github.com/schacon/ruby-git/blob/master/lib/git/log.rb#L7).