### PR TITLE
Add support for Codeship CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
+* Add support for [Codeship](https://codeship.com/) - [@ghiculescu](https://github.com/ghiculescu)
 
 ## 5.4.1
 

--- a/lib/danger/ci_source/codeship.rb
+++ b/lib/danger/ci_source/codeship.rb
@@ -19,12 +19,16 @@ module Danger
     def self.validates_as_pr?(env)
       return false unless env["CI_BRANCH"] && !env["CI_BRANCH"].empty?
 
-      # this is fairly hacky, see https://github.com/danger/danger/pull/892#issuecomment-329030616 for why
-      !Danger::RequestSources::GitHub.new(nil, env).get_pr_from_branch(env["CI_REPO_NAME"], env["CI_BRANCH"], self.class.owner_for_github(env))
+      !pr_from_env(env, nil).nil?
     end
 
     def self.owner_for_github(env)
       env["CI_REPO_NAME"].split("/").first
+    end
+
+    # this is fairly hacky, see https://github.com/danger/danger/pull/892#issuecomment-329030616 for why
+    def self.pr_from_env(env, ci_source)
+      Danger::RequestSources::GitHub.new(nil, env).get_pr_from_branch(env["CI_REPO_NAME"], env["CI_BRANCH"], owner_for_github(env))
     end
 
     def supported_request_sources
@@ -33,7 +37,7 @@ module Danger
 
     def initialize(env)
       self.repo_slug = env["CI_REPO_NAME"]
-      self.pull_request_id = Danger::RequestSources::GitHub.new(self, env).get_pr_from_branch(env["CI_REPO_NAME"], env["CI_BRANCH"], self.class.owner_for_github(env))
+      self.pull_request_id = self.class.pr_from_env(env, self)
       self.repo_url = GitRepo.new.origins
     end
   end

--- a/lib/danger/ci_source/codeship.rb
+++ b/lib/danger/ci_source/codeship.rb
@@ -19,7 +19,7 @@ module Danger
     def self.validates_as_pr?(env)
       return false unless env["CI_BRANCH"] && !env["CI_BRANCH"].empty?
 
-      !pr_from_env(env, nil).nil?
+      !pr_from_env(env).nil?
     end
 
     def self.owner_for_github(env)
@@ -27,7 +27,7 @@ module Danger
     end
 
     # this is fairly hacky, see https://github.com/danger/danger/pull/892#issuecomment-329030616 for why
-    def self.pr_from_env(env, ci_source)
+    def self.pr_from_env(env)
       Danger::RequestSources::GitHub.new(nil, env).get_pr_from_branch(env["CI_REPO_NAME"], env["CI_BRANCH"], owner_for_github(env))
     end
 
@@ -37,7 +37,7 @@ module Danger
 
     def initialize(env)
       self.repo_slug = env["CI_REPO_NAME"]
-      self.pull_request_id = self.class.pr_from_env(env, self)
+      self.pull_request_id = self.class.pr_from_env(env)
       self.repo_url = GitRepo.new.origins
     end
   end

--- a/lib/danger/ci_source/codeship.rb
+++ b/lib/danger/ci_source/codeship.rb
@@ -1,0 +1,34 @@
+# https://semaphoreci.com/docs/available-environment-variables.html
+require "danger/request_sources/github/github"
+
+module Danger
+  # ### CI Setup
+  #
+  # In Codeship, go to your "Project Settings", then add `bundle exec danger` as a test step inside
+  # one of your pipelines.
+  #
+  # ### Token Setup
+  #
+  # Add your `DANGER_GITHUB_API_TOKEN` to "Environment" section in "Project Settings".
+  #
+  class Codeship < CI
+    def self.validates_as_ci?(env)
+      env["CI_NAME"] == "codeship"
+    end
+
+    def self.validates_as_pr?(env)
+      env["CI_BRANCH"] && !env["CI_BRANCH"].empty?
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+    end
+
+    def initialize(env)
+      self.repo_slug = env["CI_REPO_NAME"]
+      owner = env["CI_REPO_NAME"].split("/").first
+      self.pull_request_id = Danger::RequestSources::GitHub.new(self, env).get_pr_from_branch(env["CI_REPO_NAME"], env["CI_BRANCH"], owner)
+      self.repo_url = GitRepo.new.origins
+    end
+  end
+end

--- a/lib/danger/ci_source/codeship.rb
+++ b/lib/danger/ci_source/codeship.rb
@@ -17,7 +17,7 @@ module Danger
     end
 
     def self.validates_as_pr?(env)
-      env["CI_BRANCH"] && !env["CI_BRANCH"].empty?
+      env["CI_BRANCH"] && !env["CI_BRANCH"].empty? && env["CI_BRANCH"] == "master"
     end
 
     def supported_request_sources

--- a/lib/danger/ci_source/codeship.rb
+++ b/lib/danger/ci_source/codeship.rb
@@ -17,7 +17,7 @@ module Danger
     end
 
     def self.validates_as_pr?(env)
-      env["CI_BRANCH"] && !env["CI_BRANCH"].empty? && env["CI_BRANCH"] == "master"
+      env["CI_BRANCH"] && !env["CI_BRANCH"].empty? && env["CI_BRANCH"] != "master"
     end
 
     def supported_request_sources

--- a/lib/danger/ci_source/semaphore.rb
+++ b/lib/danger/ci_source/semaphore.rb
@@ -4,7 +4,7 @@ require "danger/request_sources/github/github"
 module Danger
   # ### CI Setup
   #
-  # For Semaphor you will want to go to the settings page of the project. Inside "Build Settings"
+  # For Semaphore you will want to go to the settings page of the project. Inside "Build Settings"
   # you should add `bundle exec danger` to the Setup thread. Note that Semaphore only provides
   # the build environment variables necessary for Danger on PRs across forks.
   #

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -33,6 +33,13 @@ module Danger
         @token = @environment["DANGER_GITHUB_API_TOKEN"]
       end
 
+      def get_pr_from_branch(repo_name, branch_name, owner)
+        prs = client.pull_requests(repo_name, head: "#{owner}:#{branch_name}")
+        unless prs.empty?
+          prs.first.number
+        end
+      end
+
       def validates_as_api_source?
         (@token && !@token.empty?) || self.environment["DANGER_USE_LOCAL_GIT"]
       end

--- a/spec/lib/danger/ci_sources/ci_source_spec.rb
+++ b/spec/lib/danger/ci_sources/ci_source_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Danger::CI do
           "Danger::TeamCity",
           "Danger::Travis",
           "Danger::VSTS",
-          "Danger::XcodeServer"
+          "Danger::XcodeServer",
+          "Danger::Codeship",
         ]
       )
     end


### PR DESCRIPTION
Added [codeship](https://codeship.com/) as a new CI source. I mostly copied the style of the Semaphore CI source, and used the same logic that [danger.js uses](https://github.com/danger/danger-js/blob/master/source/ci_source/providers/Codeship.ts#L40) in getting a PR from a branch name.