### PR TITLE
Add buddybuild support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## 5.3.0
 
+* Add actual support for [buddybuild](buddybuild.com) - [@palleas](https://github.com/palleas)
 * Improve remotes parsing for init command - [@sleekybadger](https://github.com/sleekybadger)
 * Adds ability to get the whole diff object at `git.diff` - This lets you do
   more fine grained checks on the raw changes. - [@sleekybadger](https://github.com/sleekybadger)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
+* Add actual support for [buddybuild](buddybuild.com) - [@palleas](https://github.com/palleas)
+ 
 ## 5.3.3
 
 * Add to documentation for TeamCity CI setup - [@atelic](https://github.com/atelic)
@@ -23,7 +25,6 @@
 
 ## 5.3.0
 
-* Add actual support for [buddybuild](buddybuild.com) - [@palleas](https://github.com/palleas)
 * Improve remotes parsing for init command - [@sleekybadger](https://github.com/sleekybadger)
 * Adds ability to get the whole diff object at `git.diff` - This lets you do
   more fine grained checks on the raw changes. - [@sleekybadger](https://github.com/sleekybadger)

--- a/lib/danger/ci_source/buddybuild.rb
+++ b/lib/danger/ci_source/buddybuild.rb
@@ -18,18 +18,34 @@ module Danger
   # Add the `DANGER_GITLAB_API_TOKEN` to your build user's ENV.
 
   class Buddybuild < CI
-    def self.validates_as_ci?(_)
-      false
+
+    #######################################################################
+    def self.validates_as_ci?(env)
+      value = env["BUDDYBUILD_BUILD_ID"]
+      return !value.nil? && !env["BUDDYBUILD_BUILD_ID"].empty?
     end
 
-    def self.validates_as_pr?(_)
-      false
+    #######################################################################
+    def self.validates_as_pr?(env)
+      value = env["BUDDYBUILD_PULL_REQUEST"]
+      return !value.nil? && !env["BUDDYBUILD_PULL_REQUEST"].empty?
     end
 
-    def initialize(_) end
-
+    #######################################################################
     def supported_request_sources
-      @supported_request_sources ||= []
+      @supported_request_sources ||= [
+          Danger::RequestSources::GitHub,
+          Danger::RequestSources::GitLab,
+          Danger::RequestSources::BitbucketServer,
+          Danger::RequestSources::BitbucketCloud
+      ]
+    end
+
+    #######################################################################
+    def initialize(env)
+      self.repo_slug = env["BUDDYBUILD_REPO_SLUG"]
+      self.pull_request_id = env["BUDDYBUILD_PULL_REQUEST"]
+      self.repo_url = GitRepo.new.origins # Buddybuild doesn't provide a repo url env variable for now
     end
   end
 end

--- a/lib/danger/ci_source/buddybuild.rb
+++ b/lib/danger/ci_source/buddybuild.rb
@@ -18,7 +18,7 @@ module Danger
   # to your build user's ENV.
   #
   # #### Bitbucket server
-  # Add the `DANGER_BITBUCKETSERVER_USERNAME`, `DANGER_BITBUCKETSERVER_PASSWORD` 
+  # Add the `DANGER_BITBUCKETSERVER_USERNAME`, `DANGER_BITBUCKETSERVER_PASSWORD`
   # and `DANGER_BITBUCKETSERVER_HOST` to your build user's ENV.
   #
   class Buddybuild < CI
@@ -38,10 +38,10 @@ module Danger
     #######################################################################
     def supported_request_sources
       @supported_request_sources ||= [
-          Danger::RequestSources::GitHub,
-          Danger::RequestSources::GitLab,
-          Danger::RequestSources::BitbucketServer,
-          Danger::RequestSources::BitbucketCloud
+        Danger::RequestSources::GitHub,
+        Danger::RequestSources::GitLab,
+        Danger::RequestSources::BitbucketServer,
+        Danger::RequestSources::BitbucketCloud
       ]
     end
 

--- a/lib/danger/ci_source/buddybuild.rb
+++ b/lib/danger/ci_source/buddybuild.rb
@@ -22,7 +22,6 @@ module Danger
   # and `DANGER_BITBUCKETSERVER_HOST` to your build user's ENV.
   #
   class Buddybuild < CI
-
     #######################################################################
     def self.validates_as_ci?(env)
       value = env["BUDDYBUILD_BUILD_ID"]

--- a/lib/danger/ci_source/buddybuild.rb
+++ b/lib/danger/ci_source/buddybuild.rb
@@ -21,6 +21,11 @@ module Danger
   # Add the `DANGER_BITBUCKETSERVER_USERNAME`, `DANGER_BITBUCKETSERVER_PASSWORD`
   # and `DANGER_BITBUCKETSERVER_HOST` to your build user's ENV.
   #
+  # ### Running Danger
+  #
+  # Once the environment variables are all available, create a custom build step
+  # to run Danger as part of your build process:
+  # http://docs.buddybuild.com/docs/custom-prebuild-and-postbuild-steps
   class Buddybuild < CI
     #######################################################################
     def self.validates_as_ci?(env)

--- a/lib/danger/ci_source/buddybuild.rb
+++ b/lib/danger/ci_source/buddybuild.rb
@@ -1,22 +1,26 @@
 module Danger
   # ### CI Setup
   #
-  # Buddybuild has an integration for Danger already built-in.
-  # What you need to do is to upload your `Gemfile` and `Dangerfile` to
-  # the server and you should be all set-up. However, if you want to use
-  # different bot for Danger, you can do it with token setup described below.
-  #
   # ### Token Setup
   #
   # Login to buddybuild and select your app. Go to your *App Settings* and
   # in the *Build Settings* menu on the left, choose *Environment Variables*.
+  # http://docs.buddybuild.com/docs/environment-variables
   #
   # #### GitHub
   # Add the `DANGER_GITHUB_API_TOKEN` to your build user's ENV.
   #
   # #### GitLab
   # Add the `DANGER_GITLAB_API_TOKEN` to your build user's ENV.
-
+  #
+  # #### Bitbucket Cloud
+  # Add the `DANGER_BITBUCKETSERVER_USERNAME`, `DANGER_BITBUCKETSERVER_PASSWORD`
+  # to your build user's ENV.
+  #
+  # #### Bitbucket server
+  # Add the `DANGER_BITBUCKETSERVER_USERNAME`, `DANGER_BITBUCKETSERVER_PASSWORD` 
+  # and `DANGER_BITBUCKETSERVER_HOST` to your build user's ENV.
+  #
   class Buddybuild < CI
 
     #######################################################################

--- a/spec/lib/danger/ci_sources/buddybuild_spec.rb
+++ b/spec/lib/danger/ci_sources/buddybuild_spec.rb
@@ -1,0 +1,42 @@
+require "danger/ci_source/buddybuild"
+
+RSpec.describe Danger::Buddybuild do
+  let(:valid_env) do 
+    {
+      "BUDDYBUILD_BUILD_ID" => "595be087b095370001d8e0b3",
+      "BUDDYBUILD_PULL_REQUEST" => "4",
+      "BUDDYBUILD_REPO_SLUG" => "palleas/Batman"
+    }
+  end
+
+  let(:source) { described_class.new(valid_env) }
+
+  describe '.validates_as_ci?' do
+    it 'validates when the required env vars are set' do
+      expect(described_class.validates_as_ci?(valid_env)).to be true
+    end
+
+    it 'does not validate when the required env vars are not set' do
+      valid_env["BUDDYBUILD_BUILD_ID"] = nil
+      expect(described_class.validates_as_ci?(valid_env)).to be false
+    end
+  end
+
+  describe '.validates_as_pr?' do
+    it 'validates when the required env vars are set' do
+      expect(described_class.validates_as_pr?(valid_env)).to be true
+    end
+
+    it 'does not validate when the required env vars are not set' do
+      valid_env["BUDDYBUILD_PULL_REQUEST"] = nil
+      expect(described_class.validates_as_pr?(valid_env)).to be false
+    end
+  end
+
+  describe '.new' do
+    it 'sets the repository slug' do
+      expect(source.repo_slug).to eq("palleas/Batman")
+      expect(source.pull_request_id).to eq("4")
+    end
+  end
+end


### PR DESCRIPTION
[Buddybuild](https://buddybuild.com) will drop the native support we have for Danger to encourage people to use [custom build steps instead](https://www.buddybuild.com/blog/customizing-the-build-process)

This PR adds **actual** support for buddybuild. I will run some test on my side to make sure it works (so far it does), but in the meantime, is there anything else I need to do? I'm mostly curious about Github Enterprise and Bitbucket server.