### PR TITLE
Add support for toggling SSL Verification for Octokit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
+## 5.4.1
+
+* Add support to pass in `DANGER_OCTOKIT_VERIFY_SSL` to toggle SSL Verification for Octokit - [@nikhilsh](https://github.com/nikhilsh)
+
 ## 5.4.0
 
 * Add support for VSTS - [@petester42](https://github.com/petester42)

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -43,6 +43,36 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
     end
   end
 
+  describe "ssl verification" do
+    it "sets ssl verification environment variable to false" do
+      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com", "DANGER_OCTOKIT_VERIFY_SSL" => "false" }
+
+      result = Danger::RequestSources::GitHub.new(stub_ci, gh_env).verify_ssl
+      expect(result).to be_falsey
+    end
+
+    it "sets ssl verification environment variable to true" do
+      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com", "DANGER_OCTOKIT_VERIFY_SSL" => "true" }
+
+      result = Danger::RequestSources::GitHub.new(stub_ci, gh_env).verify_ssl
+      expect(result).to be_truthy
+    end
+
+    it "sets ssl verification environment variable to wrong input" do
+      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com", "DANGER_OCTOKIT_VERIFY_SSL" => "wronginput" }
+
+      result = Danger::RequestSources::GitHub.new(stub_ci, gh_env).verify_ssl
+      expect(result).to be_truthy
+    end
+
+    it "unsets ssl verification environment variable" do
+      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com" }
+
+      result = Danger::RequestSources::GitHub.new(stub_ci, gh_env).verify_ssl
+      expect(result).to be_truthy
+    end
+  end
+
   describe "valid server response" do
     before do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi" }


### PR DESCRIPTION
This is similar to #880, in that it allows toggling of Octokit's SSL Verification. In #880, only the `pr` command had an option to toggle SSL verification (e.g. `bundle exec danger pr --verify-ssl`). 

While that PR added the verification toggling for PR, danger (`bundle exec danger`) itself didn't have the option to toggle SSL Verification. After looking through `runner.rb` and how it passes arguments down to Octokit, I surmised that a clean way to allow toggling would be to simply read an environment variable (`DANGER_OCTOKIT_VERIFY_SSL`) that would be used by `Octokit` when starting up the Octokit client. 

This would prevent introducing a new argument in command line and having to pass that down several layers to get Octokit to use it from within `github.rb`. 

As should be expected, not having `DANGER_OCTOKIT_VERIFY_SSL` would leave SSL verification, as is the default behaviour. 