### PR TITLE
Enable Bitbucket Server support for Bitrise CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Add Bitbucket Server support for Bitrise CI. [@copini](https://github.com/copini)
+
 > _Add your own contributions to the next release on a new line above this; please include your name too._
 > _Please don't set a new version if you are the first to make the section for `master`._
 

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -29,7 +29,11 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab]
+      @supported_request_sources ||= [
+        Danger::RequestSources::GitHub,
+        Danger::RequestSources::GitLab,
+        Danger::RequestSources::BitbucketServer
+      ]
     end
 
     def initialize(env)


### PR DESCRIPTION
Simply added Bitbucket Server to the `supported_request_sources` of the Bitrise CI source, see issue #939.
Tested it in one of our Bitrise workflows and it works. I'm not sure if I should add any tests and/or documentation for this. I didn't see specific tests for buddybuild - Bitbucket Server support for example.