### PR TITLE
Use distinct on validations prior to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add Bitbucket Server support for Bitrise CI. [@copini](https://github.com/copini)
+* Use unique entries for the validation reports
 
 > _Add your own contributions to the next release on a new line above this; please include your name too._
 > _Please don't set a new version if you are the first to make the section for `master`._

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -223,7 +223,7 @@ module Danger
                   else
                     formatted
                   end
-          rows = violations[key]
+          rows = violations[key].uniq
           print_list(title, rows)
         end
 
@@ -246,10 +246,10 @@ module Danger
       violations = violation_report
 
       env.request_source.update_pull_request!(
-        warnings: violations[:warnings],
-        errors: violations[:errors],
-        messages: violations[:messages],
-        markdowns: status_report[:markdowns],
+        warnings: violations[:warnings].uniq,
+        errors: violations[:errors].uniq,
+        messages: violations[:messages].uniq,
+        markdowns: status_report[:markdowns].uniq,
         danger_id: danger_id,
         new_comment: new_comment
       )

--- a/lib/danger/danger_core/messages/markdown.rb
+++ b/lib/danger/danger_core/messages/markdown.rb
@@ -17,6 +17,18 @@ module Danger
         other.line == line
     end
 
+    def hash
+      h = 1
+      h = h * 31 + message.hash
+      h = h * 17 + (file&.hash || 0)
+      h = h * 17 + (line&.hash || 0)
+      h
+    end
+
+    def eql?(other)
+      return self == other
+    end
+
     # @return [Boolean] returns true if is a file or line, false otherwise
     def inline?
       file || line

--- a/lib/danger/danger_core/messages/markdown.rb
+++ b/lib/danger/danger_core/messages/markdown.rb
@@ -20,8 +20,8 @@ module Danger
     def hash
       h = 1
       h = h * 31 + message.hash
-      h = h * 17 + (file&.hash || 0)
-      h = h * 17 + (line&.hash || 0)
+      h = h * 17 + file.hash
+      h = h * 17 + line.hash
       h
     end
 

--- a/lib/danger/danger_core/messages/violation.rb
+++ b/lib/danger/danger_core/messages/violation.rb
@@ -22,9 +22,9 @@ module Danger
     def hash
       h = 1
       h = h * 31 + message.hash
-      h = h * 13 + (sticky ? 1 : 0)
-      h = h * 17 + (file || 0)
-      h = h * 17 + (line || 0)
+      h = h * 13 + sticky.hash
+      h = h * 17 + (file&.hash || 0)
+      h = h * 17 + (line&.hash || 0)
       h
     end
 

--- a/lib/danger/danger_core/messages/violation.rb
+++ b/lib/danger/danger_core/messages/violation.rb
@@ -19,6 +19,19 @@ module Danger
         other.line == line
     end
 
+    def hash
+      h = 1
+      h = h * 31 + message.hash
+      h = h * 13 + (sticky ? 1 : 0)
+      h = h * 17 + (file || 0)
+      h = h * 17 + (line || 0)
+      h
+    end
+
+    def eql?(other)
+      return self == other
+    end
+
     # @return [Boolean] returns true if is a file or line, false otherwise
     def inline?
       file || line

--- a/lib/danger/danger_core/messages/violation.rb
+++ b/lib/danger/danger_core/messages/violation.rb
@@ -23,8 +23,8 @@ module Danger
       h = 1
       h = h * 31 + message.hash
       h = h * 13 + sticky.hash
-      h = h * 17 + (file&.hash || 0)
-      h = h * 17 + (line&.hash || 0)
+      h = h * 17 + file.hash
+      h = h * 17 + line.hash
       h
     end
 

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -243,6 +243,33 @@ RSpec.describe Danger::Dangerfile, host: :github do
 
       dm.post_results("danger-identifier", nil)
     end
+
+    it "delegates unique entries" do
+      code = "message 'message one'\n" \
+             "message 'message two'\n" \
+             "message 'message one'\n" \
+             "warn 'message one'\n" \
+             "warn 'message two'\n" \
+             "warn 'message two'\n"
+
+      dm = testing_dangerfile
+      dm.env.request_source.ignored_violations = []
+
+      dm.parse Pathname.new(""), code
+
+      results = dm.status_report
+
+      expect(dm.env.request_source).to receive(:update_pull_request!).with(
+        warnings: [anything(), anything()],
+        errors: [],
+        messages: [anything(), anything()],
+        markdowns: [],
+        danger_id: 'danger-identifier',
+        new_comment: nil
+      )
+
+      dm.post_results("danger-identifier", nil)
+    end
   end
 
   describe "#setup_for_running" do


### PR DESCRIPTION
Currently the `validations_reports` hash is a freezed map with messages/errors/etc. If we somehow have duplicated messages we end up having the exact same messages under a category.

In my case this occurs because I have a ton of test reports and the `danger-junit` gem posts the `'A test failed'` message for each. Since I cant operate over the `validation_reports` hash because its freezed, I ended up having N times the `'A test failed'` message

I will make later a PR to @orta in the `danger-junit` gem, but I thought this would be a desired logic for danger itself (whats the point of having twice the exact same message under a category?)


  