### PR TITLE
Fix empty commits list error on GitLab

### DIFF
--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -58,8 +58,12 @@ module Danger
       end
 
       def base_commit
-        first_commit_in_branch = self.commits_json.last.id
-        @base_commit ||= self.scm.exec "rev-parse #{first_commit_in_branch}^1"
+        if self.commits_json.last
+          first_commit_in_branch = self.commits_json.last.id
+          @base_commit ||= self.scm.exec "rev-parse #{first_commit_in_branch}^1"
+        else
+          @base_commit = ""
+        end
       end
 
       def mr_comments

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -82,6 +82,7 @@ module Danger
       end
 
       def setup_danger_branches
+        raise "Are you running `danger local/pr` against the correct repository? Also this can happen if you run danger on MR without changes" if base_commit.empty?
         base_branch = self.mr_json.source_branch
         head_branch = self.mr_json.target_branch
         head_commit = self.scm.head_commit

--- a/spec/fixtures/gitlab_api/merge_request_593728_no_commits_response.json
+++ b/spec/fixtures/gitlab_api/merge_request_593728_no_commits_response.json
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Sun, 17 Jul 2016 13:06:26 GMT
+Content-Type: application/json
+Content-Length: 441
+Cache-Control: max-age=0, private, must-revalidate
+Etag: W/"1314cb10a5dab46f5853402417022a9b"
+Status: 200 OK
+Vary: Origin
+X-Request-Id: 552eb361-c391-4da2-8634-496173ca47d7
+X-Runtime: 0.046744
+
+[]

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -109,6 +109,52 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
       expect(subject.base_commit).to eq("0e4db308b6579f7cc733e5a354e026b272e1c076")
     end
 
+    context "works also on empty MR" do
+      before do
+        stub_merge_request_commits(
+          "merge_request_593728_no_commits_response",
+          "k0nserv%2Fdanger-test",
+          593_728
+        )
+      end
+      
+      it "return empty string if last commit do not exist" do
+        subject.fetch_details
+
+        expect(subject.base_commit).to eq("")
+      end
+
+      it "raise error on empty commit" do
+        subject.fetch_details
+        expect(subject.mr_json).to receive(:source_branch).
+          and_return("master")
+        expect(subject.mr_json).to receive(:target_branch).
+          and_return("")
+        expect(subject.scm).to receive(:head_commit).
+          and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
+        expect(subject.scm).to receive(:exec)
+          .with("fetch --depth=20 --prune origin +refs/heads/master:refs/remotes/origin/master")
+          .and_return("")
+        expect(subject.scm).to receive(:exec)
+          .with("fetch --depth=74 --prune origin +refs/heads/master:refs/remotes/origin/master")
+          .and_return("")
+        expect(subject.scm).to receive(:exec)
+          .with("fetch --depth=222 --prune origin +refs/heads/master:refs/remotes/origin/master")
+          .and_return("")
+        expect(subject.scm).to receive(:exec)
+          .with("fetch --depth=625 --prune origin +refs/heads/master:refs/remotes/origin/master")
+          .and_return("")
+        expect(subject.scm).to receive(:exec)
+          .with("fetch --depth 1000000")
+          .and_return("")
+        expect(subject.scm).to receive(:exec)
+          .with("rev-parse --quiet --verify ^{commit}")
+          .and_return("").exactly(6)
+
+        expect{ subject.setup_danger_branches }.to raise_error("Commit  doesn't exist. Are you running `danger local/pr` against the correct repository? Also this usually happens when you rebase/reset and force-pushed.")
+      end
+    end
+
     it "setups the danger branches" do
       subject.fetch_details
 

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -126,32 +126,8 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
 
       it "raise error on empty commit" do
         subject.fetch_details
-        expect(subject.mr_json).to receive(:source_branch).
-          and_return("master")
-        expect(subject.mr_json).to receive(:target_branch).
-          and_return("")
-        expect(subject.scm).to receive(:head_commit).
-          and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
-        expect(subject.scm).to receive(:exec)
-          .with("fetch --depth=20 --prune origin +refs/heads/master:refs/remotes/origin/master")
-          .and_return("")
-        expect(subject.scm).to receive(:exec)
-          .with("fetch --depth=74 --prune origin +refs/heads/master:refs/remotes/origin/master")
-          .and_return("")
-        expect(subject.scm).to receive(:exec)
-          .with("fetch --depth=222 --prune origin +refs/heads/master:refs/remotes/origin/master")
-          .and_return("")
-        expect(subject.scm).to receive(:exec)
-          .with("fetch --depth=625 --prune origin +refs/heads/master:refs/remotes/origin/master")
-          .and_return("")
-        expect(subject.scm).to receive(:exec)
-          .with("fetch --depth 1000000")
-          .and_return("")
-        expect(subject.scm).to receive(:exec)
-          .with("rev-parse --quiet --verify ^{commit}")
-          .and_return("").exactly(6)
 
-        expect{ subject.setup_danger_branches }.to raise_error("Commit  doesn't exist. Are you running `danger local/pr` against the correct repository? Also this usually happens when you rebase/reset and force-pushed.")
+        expect{ subject.setup_danger_branches }.to raise_error("Are you running `danger local/pr` against the correct repository? Also this can happen if you run danger on MR without changes")
       end
     end
 
@@ -161,7 +137,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
       expect(subject.scm).to receive(:head_commit).
         and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
       expect(subject).to receive(:base_commit).
-        and_return("0e4db308b6579f7cc733e5a354e026b272e1c076").twice
+        and_return("0e4db308b6579f7cc733e5a354e026b272e1c076").thrice
       expect(subject.scm).to receive(:exec)
         .with("rev-parse --quiet --verify 345e74fabb2fecea93091e8925b1a7a208b48ba6^{commit}")
         .and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")


### PR DESCRIPTION
#trivial GitLab API may return an empty list of commits and in this situation, danger fails with runtime error without explanation. This changes can process this kind of situations and raise danger error with a better explanation.
