### PR TITLE
Fix VSTS comments

### DIFF
--- a/lib/danger/request_sources/vsts.rb
+++ b/lib/danger/request_sources/vsts.rb
@@ -101,15 +101,13 @@ module Danger
           comment_id = comment[:id]
           comment_content = comment[:content].nil? ? "" : comment[:content]
           # Skip the comment if it wasn't posted by danger
-          next if !comment_content.include?("generated_by_#{danger_id}")
+          next unless comment_content.include?("generated_by_#{danger_id}")
           # Updated the danger posted comment
           @api.update_comment(thread_id, comment_id, new_comment)
           comment_updated = true
         end
-        if !comment_updated
-          # If not comment was updated, post a new one
-          @api.post_comment(new_comment)
-        end
+        # If no comment was updated, post a new one
+        @api.post_comment(new_comment) unless comment_updated
       end
     end
   end

--- a/lib/danger/request_sources/vsts.rb
+++ b/lib/danger/request_sources/vsts.rb
@@ -87,10 +87,14 @@ module Danger
                                   danger_id: danger_id,
                                    template: "vsts")
         if new_comment
-          @api.post_comment(comment)
+          post_new_comment(comment)
         else
           update_old_comment(comment, danger_id: danger_id)
         end
+      end
+
+      def post_new_comment(comment)
+        @api.post_comment(comment)
       end
 
       def update_old_comment(new_comment, danger_id: "danger")
@@ -107,7 +111,7 @@ module Danger
           comment_updated = true
         end
         # If no comment was updated, post a new one
-        @api.post_comment(new_comment) unless comment_updated
+        post_new_comment(new_comment) unless comment_updated
       end
     end
   end

--- a/lib/danger/request_sources/vsts.rb
+++ b/lib/danger/request_sources/vsts.rb
@@ -101,14 +101,14 @@ module Danger
           comment_id = comment[:id]
           comment_content = comment[:content].nil? ? "" : comment[:content]
           # Skip the comment if it wasn't posted by danger
-          next if comment_content.include?("generated_by_#{danger_id}")
+          next if !comment_content.include?("generated_by_#{danger_id}")
           # Updated the danger posted comment
           @api.update_comment(thread_id, comment_id, new_comment)
           comment_updated = true
         end
         if !comment_updated
           # If not comment was updated, post a new one
-          @api.post_comment(comment)
+          @api.post_comment(new_comment)
         end
       end
     end

--- a/spec/fixtures/vsts_api/danger_comments_response.json
+++ b/spec/fixtures/vsts_api/danger_comments_response.json
@@ -1,0 +1,155 @@
+HTTP/1.1 200 OK
+
+{
+  "value": [
+    {
+      "pullRequestThreadContext": null,
+      "id": 141,
+      "publishedDate": "2016-11-01T16:30:32.74Z",
+      "lastUpdatedDate": "2016-11-01T16:30:32.74Z",
+      "comments": [
+        {
+          "id": 1,
+          "parentCommentId": 0,
+          "author": {
+            "id": "41113706-4320-4083-9150-925feb93fc22",
+            "displayName": "[DefaultCollection]\\Project Collection Service Accounts",
+            "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/Identities/41113706-4320-4083-9150-925feb93fc22",
+            "imageUrl": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_api/_common/identityImage?id=41113706-4320-4083-9150-925feb93fc22",
+            "isContainer": true
+          },
+          "content": "The pull request is mergable and the target commit would be 39f52d24533cc712fc845ed9fd1b6c06b3942588.",
+          "publishedDate": "2016-11-01T16:30:32.74Z",
+          "lastUpdatedDate": "2016-11-01T16:30:32.74Z",
+          "commentType": "system",
+          "usersLiked": []
+        }
+      ],
+      "threadContext": null,
+      "properties": {
+        "CodeReviewMergeCommit": {
+          "$type": "System.String",
+          "$value": "39f52d24533cc712fc845ed9fd1b6c06b3942588"
+        },
+        "CodeReviewMergeStatus": {
+          "$type": "System.String",
+          "$value": "Succeeded"
+        },
+        "CodeReviewSourceCommit": {
+          "$type": "System.String",
+          "$value": "b60280bc6e62e2f880f1b63c1e24987664d3bda3"
+        },
+        "CodeReviewTargetCommit": {
+          "$type": "System.String",
+          "$value": "f47bbc106853afe3c1b07a81754bce5f4b8dbf62"
+        },
+        "CodeReviewThreadType": {
+          "$type": "System.String",
+          "$value": "MergeAttempt"
+        }
+      },
+      "isDeleted": false
+    },
+    {
+      "pullRequestThreadContext": null,
+      "id": 142,
+      "publishedDate": "2016-11-01T16:30:35Z",
+      "lastUpdatedDate": "2016-11-01T16:30:35Z",
+      "comments": [
+        {
+          "id": 1,
+          "parentCommentId": 0,
+          "author": {
+            "id": "41113706-4320-4083-9150-925feb93fc22",
+            "displayName": "[DefaultCollection]\\Project Collection Service Accounts",
+            "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/Identities/41113706-4320-4083-9150-925feb93fc22",
+            "imageUrl": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_api/_common/identityImage?id=41113706-4320-4083-9150-925feb93fc22",
+            "isContainer": true
+          },
+          "content": "generated_by_danger",
+          "publishedDate": "2016-11-01T16:30:35Z",
+          "lastUpdatedDate": "2016-11-01T16:30:35Z",
+          "commentType": "system",
+          "usersLiked": []
+        }
+      ],
+      "threadContext": null,
+      "properties": {
+        "CodeReviewThreadType": {
+          "$type": "System.String",
+          "$value": "ReviewersUpdate"
+        },
+        "CodeReviewReviewersUpdatedAddedDisplayName": {
+          "$type": "System.String",
+          "$value": "Johnnie McLeod"
+        },
+        "CodeReviewReviewersUpdatedAddedTfId": {
+          "$type": "System.String",
+          "$value": "2428198325304a9caeb788d60d57acfd"
+        },
+        "CodeReviewReviewersUpdatedByDisplayname": {
+          "$type": "System.String",
+          "$value": "Normal Paulk"
+        },
+        "CodeReviewReviewersUpdatedByTfId": {
+          "$type": "System.String",
+          "$value": "b335b0d4578f4944b94ca45216eb1a1a"
+        },
+        "CodeReviewReviewersUpdatedNumAdded": {
+          "$type": "System.Int32",
+          "$value": 1
+        },
+        "CodeReviewReviewersUpdatedNumRemoved": {
+          "$type": "System.Int32",
+          "$value": 0
+        }
+      },
+      "isDeleted": false
+    },
+    {
+      "pullRequestThreadContext": null,
+      "id": 143,
+      "publishedDate": "2016-11-01T16:30:36.58Z",
+      "lastUpdatedDate": "2016-11-01T16:30:36.58Z",
+      "comments": [
+        {
+          "id": 1,
+          "parentCommentId": 0,
+          "author": {
+            "id": "41113706-4320-4083-9150-925feb93fc22",
+            "displayName": "[DefaultCollection]\\Project Collection Service Accounts",
+            "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/Identities/41113706-4320-4083-9150-925feb93fc22",
+            "imageUrl": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_api/_common/identityImage?id=41113706-4320-4083-9150-925feb93fc22",
+            "isContainer": true
+          },
+          "content": "Normal Paulk voted 10",
+          "publishedDate": "2016-11-01T16:30:36.58Z",
+          "lastUpdatedDate": "2016-11-01T16:30:36.58Z",
+          "commentType": "system",
+          "usersLiked": []
+        }
+      ],
+      "threadContext": null,
+      "properties": {
+        "CodeReviewThreadType": {
+          "$type": "System.String",
+          "$value": "VoteUpdate"
+        },
+        "CodeReviewVotedByDisplayName": {
+          "$type": "System.String",
+          "$value": "Normal Paulk"
+        },
+        "CodeReviewVotedByTfId": {
+          "$type": "System.String",
+          "$value": "d6245f20-2af8-44f4-9451-8107cb2767db"
+        },
+        "CodeReviewVoteResult": {
+          "$type": "System.String",
+          "$value": "10"
+        }
+      },
+      "isDeleted": false
+    }
+  ],
+  "count": 4
+}

--- a/spec/fixtures/vsts_api/no_danger_comments_response.json
+++ b/spec/fixtures/vsts_api/no_danger_comments_response.json
@@ -1,0 +1,155 @@
+HTTP/1.1 200 OK
+
+{
+  "value": [
+    {
+      "pullRequestThreadContext": null,
+      "id": 141,
+      "publishedDate": "2016-11-01T16:30:32.74Z",
+      "lastUpdatedDate": "2016-11-01T16:30:32.74Z",
+      "comments": [
+        {
+          "id": 1,
+          "parentCommentId": 0,
+          "author": {
+            "id": "41113706-4320-4083-9150-925feb93fc22",
+            "displayName": "[DefaultCollection]\\Project Collection Service Accounts",
+            "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/Identities/41113706-4320-4083-9150-925feb93fc22",
+            "imageUrl": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_api/_common/identityImage?id=41113706-4320-4083-9150-925feb93fc22",
+            "isContainer": true
+          },
+          "content": "The pull request is mergable and the target commit would be 39f52d24533cc712fc845ed9fd1b6c06b3942588.",
+          "publishedDate": "2016-11-01T16:30:32.74Z",
+          "lastUpdatedDate": "2016-11-01T16:30:32.74Z",
+          "commentType": "system",
+          "usersLiked": []
+        }
+      ],
+      "threadContext": null,
+      "properties": {
+        "CodeReviewMergeCommit": {
+          "$type": "System.String",
+          "$value": "39f52d24533cc712fc845ed9fd1b6c06b3942588"
+        },
+        "CodeReviewMergeStatus": {
+          "$type": "System.String",
+          "$value": "Succeeded"
+        },
+        "CodeReviewSourceCommit": {
+          "$type": "System.String",
+          "$value": "b60280bc6e62e2f880f1b63c1e24987664d3bda3"
+        },
+        "CodeReviewTargetCommit": {
+          "$type": "System.String",
+          "$value": "f47bbc106853afe3c1b07a81754bce5f4b8dbf62"
+        },
+        "CodeReviewThreadType": {
+          "$type": "System.String",
+          "$value": "MergeAttempt"
+        }
+      },
+      "isDeleted": false
+    },
+    {
+      "pullRequestThreadContext": null,
+      "id": 142,
+      "publishedDate": "2016-11-01T16:30:35Z",
+      "lastUpdatedDate": "2016-11-01T16:30:35Z",
+      "comments": [
+        {
+          "id": 1,
+          "parentCommentId": 0,
+          "author": {
+            "id": "41113706-4320-4083-9150-925feb93fc22",
+            "displayName": "[DefaultCollection]\\Project Collection Service Accounts",
+            "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/Identities/41113706-4320-4083-9150-925feb93fc22",
+            "imageUrl": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_api/_common/identityImage?id=41113706-4320-4083-9150-925feb93fc22",
+            "isContainer": true
+          },
+          "content": "Normal Paulk added Johnnie McLeod as a reviewer",
+          "publishedDate": "2016-11-01T16:30:35Z",
+          "lastUpdatedDate": "2016-11-01T16:30:35Z",
+          "commentType": "system",
+          "usersLiked": []
+        }
+      ],
+      "threadContext": null,
+      "properties": {
+        "CodeReviewThreadType": {
+          "$type": "System.String",
+          "$value": "ReviewersUpdate"
+        },
+        "CodeReviewReviewersUpdatedAddedDisplayName": {
+          "$type": "System.String",
+          "$value": "Johnnie McLeod"
+        },
+        "CodeReviewReviewersUpdatedAddedTfId": {
+          "$type": "System.String",
+          "$value": "2428198325304a9caeb788d60d57acfd"
+        },
+        "CodeReviewReviewersUpdatedByDisplayname": {
+          "$type": "System.String",
+          "$value": "Normal Paulk"
+        },
+        "CodeReviewReviewersUpdatedByTfId": {
+          "$type": "System.String",
+          "$value": "b335b0d4578f4944b94ca45216eb1a1a"
+        },
+        "CodeReviewReviewersUpdatedNumAdded": {
+          "$type": "System.Int32",
+          "$value": 1
+        },
+        "CodeReviewReviewersUpdatedNumRemoved": {
+          "$type": "System.Int32",
+          "$value": 0
+        }
+      },
+      "isDeleted": false
+    },
+    {
+      "pullRequestThreadContext": null,
+      "id": 143,
+      "publishedDate": "2016-11-01T16:30:36.58Z",
+      "lastUpdatedDate": "2016-11-01T16:30:36.58Z",
+      "comments": [
+        {
+          "id": 1,
+          "parentCommentId": 0,
+          "author": {
+            "id": "41113706-4320-4083-9150-925feb93fc22",
+            "displayName": "[DefaultCollection]\\Project Collection Service Accounts",
+            "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/Identities/41113706-4320-4083-9150-925feb93fc22",
+            "imageUrl": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_api/_common/identityImage?id=41113706-4320-4083-9150-925feb93fc22",
+            "isContainer": true
+          },
+          "content": "Normal Paulk voted 10",
+          "publishedDate": "2016-11-01T16:30:36.58Z",
+          "lastUpdatedDate": "2016-11-01T16:30:36.58Z",
+          "commentType": "system",
+          "usersLiked": []
+        }
+      ],
+      "threadContext": null,
+      "properties": {
+        "CodeReviewThreadType": {
+          "$type": "System.String",
+          "$value": "VoteUpdate"
+        },
+        "CodeReviewVotedByDisplayName": {
+          "$type": "System.String",
+          "$value": "Normal Paulk"
+        },
+        "CodeReviewVotedByTfId": {
+          "$type": "System.String",
+          "$value": "d6245f20-2af8-44f4-9451-8107cb2767db"
+        },
+        "CodeReviewVoteResult": {
+          "$type": "System.String",
+          "$value": "10"
+        }
+      },
+      "isDeleted": false
+    }
+  ],
+  "count": 4
+}

--- a/spec/lib/danger/request_sources/vsts_spec.rb
+++ b/spec/lib/danger/request_sources/vsts_spec.rb
@@ -46,4 +46,28 @@ RSpec.describe Danger::RequestSources::VSTS, host: :vsts do
       end
     end
   end
+
+  describe "#no_danger_comments" do
+    before do
+      stub_get_comments_request_no_danger
+    end
+
+    it "has to post a new comment" do
+      allow(subject).to receive(:post_new_comment)
+      expect(subject).to receive(:post_new_comment)
+      subject.update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false)
+    end
+  end
+
+  describe "#danger_comment_update" do
+    before do
+      stub_get_comments_request_with_danger
+    end
+
+    it "it has to update the previous comment" do
+      allow(subject).to receive(:update_old_comment)
+      expect(subject).to receive(:update_old_comment)
+      subject.update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false)
+    end
+  end
 end

--- a/spec/support/vsts_helper.rb
+++ b/spec/support/vsts_helper.rb
@@ -28,6 +28,18 @@ module Danger
         url = "https://example.visualstudio.com/example/_apis/git/repositories/example/pullRequests/1?api-version=3.0"
         WebMock.stub_request(:get, url).to_return(raw_file)
       end
+
+      def stub_get_comments_request_no_danger
+        raw_file = File.new("spec/fixtures/vsts_api/no_danger_comments_response.json")
+        url = "https://example.visualstudio.com/example/_apis/git/repositories/example/pullRequests/1/threads?api-version=3.0"
+        WebMock.stub_request(:get, url).to_return(raw_file)
+      end
+      
+      def stub_get_comments_request_with_danger
+        raw_file = File.new("spec/fixtures/vsts_api/danger_comments_response.json")
+        url = "https://example.visualstudio.com/example/_apis/git/repositories/example/pullRequests/1/threads?api-version=3.0"
+        WebMock.stub_request(:get, url).to_return(raw_file)
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes the VSTS commenting logic.

At this point, the VSTS module looks for the `new_comment` flag to decide if it should post a new comment or not - which is set to false.
It then tries to update the previous comment which doesn't exist for a new pull request.

The fix looks for any comment posted by danger to determine if a previous comment was posted and tries to update it.
If no comment added by danger is found, it adds a new comment.