### PR TITLE
Correct CHANGELOG title for latest version to 5.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
-## 5.3.3
+## 5.3.4
 
 This release adds compatibility for GitLab API v4, you need to update the [danger-gitlab gem](https://github.com/danger/danger-gitlab-gem) to be version `6.x` when you migrate to the new API. 👍
 


### PR DESCRIPTION
# What
Simple edit to CHANGELOG.md file. Pretty sure the latest was supposed to be `5.3.4` as per the commit https://github.com/danger/danger/commit/942420b85a76e6970e9eb3bc01e3e2d14091a673