### PR TITLE
add bitbucket_cloud to xcode_server supported_request_sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 * Fix plugins search list to gitlab - [@leonhartX](https://github.com/leonhartX)
 * Explicitly encode the results of `git` executions in UTF-8 - [@nikhilmat](https://github.com/nikhilmat)
+* Adds BitbucketServer to XcodeServer's supported_request_sources
+[@anreitersimon](https://github.com/anreitersimon)
 
 ## 5.3.1
 

--- a/lib/danger/ci_source/xcode_server.rb
+++ b/lib/danger/ci_source/xcode_server.rb
@@ -29,7 +29,8 @@ module Danger
     def supported_request_sources
       @supported_request_sources ||= [
         Danger::RequestSources::GitHub,
-        Danger::RequestSources::BitbucketServer
+        Danger::RequestSources::BitbucketServer,
+        Danger::RequestSources::BitbucketCloud
       ]
     end
 

--- a/spec/lib/danger/ci_sources/xcode_server_spec.rb
+++ b/spec/lib/danger/ci_sources/xcode_server_spec.rb
@@ -65,5 +65,13 @@ RSpec.describe Danger::XcodeServer do
     it "supports GitHub" do
       expect(source.supported_request_sources).to include(Danger::RequestSources::GitHub)
     end
+
+    it "supports BitbucketServer" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::BitbucketServer)
+    end
+
+    it "supports BitbucketCloud" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::BitbucketCloud)
+    end
   end
 end


### PR DESCRIPTION
Noticed that Bitbucket-Cloud is not available on XcodeServer.

I saw no reason why this wouldnt work now.
Please let me know if i missed something.