### PR TITLE
Fix bug with gitlab v4 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 
+* Fix env name of jenkins gitlab plugin - [@marocchino](https://github.com/marocchino)
 * Fix removing comments when one danger_id is a substring of another - [@marcelofabri](https://github.com/marcelofabri)
 
 ## 5.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master
 
-* Fix env name of jenkins gitlab plugin - [@marocchino](https://github.com/marocchino)
+* Fix bug with gitlab v4 API- [@marocchino](https://github.com/marocchino)
 * Fix removing comments when one danger_id is a substring of another - [@marcelofabri](https://github.com/marcelofabri)
 
 ## 5.4.3

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -32,7 +32,11 @@ module Danger
   # #### General
   #
   # People occasionally see issues with Danger not classing your CI runs as a PR, to give you visibilty
-  # the Jenkins side of Danger expects to see one of these env vars: ghprbPullId, CHANGE_ID or gitlabMergeRequestIid
+  # the Jenkins side of Danger expects to see one of these env vars:
+  # - ghprbPullId
+  # - CHANGE_ID
+  # - gitlabMergeRequestIid
+  # - gitlabMergeRequestId
   #
   # ### Token Setup
   #
@@ -81,8 +85,10 @@ module Danger
         env["ghprbPullId"]
       elsif env["CHANGE_ID"]
         env["CHANGE_ID"]
-      else
+      elsif env["gitlabMergeRequestIid"]
         env["gitlabMergeRequestIid"]
+      else
+        env["gitlabMergeRequestId"]
       end
     end
 

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -32,7 +32,7 @@ module Danger
   # #### General
   #
   # People occasionally see issues with Danger not classing your CI runs as a PR, to give you visibilty
-  # the Jenkins side of Danger expects to see one of these env vars: ghprbPullId, CHANGE_ID or gitlabMergeRequestId
+  # the Jenkins side of Danger expects to see one of these env vars: ghprbPullId, CHANGE_ID or gitlabMergeRequestIid
   #
   # ### Token Setup
   #
@@ -82,7 +82,7 @@ module Danger
       elsif env["CHANGE_ID"]
         env["CHANGE_ID"]
       else
-        env["gitlabMergeRequestId"]
+        env["gitlabMergeRequestIid"]
       end
     end
 

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Danger::Jenkins do
         expect(described_class.validates_as_pr?(valid_env)).to be false
       end
 
-      it "doesn't validate_as_pr if pull_request_repo is the empty string" do
+      it "doesn't validate_as_pr if `ghprbPullId` is the empty string" do
         valid_env["ghprbPullId"] = ""
         expect(described_class.validates_as_pr?(valid_env)).to be false
       end
@@ -68,6 +68,7 @@ RSpec.describe Danger::Jenkins do
   context "with GitLab" do
     before do
       valid_env["gitlabMergeRequestIid"] = "1234"
+      valid_env["gitlabMergeRequestId"] = "2345"
       valid_env["GIT_URL"] = "https://gitlab.com/danger/danger.git"
     end
 
@@ -81,8 +82,18 @@ RSpec.describe Danger::Jenkins do
         expect(described_class.validates_as_ci?(valid_env)).to be true
       end
 
+      it "validates even when `gitlabMergeRequestId` is missing" do
+        valid_env["gitlabMergeRequestId"] = nil
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
       it "validates even when `gitlabMergeRequestIid` is empty" do
         valid_env["gitlabMergeRequestIid"] = ""
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "validates even when `gitlabMergeRequestId` is empty" do
+        valid_env["gitlabMergeRequestId"] = ""
         expect(described_class.validates_as_ci?(valid_env)).to be true
       end
 
@@ -96,13 +107,25 @@ RSpec.describe Danger::Jenkins do
         expect(described_class.validates_as_pr?(valid_env)).to be true
       end
 
-      it "doesn't validate if `gitlabMergeRequestIid` is missing" do
+      it "validates if `gitlabMergeRequestIid` is missing and `gitlabMergeRequestId` is set" do
         valid_env["gitlabMergeRequestIid"] = nil
+        expect(described_class.validates_as_pr?(valid_env)).to be true
+      end
+
+      it "doesn't validate_as_pr if `gitlabMergeRequestIid` is the empty string" do
+        valid_env["gitlabMergeRequestIid"] = ""
         expect(described_class.validates_as_pr?(valid_env)).to be false
       end
 
-      it "doesn't validate_as_pr if pull_request_repo is the empty string" do
-        valid_env["gitlabMergeRequestIid"] = ""
+      it "doesn't validate if `gitlabMergeRequestIid` is missing and `gitlabMergeRequestId` is missing" do
+        valid_env["gitlabMergeRequestIid"] = nil
+        valid_env["gitlabMergeRequestId"] = nil
+        expect(described_class.validates_as_pr?(valid_env)).to be false
+      end
+
+      it "doesn't validate_as_pr if `gitlabMergeRequestIid` is missing and `gitlabMergeRequestId` is the empty string" do
+        valid_env["gitlabMergeRequestIid"] = nil
+        valid_env["gitlabMergeRequestId"] = ""
         expect(described_class.validates_as_pr?(valid_env)).to be false
       end
 
@@ -151,7 +174,7 @@ RSpec.describe Danger::Jenkins do
         expect(described_class.validates_as_pr?(valid_env)).to be false
       end
 
-      it "doesn't validate_as_pr if pull_request_repo is the empty string" do
+      it "doesn't validate_as_pr if `CHANGE_ID` is the empty string" do
         valid_env["CHANGE_ID"] = ""
         expect(described_class.validates_as_pr?(valid_env)).to be false
       end

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Danger::Jenkins do
 
   context "with GitLab" do
     before do
-      valid_env["gitlabMergeRequestId"] = "1234"
+      valid_env["gitlabMergeRequestIid"] = "1234"
       valid_env["GIT_URL"] = "https://gitlab.com/danger/danger.git"
     end
 
@@ -76,13 +76,13 @@ RSpec.describe Danger::Jenkins do
         expect(described_class.validates_as_ci?(valid_env)).to be true
       end
 
-      it "validates even when `gitlabMergeRequestId` is missing" do
-        valid_env["gitlabMergeRequestId"] = nil
+      it "validates even when `gitlabMergeRequestIid` is missing" do
+        valid_env["gitlabMergeRequestIid"] = nil
         expect(described_class.validates_as_ci?(valid_env)).to be true
       end
 
-      it "validates even when `gitlabMergeRequestId` is empty" do
-        valid_env["gitlabMergeRequestId"] = ""
+      it "validates even when `gitlabMergeRequestIid` is empty" do
+        valid_env["gitlabMergeRequestIid"] = ""
         expect(described_class.validates_as_ci?(valid_env)).to be true
       end
 
@@ -96,13 +96,13 @@ RSpec.describe Danger::Jenkins do
         expect(described_class.validates_as_pr?(valid_env)).to be true
       end
 
-      it "doesn't validate if `gitlabMergeRequestId` is missing" do
-        valid_env["gitlabMergeRequestId"] = nil
+      it "doesn't validate if `gitlabMergeRequestIid` is missing" do
+        valid_env["gitlabMergeRequestIid"] = nil
         expect(described_class.validates_as_pr?(valid_env)).to be false
       end
 
       it "doesn't validate_as_pr if pull_request_repo is the empty string" do
-        valid_env["gitlabMergeRequestId"] = ""
+        valid_env["gitlabMergeRequestIid"] = ""
         expect(described_class.validates_as_pr?(valid_env)).to be false
       end
 

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -32,8 +32,20 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
       end
     end
 
-    it "loads Jenkins" do
+    it "loads Jenkins (Github)" do
       with_jenkins_setup_github_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::Jenkins
+      end
+    end
+
+    it "loads Jenkins (Gitlab)" do
+      with_jenkins_setup_gitlab_and_is_a_pull_request do |system_env|
+        expect(described_class.local_ci_source(system_env)).to eq Danger::Jenkins
+      end
+    end
+
+    it "loads Jenkins (Gitlab v3)" do
+      with_jenkins_setup_gitlab_v3_and_is_a_pull_request do |system_env|
         expect(described_class.local_ci_source(system_env)).to eq Danger::Jenkins
       end
     end
@@ -112,8 +124,20 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
       end
     end
 
-    it "loads Jenkins" do
+    it "loads Jenkins (Github)" do
       with_jenkins_setup_github_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Jenkins (Gitlab)" do
+      with_jenkins_setup_gitlab_and_is_a_pull_request do |system_env|
+        expect(described_class.pr?(system_env)).to eq(true)
+      end
+    end
+
+    it "loads Jenkins (Gitlab v3)" do
+      with_jenkins_setup_gitlab_v3_and_is_a_pull_request do |system_env|
         expect(described_class.pr?(system_env)).to eq(true)
       end
     end

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe Danger::Executor, use: :ci_helper do
         end
       end
 
+      it "not raises error on Jenkins (GitLab v3)" do
+        with_jenkins_setup_gitlab_v3_and_is_a_pull_request do |system_env|
+          expect { described_class.new(system_env).validate!(testing_ui) }.not_to raise_error
+        end
+      end
+
       it "not raises error on Local Git Repo" do
         with_localgitrepo_setup do |system_env|
           ui = testing_ui

--- a/spec/support/ci_helper.rb
+++ b/spec/support/ci_helper.rb
@@ -76,6 +76,15 @@ module Danger
         yield(system_env)
       end
 
+      def with_jenkins_setup_gitlab_v3_and_is_a_pull_request
+        system_env = {
+          "JENKINS_URL" => "https://ci.swift.org/job/oss-swift-incremental-RA-osx/lastBuild/",
+          "gitlabMergeRequestId" => "42"
+        }
+
+        yield(system_env)
+      end
+
       def with_localgitrepo_setup
         system_env = {
           "DANGER_USE_LOCAL_GIT" => "true"

--- a/spec/support/ci_helper.rb
+++ b/spec/support/ci_helper.rb
@@ -70,7 +70,7 @@ module Danger
       def with_jenkins_setup_gitlab_and_is_a_pull_request
         system_env = {
           "JENKINS_URL" => "https://ci.swift.org/job/oss-swift-incremental-RA-osx/lastBuild/",
-          "gitlabMergeRequestId" => "42"
+          "gitlabMergeRequestIid" => "42"
         }
 
         yield(system_env)


### PR DESCRIPTION
Currently, it failed with 404 errors.
According to gitlab's API doc we should be use merge_request_iid instead of
merge_request_id.

ref: https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr

///////////////////⚡///////////////////

# 🚫 AWESOME A PR!

- You can just delete all of this and start your PR text anytime -

Hello there, just a quick pre-warning of some of the Danger rules we run on Danger PRs.

The big one is we request that every code change to Danger include a CHANGELOG entry, 
this is so that:

1. People know what changes are between versions
2. Orta doesn't get all the credit for other people's work

Danger will look for a modification to the `CHANGELOG.md` when there are changes including
`lib/*` - if you're fixing unreleased code, or doing a simple typo change, you can
include `#trivial` in the title or the body of the PR and this is skipped.

We also request that you fill in the body of your PR, a title should be tweet length, but
ideally you can explain the PRs reasoning in the body. We look that it's longer than 5 chars.

Other than that, a lot of the other Danger rules are trickier to trigger so we can address
them as they come up!

❤ THANKS FOR HELPING OUT :D 

///////////////////⚡///////////////////