### PR TITLE
#trivial: Fixed "Ensure that all PRs have an assignee" example logical error

### DIFF
--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
@@ -32,7 +32,7 @@ module Danger
   #
   # @example Ensure that all PRs have an assignee
   #
-  #          warn "This PR does not have any assignees yet." unless bitbucket_server.pr_json["reviewers"].length == 0
+  #          warn "This PR does not have any assignees yet." if bitbucket_server.pr_json[:reviewers].length == 0
   #
   # @example Send a message with links to a collection of specific files
   #


### PR DESCRIPTION
This closes the issue #915 that I opened yesterday.

Basically, the example shown in the documentation was off. Keys have to be clarified via colon and the logic on the warning was wrong:
You want to warn if there's no assignee to the PR, not if there is one assigned. 

Tested it internally fwiw.