### PR TITLE
Fix implementation of bsearch in GitlabCI#determine_merge_request_id

### DIFF
--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -39,7 +39,7 @@ module Danger
 
       merge_requests = client.merge_requests(project_id, state: :opened)
       merge_request = merge_requests.auto_paginate.bsearch do |mr|
-        mr.sha == base_commit
+        mr.sha >= base_commit
       end
 
       merge_request.nil? ? 0 : merge_request.iid


### PR DESCRIPTION
This is a very simple PR, just change the `==` operator to `>=` according to [ruby doc](https://ruby-doc.org/core-2.2.0/Array.html#method-i-bsearch)