### PR TITLE
Raise error if port number is included in DANGER_GITLAB_HOST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 > _Add your own contributions to the next release on a new line above this; please include your name too._
 > _Please don't set a new version if you are the first to make the section for `master`._
 
+* Improves the GitLab CI error handling if port number is accidentally included in host. [@mbogh](https://github.com/mbogh)
+
 ## 5.5.5
 
 * Fix handling of Github repos slugs with dots in them (for BuildKite CI). [@orj](https://github.com/orj)

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -40,6 +40,13 @@ module Danger
         abort
       end
 
+      def validates_as_ci?
+        includes_port = self.host.include? ":"
+        raise "Port number included in `DANGER_GITLAB_HOST`, this will fail with GitLab CI Runners" if includes_port
+
+        super
+      end
+
       def validates_as_api_source?
         @token && !@token.empty?
       end


### PR DESCRIPTION
Based on the experience and feedback in #926 

An error will be raised if you accidentally include the port number in `DANGER_GITLAB_HOST`.