### PR TITLE
#trivial Fix GitLab Setup — GitHub env variable to GitLab env variable

### DIFF
--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -15,7 +15,7 @@ module Danger
   # ```
   # ### Token Setup
   #
-  # Add the `DANGER_GITHUB_API_TOKEN` to your pipeline env variables.
+  # Add the `DANGER_GITLAB_API_TOKEN` to your pipeline env variables.
   class GitLabCI < CI
     def self.validates_as_ci?(env)
       env.key? "GITLAB_CI"


### PR DESCRIPTION
I suppose this is the right environment variable. GitHub token doesn't make sense here for me.