### PR TITLE
Fix undefined local variable or method `messages'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixes for duplicated GitHub inline comments - [@litmon](https://github.com/litmon)
 * Fix wrong commits count for PR's that have more than 30 commits - [@sleekybadger](https://github.com/sleekybadger)
+* Fix markdown links to files in messages - [@ffittschen](https://github.com/ffittschen)
 
 ## 5.3.0
 

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -25,7 +25,7 @@ module Danger
       #
       # @return [String] The Markdown compatible link
       def markdown_link_to_message(message, _)
-        "#{messages.file}#L#{message.line}"
+        "#{message.file}#L#{message.line}"
       end
 
       # !@group Extension points


### PR DESCRIPTION
This PR fixes a small typo that causes Danger to crash in my current setup (gitlab.com repo with GitLab CI runner to execute Danger).

The "original" version of the `markdown_link_to_message` method ([github.rb#L419](https://github.com/danger/danger/blob/master/lib/danger/request_sources/github/github.rb#L419)) also uses `message` and not `messages`.

### Crashlog
```
$ if [ -n "${CI_MERGE_REQUEST_ID}" ]; then bundle exec danger --version && bundle exec danger; fi
5.2.2
bundler: failed to load command: danger (/Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/bin/danger)
NameError: undefined local variable or method `messages' for #<Danger::RequestSources::GitLab:0x007fef7899c1d0>
Did you mean?  message
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/helpers/comments_helper.rb:28:in `markdown_link_to_message'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/helpers/comments_helper.rb:49:in `process_markdown'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/helpers/comments_helper.rb:59:in `block in table'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/helpers/comments_helper.rb:59:in `map'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/helpers/comments_helper.rb:59:in `table'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/helpers/comments_helper.rb:98:in `generate_comment'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/request_sources/gitlab.rb:123:in `update_pull_request!'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/danger_core/dangerfile.rb:247:in `post_results'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/danger_core/dangerfile.rb:277:in `run'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/danger_core/executor.rb:27:in `run'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/lib/danger/commands/runner.rb:66:in `run'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/claide-1.0.2/lib/claide/command.rb:334:in `run'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/gems/danger-5.2.2/bin/danger:5:in `<top (required)>'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/bin/danger:22:in `load'
  /Users/ci-user/builds/7e7afdcc/0/demo-app/ios/vendor/ruby/2.4.0/bin/danger:22:in `<top (required)>'
```