### PR TITLE
Show more detail for UnprocessableEntity

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -148,3 +148,6 @@ PercentLiteralDelimiters:
     "%w": ()
     "%W": ()
     "%x": ()
+
+Security/YAMLLoad:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 * Add to documentation for TeamCity CI setup - [@atelic](https://github.com/atelic)
+* Show more error detail for UnprocessableEntity - [@litmon](https://github.com/litmon)
 
 ## 5.3.2
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -329,8 +329,17 @@ module Danger
           end
 
           if matching_comments.empty?
-            client.create_pull_request_comment(ci_source.repo_slug, ci_source.pull_request_id,
-                                               body, head_ref, m.file, position)
+            begin
+              client.create_pull_request_comment(ci_source.repo_slug, ci_source.pull_request_id,
+                                                 body, head_ref, m.file, position)
+            rescue Octokit::UnprocessableEntity => e
+              # Show more detail for UnprocessableEntity error
+              message = [e, "body: #{body}", "head_ref: #{head_ref}", "filename: #{m.file}", "position: #{position}"].join("\n")
+              puts message
+              
+              # Not reject because this comment has not completed
+              next false
+            end
           else
             # Remove the surviving comment so we don't strike it out
             danger_comments.reject! { |c| matching_comments.include? c }

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -336,7 +336,7 @@ module Danger
               # Show more detail for UnprocessableEntity error
               message = [e, "body: #{body}", "head_ref: #{head_ref}", "filename: #{m.file}", "position: #{position}"].join("\n")
               puts message
-              
+
               # Not reject because this comment has not completed
               next false
             end


### PR DESCRIPTION
Danger crashed and stopped CI Job because of Octokit::UnprocessableEntity when use github inline-comments.
This is maybe Danger's bug but the causes could not found because its error has no information.
So, it makes to show more detail for UnprocessableEntity, and not fail CI job.

See detail: https://github.com/danger/danger/issues/774