### PR TITLE
Look at locking the rubocop version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   # Tests use real git commands
   - git config --global user.email "danger@example.com"
   - git config --global user.name "Danger McShane"
+  - bundle exec rubocop -v
   - bundle exec rubocop lib
   - bundle exec rake spec
   - bundle exec danger --verbose

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gem "danger-gitlab"
 
 gem "danger-junit", "~> 0.5"
 gem "rspec_junit_formatter", git: "https://github.com/JuanitoFatas/rspec_junit_formatter.git", branch: "dump-rspec_junit_formatter-failed-examples"
-gem "rubocop"
+
+gem "rubocop", "0.44.1"


### PR DESCRIPTION
I'm not really sure _why_ the `bundle exec` is  being ignored, so I want to first verify that it's using 0.50.x 