### PR TITLE
Fix Violation#to_s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
+* Fix `Violation#to_s` showing file and line when they are empty and not showing when they are set
 
 ## 5.4.1
 

--- a/lib/danger/danger_core/messages/violation.rb
+++ b/lib/danger/danger_core/messages/violation.rb
@@ -26,9 +26,9 @@ module Danger
 
     def to_s
       extra = []
-      extra << "sticky: true" if sticky
-      extra << "file: #{file}" unless file
-      extra << "line: #{line}" unless line
+      extra << "sticky: #{sticky}"
+      extra << "file: #{file}" if file
+      extra << "line: #{line}" if line
 
       "Violation #{message} { #{extra.join ', '.freeze} }"
     end

--- a/spec/lib/danger/danger_core/plugins/messages_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/messages_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Danger::Violation, host: :github do
+
+  describe "#to_s" do
+    it "formats a message" do
+      expect(violation_factory('hello!').to_s).to eq('Violation hello! { sticky: false }')
+    end
+
+    it "formats a sticky message" do
+      expect(violation_factory('hello!', sticky: true).to_s).to eq('Violation hello! { sticky: true }')
+    end
+
+    it "formats a message with file and line" do
+      expect(violation_factory('hello!', file: 'foo.rb', line: 2).to_s).to eq('Violation hello! { sticky: false, file: foo.rb, line: 2 }')
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,8 +92,8 @@ def diff_fixture(file)
   File.read("spec/fixtures/#{file}.diff")
 end
 
-def violation_factory(message, sticky: false)
-  Danger::Violation.new(message, sticky)
+def violation_factory(message, sticky: false, file: nil, line: nil)
+  Danger::Violation.new(message, sticky, file, line)
 end
 
 def violations_factory(messages, sticky: false)


### PR DESCRIPTION
It was showing file and line when they are empty and not showing when they are set.

Originally `spec/lib/danger/danger_core/plugins/messages_spec.rb` which I've added was failing like this.

<img width="949" alt="1____prog_danger___zsh_" src="https://user-images.githubusercontent.com/28143/30341825-7bb1eaa2-9832-11e7-95c7-5f926032fa02.png">


