### PR TITLE
Use linear search to get GitLab MR ID in GitLab CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 > _Add your own contributions to the next release on a new line line above this; please include your name too._
 > _Please don't set a new version if you are the first to make the section for `master`._
 
+* Fixes fetching merge request ID in GitLab CI - [@nikolaykasyanov](https://github.com/nikolaykasyanov) 
+
 ## 5.5.1
 
 * Update documentation for BitRise CI now that it supports Secret Env Vars - [@AliSoftware](https://github.com/AliSoftware)

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -38,8 +38,8 @@ module Danger
       client = RequestSources::GitLab.new(nil, env).client
 
       merge_requests = client.merge_requests(project_id, state: :opened)
-      merge_request = merge_requests.auto_paginate.bsearch do |mr|
-        mr.sha >= base_commit
+      merge_request = merge_requests.auto_paginate.find do |mr|
+        mr.sha == base_commit
       end
 
       merge_request.nil? ? 0 : merge_request.iid


### PR DESCRIPTION
`bsearch` can't be used on an array not sorted by `mr.sha`. See discussion: https://github.com/danger/danger/pull/883#issuecomment-334143581.