### PR TITLE
Update Bitrise doc now that secret env vars are supported #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master
 
-* Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
+* Update documentation for BitRise CI now that it supports Secret Env Vars - [@AliSoftware](https://github.com/AliSoftware)
 
 ## 5.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Update documentation for BitRise CI now that it supports Secret Env Vars - [@AliSoftware](https://github.com/AliSoftware)
+* _Add your own contributions to the next release on the line above this; please include your name too. Please don't set a new version if you are the first to make the section for `master`._
 
 ## 5.5.0
 

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -17,8 +17,7 @@ module Danger
   #
   # ### Token Setup
   #
-  # Add the `DANGER_GITHUB_API_TOKEN` to your workflow's App Env Vars.
-  # Warning: adding the token as a Secret Env Var will not work for PR builds, as [Bitrise does not expose secret vars to PRs](https://bitrise.uservoice.com/forums/235233-general/suggestions/11701587-make-secret-env-variables-available-for-prs-from-t).
+  # Add the `DANGER_GITHUB_API_TOKEN` to your workflow's [Secret App Env Vars](https://blog.bitrise.io/anyone-even-prs-can-have-secrets).
   #
   class Bitrise < CI
     def self.validates_as_ci?(env)


### PR DESCRIPTION
The limitation of BitRise and Secret env vars in PRs that is pointed to in the documentation has just been [addressed by Bitrise 6 days ago](https://discuss.bitrise.io/t/secret-env-vars-and-generic-file-storage-files-control-whether-its-available-in-pull-request-builds/718/8).

This means that we can update the documentation accordingly now 🎉  