### PR TITLE
Support for gitlab api v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add actual support for [buddybuild](buddybuild.com) - [@palleas](https://github.com/palleas)
 * Add ability to add multiple messages - [@sleekybadger](https://github.com/sleekybadger)
 * Use gitlab api v4, instead of deprecated v3 - [@sleekybadger](https://github.com/sleekybadger)
+* Add support for GitLabCI - [@sleekybadger](https://github.com/sleekybadger)
 
 ## 5.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add actual support for [buddybuild](buddybuild.com) - [@palleas](https://github.com/palleas)
 * Add ability to add multiple messages - [@sleekybadger](https://github.com/sleekybadger)
+* Use gitlab api v4, instead of deprecated v3 - [@sleekybadger](https://github.com/sleekybadger)
 
 ## 5.3.3
 

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -4,30 +4,54 @@ require "danger/request_sources/gitlab"
 
 module Danger
   # ### CI Setup
-  # GitLab CI is currently not supported because GitLab's runners don't expose
-  # the required values in the environment. Namely CI_MERGE_REQUEST_ID does not
-  # exist as of yet, however there is an
-  # [MR](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/5698) fixing this.
-  # If that has been merged and you are using either gitlab.com or a release
-  # with that change this CISource will work.
   #
+  # Install dependencies and add a danger step to your .gitlab-ci.yml:
+  # ``` yml
+  # before_script:
+  #  - bundle install
+  # danger:
+  #   script:
+  #    - bundle exec danger
+  # ```
+  # ### Token Setup
+  #
+  # Add the `DANGER_GITHUB_API_TOKEN` to your pipeline env variables.
   class GitLabCI < CI
     def self.validates_as_ci?(env)
       env.key? "GITLAB_CI"
     end
 
     def self.validates_as_pr?(env)
-      exists = ["CI_MERGE_REQUEST_ID", "CI_PROJECT_ID", "GITLAB_CI"].all? { |x| env[x] }
-      exists && env["CI_MERGE_REQUEST_ID"].to_i > 0
+      exists = [
+        "GITLAB_CI", "CI_PROJECT_ID"
+      ].all? { |x| env[x] }
+
+      exists && determine_merge_request_id(env).to_i > 0
     end
 
-    def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitLab]
+    def self.determine_merge_request_id(env)
+      return env["CI_MERGE_REQUEST_ID"] if env["CI_MERGE_REQUEST_ID"]
+      return 0 unless env["CI_COMMIT_SHA"]
+
+      project_id = env["CI_PROJECT_ID"]
+      base_commit = env["CI_COMMIT_SHA"]
+      client = RequestSources::GitLab.new(nil, env).client
+
+      merge_requests = client.merge_requests(project_id, state: :opened)
+      merge_request = merge_requests.auto_paginate.bsearch do |mr|
+        mr.sha == base_commit
+      end
+
+      merge_request.nil? ? 0 : merge_request.iid
     end
 
     def initialize(env)
       self.repo_slug = env["CI_PROJECT_ID"]
-      self.pull_request_id = env["CI_MERGE_REQUEST_ID"]
+      self.pull_request_id = self.class.determine_merge_request_id(env)
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= [Danger::RequestSources::GitLab]
     end
   end
 end

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -33,10 +33,7 @@ module Danger
         # The require happens inline so that it won't cause exceptions when just using the `danger` gem.
         require "gitlab"
 
-        params = { private_token: token }
-        params[:endpoint] = endpoint
-
-        @client ||= Gitlab.client(params)
+        @client ||= Gitlab.client(endpoint: endpoint, private_token: token)
       rescue LoadError
         puts "The GitLab gem was not installed, you will need to change your Gem from `danger` to `danger-gitlab`.".red
         puts "\n - See https://github.com/danger/danger/blob/master/CHANGELOG.md#400"
@@ -52,7 +49,8 @@ module Danger
       end
 
       def endpoint
-        @endpoint ||= @environment["DANGER_GITLAB_API_BASE_URL"] || "https://gitlab.com/api/v3"
+        @endpoint ||= @environment["DANGER_GITLAB_API_BASE_URL"] ||
+                      "https://gitlab.com/api/v4"
       end
 
       def host
@@ -135,7 +133,10 @@ module Danger
           else
             original_id = editable_comments.first.id
             client.edit_merge_request_comment(
-              ci_source.repo_slug, ci_source.pull_request_id, original_id, body
+              ci_source.repo_slug,
+              ci_source.pull_request_id,
+              original_id,
+              { body: body }
             )
           end
         end

--- a/spec/fixtures/gitlab_api/merge_request_593728_comments_existing_danger_comment_response.json
+++ b/spec/fixtures/gitlab_api/merge_request_593728_comments_existing_danger_comment_response.json
@@ -5,7 +5,7 @@ Content-Type: application/json
 Content-Length: 4268
 Cache-Control: max-age=0, private, must-revalidate
 Etag: W/"96ab78e8b2a9877ef87a8949b18be8a6"
-Link: <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
+Link: <https://gitlab.com/api/v4/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
 Status: 200 OK
 Vary: Origin
 X-Next-Page:

--- a/spec/fixtures/gitlab_api/merge_request_593728_comments_no_stickies_response.json
+++ b/spec/fixtures/gitlab_api/merge_request_593728_comments_no_stickies_response.json
@@ -5,7 +5,7 @@ Content-Type: application/json
 Content-Length: 4269
 Cache-Control: max-age=0, private, must-revalidate
 Etag: W/"523873940d3665b9a0193652c6e8c578"
-Link: <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
+Link: <https://gitlab.com/api/v4/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
 Status: 200 OK
 Vary: Origin
 X-Next-Page:

--- a/spec/fixtures/gitlab_api/merge_request_593728_comments_response.json
+++ b/spec/fixtures/gitlab_api/merge_request_593728_comments_response.json
@@ -5,7 +5,7 @@ Content-Type: application/json
 Content-Length: 1507
 Cache-Control: max-age=0, private, must-revalidate
 Etag: W/"e810a3b50890dd0a5823597abbbf9fc9"
-Link: <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
+Link: <https://gitlab.com/api/v4/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v3/projects/k0nserv/danger-test/merge_requests/593728/notes?id=k0nserv/danger-test&merge_request_id=593728&page=1&per_page=20>; rel="last"
 Status: 200 OK
 Vary: Origin
 X-Next-Page:

--- a/spec/fixtures/gitlab_api/merge_requests_response.json
+++ b/spec/fixtures/gitlab_api/merge_requests_response.json
@@ -1,0 +1,33 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Sun, 17 Jul 2016 13:05:46 GMT
+Content-Type: application/json
+Content-Length: 1507
+Cache-Control: max-age=0, private, must-revalidate
+Etag: W/"e810a3b50890dd0a5823597abbbf9fc9"
+Link: <https://gitlab.com/api/v4/projects/k0nserv/danger-test/merge_requests?state=opened&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v4/projects/k0nserv/danger-test/merge_requests?state=opened&page=1&per_page=20>; rel="last"
+Status: 200 OK
+Vary: Origin
+X-Next-Page:
+X-Page: 1
+X-Per-Page: 20
+X-Prev-Page:
+X-Request-Id: dee4a515-c1dd-4fec-8665-e6ce44bc6c41
+X-Runtime: 0.079596
+X-Total: 3
+X-Total-Pages: 1
+
+[
+  {
+    "iid": 1,
+    "sha": "1111111111111111111111111111111111111111"
+  },
+  {
+    "iid": 2,
+    "sha": "2222222222222222222222222222222222222222"
+  },
+  {
+    "iid": 3,
+    "sha": "3333333333333333333333333333333333333333"
+  }
+]

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -26,9 +26,39 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
       end
     end
 
+    describe ".determine_merge_request_id" do
+      context "when CI_MERGE_REQUEST_ID present in envrionment" do
+        it "returns CI_MERGE_REQUEST_ID" do
+          expect(described_class.determine_merge_request_id({
+            "CI_MERGE_REQUEST_ID" => 1
+          })).to eq(1)
+        end
+      end
+
+      context "when CI_COMMIT_SHA not present in envrionment" do
+        it "returns 0" do
+          expect(described_class.determine_merge_request_id({})).to eq(0)
+        end
+      end
+
+      context "when CI_COMMIT_SHA present in envrionment" do
+        it "uses gitlab api to find merge request id" do
+          stub_merge_requests("merge_requests_response", "danger%2Fdanger")
+
+          expect(described_class.determine_merge_request_id({
+            "CI_PROJECT_ID" => "danger/danger",
+            "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
+            "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
+          })).to eq(3)
+        end
+      end
+    end
+
     describe "#supported_request_sources" do
       it "it is gitlab" do
-        expect(ci_source.supported_request_sources).to eq([Danger::RequestSources::GitLab])
+        expect(ci_source.supported_request_sources).to eq([
+          Danger::RequestSources::GitLab
+        ])
       end
     end
 

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
 
   describe "the GitLab API endpoint" do
     it "sets the default GitLab API endpoint" do
-      expect(subject.endpoint).to eq("https://gitlab.com/api/v3")
+      expect(subject.endpoint).to eq("https://gitlab.com/api/v4")
     end
 
     it "allows the GitLab API endpoint to be overidden with `DANGER_GITLAB_API_BASE_URL`" do
@@ -40,7 +40,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
     end
 
     it "set the default API endpoint" do
-      expect(subject.client.endpoint).to eq("https://gitlab.com/api/v3")
+      expect(subject.client.endpoint).to eq("https://gitlab.com/api/v4")
     end
 
     it "respects overriding the API endpoint" do
@@ -161,7 +161,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
           messages: violations_factory(["Test message"]),
           template: "gitlab"
         )
-        stub_request(:post, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes").with(
+        stub_request(:post, "https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes").with(
           body: "body=#{ERB::Util.url_encode(body)}",
           headers: expected_headers
         ).to_return(status: 200, body: "", headers: {})
@@ -196,8 +196,10 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
             },
             template: "gitlab"
           )
-          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
-            body: "body=#{ERB::Util.url_encode(body)}",
+          stub_request(:put, "https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
+            body: {
+              body: body
+            },
             headers: expected_headers
           ).to_return(status: 200, body: "", headers: {})
 
@@ -215,8 +217,10 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
             messages: violations_factory(["Test message"]),
             template: "gitlab"
           )
-          stub_request(:put, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
-            body: "body=#{ERB::Util.url_encode(body)}",
+          stub_request(:put, "https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
+            body: {
+              body: body
+            },
             headers: expected_headers
           ).to_return(status: 200, body: "", headers: {})
           subject.update_pull_request!(
@@ -240,7 +244,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
         end
 
         it "removes the previous danger comment if there are no new messages" do
-          stub_request(:delete, "https://gitlab.com/api/v3/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
+          stub_request(:delete, "https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/merge_requests/593728/notes/13471894").with(
             headers: expected_headers
           )
 

--- a/spec/support/gitlab_helper.rb
+++ b/spec/support/gitlab_helper.rb
@@ -26,6 +26,12 @@ module Danger
         Danger::RequestSources::GitLab.new(stub_ci, stub_env)
       end
 
+      def stub_merge_requests(fixture, slug)
+        raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
+        url = "https://gitlab.com/api/v4/projects/#{slug}/merge_requests?state=opened"
+        WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
+      end
+
       def stub_merge_request(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
         url = "https://gitlab.com/api/v4/projects/#{slug}/merge_requests/#{merge_request_id}"

--- a/spec/support/gitlab_helper.rb
+++ b/spec/support/gitlab_helper.rb
@@ -28,25 +28,25 @@ module Danger
 
       def stub_merge_request(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}"
+        url = "https://gitlab.com/api/v4/projects/#{slug}/merge_requests/#{merge_request_id}"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 
       def stub_merge_request_changes(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}/changes"
+        url = "https://gitlab.com/api/v4/projects/#{slug}/merge_requests/#{merge_request_id}/changes"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 
       def stub_merge_request_commits(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}/commits"
+        url = "https://gitlab.com/api/v4/projects/#{slug}/merge_requests/#{merge_request_id}/commits"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 
       def stub_merge_request_comments(fixture, slug, merge_request_id)
         raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
-        url = "https://gitlab.com/api/v3/projects/#{slug}/merge_requests/#{merge_request_id}/notes?per_page=100"
+        url = "https://gitlab.com/api/v4/projects/#{slug}/merge_requests/#{merge_request_id}/notes?per_page=100"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
     end


### PR DESCRIPTION
This should resolve https://github.com/danger/danger/issues/860.

### Summary 
It turned out, that support for v4 doesn't require a lot of changes. But we need to check that everything works as expected, right now we support gitlab for:

- ~~[Bitrise](https://www.bitrise.io)~~ ✅ 
- ~~[Buddybuild](https://www.buddybuild.com)~~ ✅ 
- [Buildkite](https://buildkite.com)
- [Drone](https://github.com/drone/drone)
- [GitLabCI](https://about.gitlab.com/features/gitlab-ci-cd)
- ~~[Jenkins](https://jenkins.io)~~ ✅ 
- [TeamCity](https://www.jetbrains.com/teamcity)

So, I will appreciate any help in testing the remaining ci's 🙏 
You can do this via my danger fork:
```ruby
gem 'danger', github: 'sleekybadger/danger', 
              branch: 'feature/gitlab-api-v4'
```

### P.S.
Right now, if you will use this PR, make sure that you have `gitlab` gem with version 4.2.0. Dependencies in [danger-gitlab](https://github.com/danger/danger-gitlab-gem) not bumped yet