### PR TITLE
Explicitly Encode Git Execution in UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 ## master
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
+* Explicitly encode the results of `git` executions in UTF-8 - [@nikhilmat](https://github.com/nikhilmat)
 
 ## 5.3.1
 
 * Fixes for duplicated GitHub inline comments - [@litmon](https://github.com/litmon)
 * Fix wrong commits count for PR's that have more than 30 commits - [@sleekybadger](https://github.com/sleekybadger)
 * Fix markdown links to files in messages - [@ffittschen](https://github.com/ffittschen)
-* Explicitly encode the results of `git` executions in UTF-8 - [@nikhilmat](https://github.com/nikhilmat)
 
 ## 5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixes for duplicated GitHub inline comments - [@litmon](https://github.com/litmon)
 * Fix wrong commits count for PR's that have more than 30 commits - [@sleekybadger](https://github.com/sleekybadger)
 * Fix markdown links to files in messages - [@ffittschen](https://github.com/ffittschen)
+* Explicitly encode the results of `git` executions in UTF-8 - [@nikhilmat](https://github.com/nikhilmat)
 
 ## 5.3.0
 

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -29,7 +29,7 @@ module Danger
     end
 
     def run_git(command)
-      git.exec command
+      git.exec(command).encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
     end
 
     def supported_request_sources

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -29,7 +29,7 @@ module Danger
     end
 
     def run_git(command)
-      git.exec(command).encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+      git.exec(command).encode("UTF-8", "binary", invalid: :replace, undef: :replace, replace: "")
     end
 
     def supported_request_sources

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Danger::LocalGitRepo do
       context "with a non UTF-8 character" do
         let(:invalid_encoded_string) { "testing\xC2 a non UTF-8 string" }
 
-        it "enocdes the string correctly" do
+        it "encodes the string correctly" do
           expect { invalid_encoded_string.gsub(//, '') }.to raise_error(ArgumentError)
 
           run_in_repo do

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Danger::LocalGitRepo do
         let(:invalid_encoded_string) { "testing\xC2 a non UTF-8 string" }
 
         it "encodes the string correctly" do
-          expect { invalid_encoded_string.gsub(//, '') }.to raise_error(ArgumentError)
+          expect { invalid_encoded_string.gsub(//, "") }.to raise_error(ArgumentError)
 
           run_in_repo do
             File.open("file3", "w") {}

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -65,6 +65,45 @@ RSpec.describe Danger::LocalGitRepo do
       end
     end
 
+    describe "repo_logs" do
+      let(:git_sha_regex) { /\b[0-9a-f]{5,40}\b/ }
+
+      it "returns the git logs correctly" do
+        run_in_repo do
+          result = source(valid_env)
+          expect(result.run_git("log --oneline -1000000".freeze).split("\n")).to match_array [
+            /#{git_sha_regex} Merge pull request #1234 from new-branch/,
+            /#{git_sha_regex} adding file2/,
+            /#{git_sha_regex} adding file1/
+          ]
+        end
+      end
+
+      context "with a non UTF-8 character" do
+        let(:invalid_encoded_string) { "testing\xC2 a non UTF-8 string" }
+
+        it "enocdes the string correctly" do
+          expect { invalid_encoded_string.gsub(//, '') }.to raise_error(ArgumentError)
+
+          run_in_repo do
+            File.open("file3", "w") {}
+            `git add .`
+            `git commit -m "#{invalid_encoded_string}"`
+
+            result = source(valid_env)
+            logs = nil
+            expect { logs = result.run_git("log --oneline -1000000".freeze) }.to_not raise_error
+            expect(logs.split("\n")).to match_array [
+              /#{git_sha_regex} testing a non UTF-8 string/,
+              /#{git_sha_regex} Merge pull request #1234 from new-branch/,
+              /#{git_sha_regex} adding file2/,
+              /#{git_sha_regex} adding file1/
+            ]
+          end
+        end
+      end
+    end
+
     describe "repo_slug" do
       it "gets the repo slug when it uses https" do
         run_in_repo do


### PR DESCRIPTION
Git commit messages can contain non UTF-8 characters, which can cause exceptions in Ruby when the string is manipulated. This PR ensures the results of the git execution are explicitly encoded in UTF-8 by removing any invalid characters.