### PR TITLE
Add `verify_ssl` argument to skip ssl verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 * Tightens up pronouns in `danger init`.
+* Add `--verify-ssl` option to bypass Octokit's SSL Verification
+* Add `no_proxy_fix` gem as Ruby's no proxy is not working in `2.4.0/2.4.1`
 
 ## 5.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 * Tightens up pronouns in `danger init`.
-* Add `--verify-ssl` option to bypass Octokit's SSL Verification
-* Add `no_proxy_fix` gem as Ruby's no proxy is not working in `2.4.0/2.4.1`
+* Add `--verify-ssl` option to bypass Octokit's SSL Verification - [@nikhilsh](https://github.com/nikhilsh)
+* Add `no_proxy_fix` gem as Ruby's no proxy is not working in `2.4.0/2.4.1` - [@nikhilsh](https://github.com/nikhilsh)
 
 ## 5.3.4
 

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown", "~> 1.5"
   spec.add_runtime_dependency "terminal-table", "~> 1"
   spec.add_runtime_dependency "cork", "~> 0.1"
+  spec.add_runtime_dependency "no_proxy_fix"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -75,7 +75,7 @@ module Danger
       cache_file = File.join(cache_dir, "danger_local_cache")
       cache = HTTPCache.new(cache_file, clear_cache: @clear_http_cache)
       Octokit.configure do |config|
-        config.connection_options[:ssl] = { :verify => @verify_ssl }
+        config.connection_options[:ssl] = { verify: @verify_ssl }
       end
       Octokit.middleware = Faraday::RackBuilder.new do |builder|
         builder.use Faraday::HttpCache, store: cache, serializer: Marshal, shared_cache: false

--- a/spec/lib/danger/commands/pr_spec.rb
+++ b/spec/lib/danger/commands/pr_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Danger::PR do
       expect(result).to include ["--clear-http-cache", "Clear the local http cache before running Danger locally."]
       expect(result).to include ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
       expect(result).to include ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"]
+      expect(result).to include ["--verify-ssl", "Verify SSL in Octokit"]
+
     end
 
     it "dangerfile can be set" do
@@ -56,14 +58,15 @@ RSpec.describe Danger::PR do
   end
 
   context "default options" do
-    it "pr url is nil and clear_http_cache defaults to false" do
+    it "pr url is nil, clear_http_cache defaults to false and verify-ssl defaults to true" do
       argv = CLAide::ARGV.new([])
 
       result = described_class.new(argv)
 
       expect(result).to have_instance_variables(
         "@pr_url" => nil,
-        "@clear_http_cache" => false
+        "@clear_http_cache" => false,
+        "@verify_ssl" => true
       )
     end
   end


### PR DESCRIPTION

- Add tests for verify ssl
- Add no_proxy_fix gem to fix issue in Ruby 2.4.0/2.4.1

As discussed in https://github.com/danger/danger/issues/830

Done with the help of @winston

