### PR TITLE
update plugin list to gitlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
+* Fix plugins search list to gitlab - [@leonhartX](https://github.com/leonhartX)
 * Explicitly encode the results of `git` executions in UTF-8 - [@nikhilmat](https://github.com/nikhilmat)
 
 ## 5.3.1

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -12,7 +12,7 @@ module Danger
       CLAide::Plugins::Configuration.new(
         "Danger",
         "danger",
-        "https://raw.githubusercontent.com/danger/danger.systems/master/plugins-search-generated.json",
+        "https://gitlab.com/danger-systems/danger.systems/raw/master/plugins-search-generated.json",
         "https://github.com/danger/danger-plugin-template"
       )
 


### PR DESCRIPTION
Since the danger.systems is moved to gitlab, the `danger plugins list` should search list from gitlab instead of github.