### PR TITLE
Multiple messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
 * Add actual support for [buddybuild](buddybuild.com) - [@palleas](https://github.com/palleas)
- 
+* Add ability to add multiple messages - [@sleekybadger](https://github.com/sleekybadger)
+
 ## 5.3.3
 
 * Add to documentation for TeamCity CI setup - [@atelic](https://github.com/atelic)

--- a/spec/lib/danger/ci_sources/buddybuild_spec.rb
+++ b/spec/lib/danger/ci_sources/buddybuild_spec.rb
@@ -1,7 +1,7 @@
 require "danger/ci_source/buddybuild"
 
 RSpec.describe Danger::Buddybuild do
-  let(:valid_env) do 
+  let(:valid_env) do
     {
       "BUDDYBUILD_BUILD_ID" => "595be087b095370001d8e0b3",
       "BUDDYBUILD_PULL_REQUEST" => "4",
@@ -11,30 +11,30 @@ RSpec.describe Danger::Buddybuild do
 
   let(:source) { described_class.new(valid_env) }
 
-  describe '.validates_as_ci?' do
-    it 'validates when the required env vars are set' do
+  describe ".validates_as_ci?" do
+    it "validates when the required env vars are set" do
       expect(described_class.validates_as_ci?(valid_env)).to be true
     end
 
-    it 'does not validate when the required env vars are not set' do
+    it "does not validate when the required env vars are not set" do
       valid_env["BUDDYBUILD_BUILD_ID"] = nil
       expect(described_class.validates_as_ci?(valid_env)).to be false
     end
   end
 
-  describe '.validates_as_pr?' do
-    it 'validates when the required env vars are set' do
+  describe ".validates_as_pr?" do
+    it "validates when the required env vars are set" do
       expect(described_class.validates_as_pr?(valid_env)).to be true
     end
 
-    it 'does not validate when the required env vars are not set' do
+    it "does not validate when the required env vars are not set" do
       valid_env["BUDDYBUILD_PULL_REQUEST"] = nil
       expect(described_class.validates_as_pr?(valid_env)).to be false
     end
   end
 
-  describe '.new' do
-    it 'sets the repository slug' do
+  describe ".new" do
+    it "sets the repository slug" do
       expect(source.repo_slug).to eq("palleas/Batman")
       expect(source.pull_request_id).to eq("4")
     end

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Danger::Dangerfile, host: :github do
 
       dm.parse Pathname.new(""), code
 
-      expect(dm).to receive(:print_list).with("Errors:".red, violations(["Another error", "An error"], sticky: false))
-      expect(dm).to receive(:print_list).with("Warnings:".yellow, violations(["Another warning", "A warning"], sticky: false))
-      expect(dm).to receive(:print_list).with("Messages:", violations(["A message"], sticky: false))
+      expect(dm).to receive(:print_list).with("Errors:".red, violations_factory(["Another error", "An error"], sticky: false))
+      expect(dm).to receive(:print_list).with("Warnings:".yellow, violations_factory(["Another warning", "A warning"], sticky: false))
+      expect(dm).to receive(:print_list).with("Messages:", violations_factory(["A message"], sticky: false))
 
       dm.print_results
     end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_messaging_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_messaging_plugin_spec.rb
@@ -1,0 +1,174 @@
+RSpec.describe Danger::DangerfileMessagingPlugin, host: :github do
+  subject(:dangerfile) { testing_dangerfile }
+
+  describe "#markdown" do
+    it "adds single markdown" do
+      dangerfile.parse(nil, "markdown('hello', file: 'foo.rb', line: 1)")
+      markdown = added_messages(dangerfile, :markdowns).first
+
+      expect(markdown.message).to eq("hello")
+      expect(markdown.file).to eq("foo.rb")
+      expect(markdown.line).to eq(1)
+    end
+
+    it "adds markdowns as array" do
+      dangerfile.parse(nil, "markdown(['hello'], file: 'foo.rb', line: 1)")
+      markdown = added_messages(dangerfile, :markdowns).first
+
+      expect(markdown.message).to eq("hello")
+      expect(markdown.file).to eq("foo.rb")
+      expect(markdown.line).to eq(1)
+    end
+
+    it "adds multiple markdowns" do
+      dangerfile.parse(nil, "markdown('hello', 'bye', file: 'foo.rb', line: 1)")
+      markdowns = added_messages(dangerfile, :markdowns)
+
+      expect(markdowns.first.message).to eq("hello")
+      expect(markdowns.first.file).to eq("foo.rb")
+      expect(markdowns.first.line).to eq(1)
+
+      expect(markdowns.last.message).to eq("bye")
+      expect(markdowns.last.file).to eq("foo.rb")
+      expect(markdowns.last.line).to eq(1)
+    end
+  end
+
+  describe "#message" do
+    it "adds single message" do
+      dangerfile.parse(nil, "message('hello', file: 'foo.rb', line: 1)")
+      message = added_messages(dangerfile, :messages).first
+
+      expect(message.message).to eq("hello")
+      expect(message.file).to eq("foo.rb")
+      expect(message.line).to eq(1)
+    end
+
+    it "adds messages as array" do
+      dangerfile.parse(nil, "message(['hello'], file: 'foo.rb', line: 1)")
+      message = added_messages(dangerfile, :messages).first
+
+      expect(message.message).to eq("hello")
+      expect(message.file).to eq("foo.rb")
+      expect(message.line).to eq(1)
+    end
+
+    it "adds multiple messages" do
+      dangerfile.parse(nil, "message('hello', 'bye', file: 'foo.rb', line: 1)")
+      messages = added_messages(dangerfile, :messages)
+
+      expect(messages.first.message).to eq("hello")
+      expect(messages.first.file).to eq("foo.rb")
+      expect(messages.first.line).to eq(1)
+
+      expect(messages.last.message).to eq("bye")
+      expect(messages.last.file).to eq("foo.rb")
+      expect(messages.last.line).to eq(1)
+    end
+  end
+
+  describe "#warn" do
+    it "adds single warning" do
+      dangerfile.parse(nil, "warn('hello', file: 'foo.rb', line: 1)")
+      warning = added_messages(dangerfile, :warnings).first
+
+      expect(warning.message).to eq("hello")
+      expect(warning.file).to eq("foo.rb")
+      expect(warning.line).to eq(1)
+    end
+
+    it "adds warnings as array" do
+      dangerfile.parse(nil, "warn(['hello'], file: 'foo.rb', line: 1)")
+      warning = added_messages(dangerfile, :warnings).first
+
+      expect(warning.message).to eq("hello")
+      expect(warning.file).to eq("foo.rb")
+      expect(warning.line).to eq(1)
+    end
+
+    it "adds multiple warnings" do
+      dangerfile.parse(nil, "warn('hello', 'bye', file: 'foo.rb', line: 1)")
+      warnings = added_messages(dangerfile, :warnings)
+
+      expect(warnings.first.message).to eq("hello")
+      expect(warnings.first.file).to eq("foo.rb")
+      expect(warnings.first.line).to eq(1)
+
+      expect(warnings.last.message).to eq("bye")
+      expect(warnings.last.file).to eq("foo.rb")
+      expect(warnings.last.line).to eq(1)
+    end
+  end
+
+  describe "#fail" do
+    it "adds single failure" do
+      dangerfile.parse(nil, "fail('hello', file: 'foo.rb', line: 1)")
+      failure = added_messages(dangerfile, :errors).first
+
+      expect(failure.message).to eq("hello")
+      expect(failure.file).to eq("foo.rb")
+      expect(failure.line).to eq(1)
+    end
+
+    it "adds failures as array" do
+      dangerfile.parse(nil, "fail(['hello'], file: 'foo.rb', line: 1)")
+      error = added_messages(dangerfile, :errors).first
+
+      expect(error.message).to eq("hello")
+      expect(error.file).to eq("foo.rb")
+      expect(error.line).to eq(1)
+    end
+
+    it "adds multiple failures" do
+      dangerfile.parse(nil, "fail('hello', 'bye', file: 'foo.rb', line: 1)")
+      failures = added_messages(dangerfile, :errors)
+
+      expect(failures.first.message).to eq("hello")
+      expect(failures.first.file).to eq("foo.rb")
+      expect(failures.first.line).to eq(1)
+
+      expect(failures.last.message).to eq("bye")
+      expect(failures.last.file).to eq("foo.rb")
+      expect(failures.last.line).to eq(1)
+    end
+  end
+
+  describe "#status_report" do
+    it "returns errors, warnings, messages and markdowns" do
+      code = "fail('failure');" \
+             "warn('warning');" \
+             "message('message');" \
+             "markdown('markdown')"
+
+      dangerfile.parse(nil, code)
+
+      expect(dangerfile.status_report).to eq(
+        errors: ["failure"],
+        warnings: ["warning"],
+        messages: ["message"],
+        markdowns: [markdown_factory("markdown")]
+      )
+    end
+  end
+
+  describe "#violation_report" do
+    it "returns errors, warnings and messages" do
+      code = "fail('failure');" \
+             "warn('warning');" \
+             "message('message');"
+
+      dangerfile.parse(nil, code)
+
+      expect(dangerfile.violation_report).to eq(
+        errors: [violation_factory("failure")],
+        warnings: [violation_factory("warning")],
+        messages: [violation_factory("message")]
+      )
+    end
+  end
+
+  def added_messages(dangerfile, type)
+    plugin = dangerfile.plugins.fetch(Danger::DangerfileMessagingPlugin)
+    plugin.instance_variable_get("@#{type}")
+  end
+end

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
 
       expect(violations.size).to be(1)
       expect(violations.first).to eq(
-        violation("<p>Please include a CHANGELOG entry. You can find it at <a href=\"https://github.com/danger/danger/blob/master/CHANGELOG.md\">CHANGELOG.md</a>.</p>", sticky: true)
+        violation_factory("<p>Please include a CHANGELOG entry. You can find it at <a href=\"https://github.com/danger/danger/blob/master/CHANGELOG.md\">CHANGELOG.md</a>.</p>", sticky: true)
       )
     end
   end
@@ -125,9 +125,9 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       expect(violations[:message]).to be_nil
 
       expect(violations[:error][0]).to eq(
-        violation("<p>Please include a CHANGELOG entry. You can find it at <a href=\"https://github.com/danger/danger/blob/master/CHANGELOG.md\">CHANGELOG.md</a>.</p>", sticky: true)
+        violation_factory("<p>Please include a CHANGELOG entry. You can find it at <a href=\"https://github.com/danger/danger/blob/master/CHANGELOG.md\">CHANGELOG.md</a>.</p>", sticky: true)
       )
-      expect(violations[:warning][0]).to eq(violation("<p>External contributor has edited the Gemspec</p>", sticky: true))
+      expect(violations[:warning][0]).to eq(violation_factory("<p>External contributor has edited the Gemspec</p>", sticky: true))
     end
 
     it "handles data-danger-table to identify danger tables" do
@@ -170,9 +170,9 @@ RSpec.describe Danger::Helpers::CommentsHelper do
   end
 
   describe "#table" do
-    let(:violation_1) { violation("**Violation 1**") }
+    let(:violation_1) { violation_factory("**Violation 1**") }
     let(:violation_2) do
-      violation("A [link](https://example.com)", sticky: true)
+      violation_factory("A [link](https://example.com)", sticky: true)
     end
 
     it "produces table data" do
@@ -221,10 +221,10 @@ RSpec.describe Danger::Helpers::CommentsHelper do
   describe "#generate_comment" do
     it "produces the expected comment" do
       comment = dummy.generate_comment(
-        warnings: [violation("This is a warning")],
-        errors: [violation("This is an error", sticky: true)],
-        messages: [violation("This is a message")],
-        markdowns: [markdown("*Raw markdown*")],
+        warnings: [violation_factory("This is a warning")],
+        errors: [violation_factory("This is an error", sticky: true)],
+        messages: [violation_factory("This is a message")],
+        markdowns: [markdown_factory("*Raw markdown*")],
         danger_id: "my_danger_id",
         template: "github"
       )
@@ -246,10 +246,10 @@ RSpec.describe Danger::Helpers::CommentsHelper do
     it "produces HTML that a CommonMark parser will accept inline" do
       ["github", "github_inline"].each do |template|
         comment = dummy.generate_comment(
-          warnings: [violation("This is a warning")],
-          errors: [violation("This is an error", sticky: true)],
-          messages: [violation("This is a message")],
-          markdowns: [markdown("*Raw markdown*")],
+          warnings: [violation_factory("This is a warning")],
+          errors: [violation_factory("This is an error", sticky: true)],
+          messages: [violation_factory("This is a message")],
+          markdowns: [markdown_factory("*Raw markdown*")],
           danger_id: "my_danger_id",
           template: template
         )
@@ -261,7 +261,7 @@ RSpec.describe Danger::Helpers::CommentsHelper do
 
     it "produces the expected comment when there are newlines" do
       comment = dummy.generate_comment(
-        warnings: [violation("This is a warning\nin two lines")],
+        warnings: [violation_factory("This is a warning\nin two lines")],
         errors: [],
         messages: [],
         markdowns: [],
@@ -277,10 +277,10 @@ RSpec.describe Danger::Helpers::CommentsHelper do
 
     it "produces a comment containing a summary" do
       comment = dummy.generate_comment(
-        warnings: [violation("Violations that are very very very very long should be truncated")],
-        errors: [violation("This is an error", sticky: true)],
-        messages: [violation("This is a message")],
-        markdowns: [markdown("*Raw markdown*")],
+        warnings: [violation_factory("Violations that are very very very very long should be truncated")],
+        errors: [violation_factory("This is an error", sticky: true)],
+        messages: [violation_factory("This is a message")],
+        markdowns: [markdown_factory("*Raw markdown*")],
         danger_id: "my_danger_id",
         template: "github"
       )
@@ -305,21 +305,21 @@ COMMENT
     end
 
     it "supports markdown code below the summary table" do
-      result = dummy.generate_comment(warnings: violations(["ups"]), markdowns: violations(["### h3"]))
+      result = dummy.generate_comment(warnings: violations_factory(["ups"]), markdowns: violations_factory(["### h3"]))
       expect(result.gsub(/\s+/, "")).to end_with(
         '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">ups</td></tr></tbody></table>###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">Danger</a></p>'
       )
     end
 
     it "supports markdown only without a table" do
-      result = dummy.generate_comment(markdowns: violations(["### h3"]))
+      result = dummy.generate_comment(markdowns: violations_factory(["### h3"]))
       expect(result.gsub(/\s+/, "")).to end_with(
         '###h3<palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">Danger</a></p>'
       )
     end
 
     it "some warnings, no errors" do
-      result = dummy.generate_comment(warnings: violations(["my warning", "second warning"]), errors: [], messages: [])
+      result = dummy.generate_comment(warnings: violations_factory(["my warning", "second warning"]), errors: [], messages: [])
       # rubocop:disable Metrics/LineLength
       expect(result.gsub(/\s+/, "")).to end_with(
         '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky="false">secondwarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">Danger</a></p>'
@@ -328,7 +328,7 @@ COMMENT
     end
 
     it "some warnings with markdown, no errors" do
-      warnings = violations(["a markdown [link to danger](https://github.com/danger/danger)", "second **warning**"])
+      warnings = violations_factory(["a markdown [link to danger](https://github.com/danger/danger)", "second **warning**"])
       result = dummy.generate_comment(warnings: warnings, errors: [], messages: [])
       # rubocop:disable Metrics/LineLength
       expect(result.gsub(/\s+/, "")).to end_with(
@@ -338,7 +338,7 @@ COMMENT
     end
 
     it "a multiline warning with markdown, no errors" do
-      warnings = violations(["a markdown [link to danger](https://github.com/danger/danger)\n\n```\nsomething\n```\n\nHello"])
+      warnings = violations_factory(["a markdown [link to danger](https://github.com/danger/danger)\n\n```\nsomething\n```\n\nHello"])
       result = dummy.generate_comment(warnings: warnings, errors: [], messages: [])
       # rubocop:disable Metrics/LineLength
       expect(result.gsub(/\s+/, "")).to end_with(
@@ -348,7 +348,7 @@ COMMENT
     end
 
     it "some warnings, some errors" do
-      result = dummy.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]), messages: [])
+      result = dummy.generate_comment(warnings: violations_factory(["my warning"]), errors: violations_factory(["some error"]), messages: [])
       # rubocop:disable Metrics/LineLength
       expect(result.gsub(/\s+/, "")).to end_with(
         '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">someerror</td></tr></tbody></table><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="http://danger.systems/">Danger</a></p>'
@@ -357,29 +357,29 @@ COMMENT
     end
 
     it "deduplicates previous violations" do
-      previous_violations = { error: violations(["an error", "an error"]) }
-      result = dummy.generate_comment(warnings: [], errors: violations([]), messages: [], previous_violations: previous_violations)
+      previous_violations = { error: violations_factory(["an error", "an error"]) }
+      result = dummy.generate_comment(warnings: [], errors: violations_factory([]), messages: [], previous_violations: previous_violations)
       expect(result.scan("an error").size).to eq(1)
     end
 
     it "includes a random compliment" do
-      previous_violations = { error: violations(["an error"]) }
-      result = dummy.generate_comment(warnings: [], errors: violations([]), messages: [], previous_violations: previous_violations)
+      previous_violations = { error: violations_factory(["an error"]) }
+      result = dummy.generate_comment(warnings: [], errors: violations_factory([]), messages: [], previous_violations: previous_violations)
       expect(result).to match(/:white_check_mark: \w+?/)
     end
 
     it "crosses resolved violations and changes the title" do
-      previous_violations = { error: violations(["an error"]) }
+      previous_violations = { error: violations_factory(["an error"]) }
       result = dummy.generate_comment(warnings: [], errors: [], messages: [], previous_violations: previous_violations)
       expect(result.gsub(/\s+/, "")).to include('<thwidth="100%"data-danger-table="true"data-kind="Error">:white_check_mark:')
       expect(result.gsub(/\s+/, "")).to include('<td>:white_check_mark:</td><tddata-sticky="true"><del>anerror</del></td>')
     end
 
     it "uncrosses violations that were on the list and happened again" do
-      previous_violations = { error: violations(["an error"]) }
+      previous_violations = { error: violations_factory(["an error"]) }
       result = dummy.generate_comment(
         warnings: [],
-        errors: violations(["an error"]),
+        errors: violations_factory(["an error"]),
         messages: [],
         previous_violations: previous_violations
       )
@@ -390,19 +390,19 @@ COMMENT
     end
 
     it "counts only unresolved violations on the title" do
-      previous_violations = { error: violations(["an error"]) }
-      result = dummy.generate_comment(warnings: [], errors: violations(["another error"]),
+      previous_violations = { error: violations_factory(["an error"]) }
+      result = dummy.generate_comment(warnings: [], errors: violations_factory(["another error"]),
                                    messages: [], previous_violations: previous_violations)
       expect(result.gsub(/\s+/, "")).to include('<thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th>')
     end
 
     it "needs to include generated_by_danger" do
-      result = dummy.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]), messages: [])
+      result = dummy.generate_comment(warnings: violations_factory(["my warning"]), errors: violations_factory(["some error"]), messages: [])
       expect(result.gsub(/\s+/, "")).to include("generated_by_danger")
     end
 
     it "handles a custom danger_id" do
-      result = dummy.generate_comment(warnings: violations(["my warning"]), errors: violations(["some error"]),
+      result = dummy.generate_comment(warnings: violations_factory(["my warning"]), errors: violations_factory(["some error"]),
                                    messages: [], danger_id: "another_danger")
       expect(result.gsub(/\s+/, "")).to include("generated_by_another_danger")
     end
@@ -421,7 +421,7 @@ COMMENT
 
     it "truncates comments which would exceed githubs maximum comment length" do
       warnings = (1..900).map { |i| "single long warning" * (rand(10) + 1) + i.to_s }
-      result = dummy.generate_comment(warnings: violations(warnings), errors: violations([]), messages: [])
+      result = dummy.generate_comment(warnings: violations_factory(warnings), errors: violations_factory([]), messages: [])
       expect(result.length).to be <= GITHUB_MAX_COMMENT_LENGTH
       expect(result).to include("has been truncated")
     end

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -178,17 +178,17 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "Shows an error messages when there are errors" do
-        message = @g.generate_description(warnings: violations([1, 2, 3]), errors: [])
+        message = @g.generate_description(warnings: violations_factory([1, 2, 3]), errors: [])
         expect(message).to eq("⚠️ 3 Warnings. Don't worry, everything is fixable.")
       end
 
       it "Shows an error message when errors and warnings" do
-        message = @g.generate_description(warnings: violations([1, 2]), errors: violations([1, 2, 3]))
+        message = @g.generate_description(warnings: violations_factory([1, 2]), errors: violations_factory([1, 2, 3]))
         expect(message).to eq("⚠️ 3 Errors. 2 Warnings. Don't worry, everything is fixable.")
       end
 
       it "Deals with singualars in messages when errors and warnings" do
-        message = @g.generate_description(warnings: violations([1]), errors: violations([1]))
+        message = @g.generate_description(warnings: violations_factory([1]), errors: violations_factory([1]))
         expect(message).to eq("⚠️ 1 Error. 1 Warning. Don't worry, everything is fixable.")
       end
     end
@@ -219,7 +219,7 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
         @g.pr_json = { "head" => { "sha" => "pr_commit_ref" }, "base" => { "repo" => { "private" => true } } }
 
         expect do
-          @g.submit_pull_request_status!(errors: violations(["error"]))
+          @g.submit_pull_request_status!(errors: violations_factory(["error"]))
         end.to raise_error.and output(/Danger has failed this build/).to_stderr
       end
 
@@ -229,7 +229,7 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
         @g.pr_json = { "head" => { "sha" => "pr_commit_ref" }, "base" => { "repo" => { "private" => true } } }
 
         expect do
-          @g.submit_pull_request_status!(warnings: violations(["error"]))
+          @g.submit_pull_request_status!(warnings: violations_factory(["error"]))
         end.to output(/warning.*not have write access/im).to_stdout
       end
     end
@@ -244,40 +244,40 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
         comments = []
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
 
-        body = @g.generate_comment(warnings: violations(["hi"]), errors: [], messages: [])
+        body = @g.generate_comment(warnings: violations_factory(["hi"]), errors: [], messages: [])
         expect(@g.client).to receive(:add_comment).with("artsy/eigen", "800", body).and_return({})
 
-        @g.update_pull_request!(warnings: violations(["hi"]), errors: [], messages: [])
+        @g.update_pull_request!(warnings: violations_factory(["hi"]), errors: [], messages: [])
       end
 
       it "updates the issue if no danger comments exist" do
         comments = [{ "body" => "generated_by_danger", "id" => "12" }]
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
 
-        body = @g.generate_comment(warnings: violations(["hi"]), errors: [], messages: [])
+        body = @g.generate_comment(warnings: violations_factory(["hi"]), errors: [], messages: [])
         expect(@g.client).to receive(:update_comment).with("artsy/eigen", "12", body).and_return({})
 
-        @g.update_pull_request!(warnings: violations(["hi"]), errors: [], messages: [])
+        @g.update_pull_request!(warnings: violations_factory(["hi"]), errors: [], messages: [])
       end
 
       it "creates a new comment instead of updating the issue if --new-comment is provided" do
         comments = [{ "body" => "generated_by_danger", "id" => "12" }]
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
 
-        body = @g.generate_comment(warnings: violations(["hi"]), errors: [], messages: [])
+        body = @g.generate_comment(warnings: violations_factory(["hi"]), errors: [], messages: [])
         expect(@g.client).to receive(:add_comment).with("artsy/eigen", "800", body).and_return({})
 
-        @g.update_pull_request!(warnings: violations(["hi"]), errors: [], messages: [], new_comment: true)
+        @g.update_pull_request!(warnings: violations_factory(["hi"]), errors: [], messages: [], new_comment: true)
       end
 
       it "updates the issue if no danger comments exist and a custom danger_id is provided" do
         comments = [{ "body" => "generated_by_another_danger", "id" => "12" }]
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
 
-        body = @g.generate_comment(warnings: violations(["hi"]), errors: [], messages: [], danger_id: "another_danger")
+        body = @g.generate_comment(warnings: violations_factory(["hi"]), errors: [], messages: [], danger_id: "another_danger")
         expect(@g.client).to receive(:update_comment).with("artsy/eigen", "12", body).and_return({})
 
-        @g.update_pull_request!(warnings: violations(["hi"]), errors: [], messages: [], danger_id: "another_danger")
+        @g.update_pull_request!(warnings: violations_factory(["hi"]), errors: [], messages: [], danger_id: "another_danger")
       end
 
       it "deletes existing comments if danger doesnt need to say anything" do

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -156,9 +156,9 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
     describe "#update_pull_request!" do
       it "creates a new comment when there is not one already" do
         body = subject.generate_comment(
-          warnings: violations(["Test warning"]),
-          errors: violations(["Test error"]),
-          messages: violations(["Test message"]),
+          warnings: violations_factory(["Test warning"]),
+          errors: violations_factory(["Test error"]),
+          messages: violations_factory(["Test message"]),
           template: "gitlab"
         )
         stub_request(:post, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes").with(
@@ -166,9 +166,9 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
           headers: expected_headers
         ).to_return(status: 200, body: "", headers: {})
         subject.update_pull_request!(
-          warnings: violations(["Test warning"]),
-          errors: violations(["Test error"]),
-          messages: violations(["Test message"])
+          warnings: violations_factory(["Test warning"]),
+          errors: violations_factory(["Test error"]),
+          messages: violations_factory(["Test message"])
         )
       end
 
@@ -186,12 +186,12 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
         it "updates the existing comment instead of creating a new one" do
           allow(subject).to receive(:random_compliment).and_return("random compliment")
           body = subject.generate_comment(
-            warnings: violations(["New Warning"]),
+            warnings: violations_factory(["New Warning"]),
             errors: [],
             messages: [],
             previous_violations: {
               warning: [],
-              error: violations(["Test error"]),
+              error: violations_factory(["Test error"]),
               message: []
             },
             template: "gitlab"
@@ -202,7 +202,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
           ).to_return(status: 200, body: "", headers: {})
 
           subject.update_pull_request!(
-            warnings: violations(["New Warning"]),
+            warnings: violations_factory(["New Warning"]),
             errors: [],
             messages: []
           )
@@ -210,9 +210,9 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
 
         it "creates a new comment instead of updating the existing one if --new-comment is provided" do
           body = subject.generate_comment(
-            warnings: violations(["Test warning"]),
-            errors: violations(["Test error"]),
-            messages: violations(["Test message"]),
+            warnings: violations_factory(["Test warning"]),
+            errors: violations_factory(["Test error"]),
+            messages: violations_factory(["Test message"]),
             template: "gitlab"
           )
           stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
@@ -220,9 +220,9 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
             headers: expected_headers
           ).to_return(status: 200, body: "", headers: {})
           subject.update_pull_request!(
-            warnings: violations(["Test warning"]),
-            errors: violations(["Test error"]),
-            messages: violations(["Test message"]),
+            warnings: violations_factory(["Test warning"]),
+            errors: violations_factory(["Test error"]),
+            messages: violations_factory(["Test message"]),
             new_comment: true
           )
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,20 +91,20 @@ def diff_fixture(file)
   File.read("spec/fixtures/#{file}.diff")
 end
 
-def violation(message, sticky: false)
+def violation_factory(message, sticky: false)
   Danger::Violation.new(message, sticky)
 end
 
-def violations(messages, sticky: false)
-  messages.map { |s| violation(s, sticky: sticky) }
+def violations_factory(messages, sticky: false)
+  messages.map { |s| violation_factory(s, sticky: sticky) }
 end
 
-def markdown(message)
+def markdown_factory(message)
   Danger::Markdown.new(message)
 end
 
-def markdowns(messages)
-  messages.map { |s| markdown(s) }
+def markdowns_factory(messages)
+  messages.map { |s| markdown_factory(s) }
 end
 
 def with_git_repo(origin: "git@github.com:artsy/eigen")


### PR DESCRIPTION
This should resolve https://github.com/danger/danger/issues/856. 

I extended danger messaging plugin api a little bit, so now it supports such usage:

```
message 'Hello World!'
message 'Hello', 'World!', file: 'foo.rb', line: 1
message ['Hello', 'World!'], sticky: true
```

Also I renamed `violation` and `markdown` factory methods from `spec_helper.rb`, cause they conflicted with messaging file api and I did not find better way to solve this 😞 

And make rubocop green again 💚 💚 💚 