### PR TITLE
Handle Github repos with dots in them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## master
-
+ 
 > _Add your own contributions to the next release on a new line above this; please include your name too._
 > _Please don't set a new version if you are the first to make the section for `master`._
+
+* Fix handling of Github repos slugs with dots in them (for BuildKite CI). [@orj](https://github.com/orj)
 
 ## 5.5.4
 

--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -40,7 +40,7 @@ module Danger
       self.repo_url = env["BUILDKITE_REPO"]
       self.pull_request_id = env["BUILDKITE_PULL_REQUEST"]
 
-      repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
+      repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/]+?)(\.git$|$)})
       self.repo_slug = repo_matches[2] unless repo_matches.nil?
     end
 

--- a/spec/lib/danger/ci_sources/buildkite_spec.rb
+++ b/spec/lib/danger/ci_sources/buildkite_spec.rb
@@ -62,6 +62,11 @@ RSpec.describe Danger::Buildkite do
         valid_env["BUILDKITE_REPO"] = "https://github.com/Danger/danger.git"
         expect(source.repo_slug).to eq("Danger/danger")
       end
+
+      it "gets out a repo slug from a repo with dots in it" do
+        valid_env["BUILDKITE_REPO"] = "https://github.com/Danger/danger.systems.git"
+        expect(source.repo_slug).to eq("Danger/danger.systems")
+      end
     end
 
     it "sets the pull request id" do


### PR DESCRIPTION
The PR corrects the regex that was used to extract the Github repo slug to handle repositories with periods (dots) in them.