### PR TITLE
Insert newline before binding.pry on _Dangerfile.tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Fix removing comments when one danger_id is a substring of another - [@marcelofabri](https://github.com/marcelofabri)
+* Fix possible invalid binding.pry statement when Dangerfile does not have an empty new line at the end (`danger pr --pry`) - [@pedrovieira](https://github.com/pedrovieira)
 
 ## 5.4.3
 

--- a/lib/danger/commands/local_helpers/pry_setup.rb
+++ b/lib/danger/commands/local_helpers/pry_setup.rb
@@ -9,7 +9,7 @@ module Danger
       validate_pry_available
       FileUtils.cp dangerfile_path, DANGERFILE_COPY
       File.open(DANGERFILE_COPY, "a") do |f|
-        f.write("binding.pry; File.delete(\"#{DANGERFILE_COPY}\")")
+        f.write("\nbinding.pry; File.delete(\"#{DANGERFILE_COPY}\")")
       end
       DANGERFILE_COPY
     end


### PR DESCRIPTION
Fix possible invalid `binding.pry` statement when Dangerfile does not have an empty new line at the end, when using `danger pr --pry`, by adding a newline manually.  

I discovered this bug when my Dangerfile ended with the keyword `end` and so the final line in the `_Dangerfile.tmp` was `endbinding.pry; File.delete("_Dangerfile.tmp")`, which resulted in an error.