### PR TITLE
Fix filename comparisons that include brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## master
 
+* Fix handling of filenames that contain square brackets (and possibly other characters) - [@allewun](https://github.com/allewun)
 
-> _Add your own contributions to the next release on a new line line above this; please include your name too._
+> _Add your own contributions to the next release on a new line above this; please include your name too._
 > _Please don't set a new version if you are the first to make the section for `master`._
 
 ## 5.5.3

--- a/lib/danger/core_ext/file_list.rb
+++ b/lib/danger/core_ext/file_list.rb
@@ -8,7 +8,7 @@ module Danger
     # e.g. "**/something.*" for any file called something with any extension
     def include?(pattern)
       self.each do |current|
-        return true if File.fnmatch(pattern, current)
+        return true if File.fnmatch(pattern, current) || pattern == current
       end
       return false
     end

--- a/spec/lib/danger/core_ext/file_list_spec.rb
+++ b/spec/lib/danger/core_ext/file_list_spec.rb
@@ -3,12 +3,13 @@ require "danger/core_ext/file_list"
 RSpec.describe Danger::FileList do
   describe "#include?" do
     before do
-      paths = ["path1/file_name.txt", "path1/file_name1.txt", "path2/subfolder/example.json"]
+      paths = ["path1/file_name.txt", "path1/file_name1.txt", "path2/subfolder/example.json", "path1/file_name_with_[brackets].txt"]
       @filelist = Danger::FileList.new(paths)
     end
 
     it "supports exact matches" do
       expect(@filelist.include?("path1/file_name.txt")).to eq(true)
+      expect(@filelist.include?("path1/file_name_with_[brackets].txt")).to eq(true)
     end
 
     it "supports * for wildcards" do


### PR DESCRIPTION
I had a filename with some square brackets in them that `diff_for_file` was not properly finding in `(added_files + modified_files).include?(file)`.

It seems `File.fnmatch` recognizes brackets as special tokens and not literally. I suppose this might cause some extremely rare and subtle issues where we mistakenly capture a filename with asterisks (or other glob characters), but I think the case I ran into is more likely tbh.

Basically, I was seeing the following:

```ruby
filename = "file/with/bracket[].txt"
filenames = [ filename ]
filenames.include?(filename) == false
```

---

```
bundler: failed to load command: danger (/Users/distiller/.gem/ruby/2.3.4/bin/danger)
Danger::DSLError: 
[!] Invalid `Dangerfile` file: undefined method `patch' for nil:NilClass
 #  from Dangerfile:59
 #  -------------------------------------------
 #   >   #  
 #  -------------------------------------------

/Users/distiller/.gem/ruby/2.3.4/gems/danger-todoist-1.2.3/lib/todoist/diff_todo_finder.rb:12:in `block in find_diffs_containing_todos'
  /Users/distiller/.gem/ruby/2.3.4/gems/danger-5.5.3/lib/danger/helpers/array_subclass.rb:49:in `each'
  /Users/distiller/.gem/ruby/2.3.4/gems/danger-5.5.3/lib/danger/helpers/array_subclass.rb:49:in `respond_to_method'
  /Users/distiller/.gem/ruby/2.3.4/gems/danger-5.5.3/lib/danger/helpers/array_subclass.rb:19:in `method_missing'
  /Users/distiller/.gem/ruby/2.3.4/gems/danger-todoist-1.2.3/lib/todoist/diff_todo_finder.rb:11:in `find_diffs_containing_todos'
  /Users/distiller/.gem/ruby/2.3.4/gems/danger-todoist-1.2.3/lib/todoist/plugin.rb:112:in `find_todos'
  /Users/distiller/.gem/ruby/2.3.4/gems/danger-todoist-1.2.3/lib/todoist/plugin.rb:103:in `call_method_for_todos'
  /Users/distiller/.gem/ruby/2.3.4/gems/danger-todoist-1.2.3/lib/todoist/plugin.rb:55:in `warn_for_todos'
```