### PR TITLE
Added support for Bitbucket Server to TeamCity CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add Bitbucket Server support for Bitrise CI. [@copini](https://github.com/copini)
+* Add Bitbucket Server support for TeamCity CI. [@davevdveen](https://github.com/davevdveen)
 * Use unique entries for the validation reports
 
 > _Add your own contributions to the next release on a new line above this; please include your name too._

--- a/lib/danger/ci_source/teamcity.rb
+++ b/lib/danger/ci_source/teamcity.rb
@@ -64,7 +64,7 @@ module Danger
   # - `BITBUCKETSERVER_PULL_REQUEST_ID`
   # - `BITBUCKETSERVER_REPO_URL`
   #
-  
+
   class TeamCity < CI
     class << self
       def validates_as_github_pr?(env)
@@ -78,7 +78,7 @@ module Danger
       def validates_as_bitbucket_cloud_pr?(env)
         ["BITBUCKET_REPO_SLUG", "BITBUCKET_BRANCH_NAME", "BITBUCKET_REPO_URL"].all? { |x| env[x] && !env[x].empty? }
       end
-      
+
       def validates_as_bitbucket_server_pr?(env)
         ["BITBUCKETSERVER_REPO_SLUG", "BITBUCKETSERVER_PULL_REQUEST_ID", "BITBUCKETSERVER_REPO_URL"].all? { |x| env[x] && !env[x].empty? }
       end

--- a/lib/danger/ci_source/teamcity.rb
+++ b/lib/danger/ci_source/teamcity.rb
@@ -133,7 +133,7 @@ module Danger
 
     def extract_bitbucket_server_variables!(env)
       self.repo_slug       = env["BITBUCKETSERVER_REPO_SLUG"]
-      self.pull_request_id = env["BITBUCKETSERVER_PULL_REQUEST_ID"]
+      self.pull_request_id = env["BITBUCKETSERVER_PULL_REQUEST_ID"].to_i
       self.repo_url        = env["BITBUCKETSERVER_REPO_URL"]
     end
 

--- a/lib/danger/ci_source/teamcity.rb
+++ b/lib/danger/ci_source/teamcity.rb
@@ -64,7 +64,6 @@ module Danger
   # - `BITBUCKETSERVER_PULL_REQUEST_ID`
   # - `BITBUCKETSERVER_REPO_URL`
   #
-
   class TeamCity < CI
     class << self
       def validates_as_github_pr?(env)

--- a/lib/danger/ci_source/teamcity.rb
+++ b/lib/danger/ci_source/teamcity.rb
@@ -53,6 +53,18 @@ module Danger
   # export BITBUCKET_BRANCH_NAME="%teamcity.build.branch%"
   # ```
   #
+  # #### BitBucket Server
+  #
+  # You will need to add the following environment variables as build parameters or by exporting them inside your
+  # Simple Command Runner.
+  # - `DANGER_BITBUCKETSERVER_USERNAME`
+  # - `DANGER_BITBUCKETSERVER_PASSWORD`
+  # - `DANGER_BITBUCKETSERVER_HOST`
+  # - `BITBUCKETSERVER_REPO_SLUG`
+  # - `BITBUCKETSERVER_PULL_REQUEST_ID`
+  # - `BITBUCKETSERVER_REPO_URL`
+  #
+  
   class TeamCity < CI
     class << self
       def validates_as_github_pr?(env)
@@ -66,6 +78,10 @@ module Danger
       def validates_as_bitbucket_cloud_pr?(env)
         ["BITBUCKET_REPO_SLUG", "BITBUCKET_BRANCH_NAME", "BITBUCKET_REPO_URL"].all? { |x| env[x] && !env[x].empty? }
       end
+      
+      def validates_as_bitbucket_server_pr?(env)
+        ["BITBUCKETSERVER_REPO_SLUG", "BITBUCKETSERVER_PULL_REQUEST_ID", "BITBUCKETSERVER_REPO_URL"].all? { |x| env[x] && !env[x].empty? }
+      end
     end
 
     def self.validates_as_ci?(env)
@@ -73,24 +89,25 @@ module Danger
     end
 
     def self.validates_as_pr?(env)
-      validates_as_github_pr?(env) || validates_as_gitlab_pr?(env) || validates_as_bitbucket_cloud_pr?(env)
+      validates_as_github_pr?(env) || validates_as_gitlab_pr?(env) || validates_as_bitbucket_cloud_pr?(env) || validates_as_bitbucket_server_pr?(env)
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab, Danger::RequestSources::BitbucketCloud]
+      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab, Danger::RequestSources::BitbucketCloud, Danger::RequestSources::BitbucketServer]
     end
 
     def initialize(env)
       # NB: Unfortunately TeamCity doesn't provide these variables
       # automatically so you have to add these variables manually to your
       # project or build configuration
-
       if self.class.validates_as_github_pr?(env)
         extract_github_variables!(env)
       elsif self.class.validates_as_gitlab_pr?(env)
         extract_gitlab_variables!(env)
       elsif self.class.validates_as_bitbucket_cloud_pr?(env)
         extract_bitbucket_variables!(env)
+      elsif self.class.validates_as_bitbucket_server_pr?(env)
+        extract_bitbucket_server_variables!(env)
       end
     end
 
@@ -112,6 +129,12 @@ module Danger
       self.repo_slug       = env["BITBUCKET_REPO_SLUG"]
       self.pull_request_id = bitbucket_pr_from_env(env)
       self.repo_url        = env["BITBUCKET_REPO_URL"]
+    end
+
+    def extract_bitbucket_server_variables!(env)
+      self.repo_slug       = env["BITBUCKETSERVER_REPO_SLUG"]
+      self.pull_request_id = env["BITBUCKETSERVER_PULL_REQUEST_ID"]
+      self.repo_url        = env["BITBUCKETSERVER_REPO_URL"]
     end
 
     # This is a little hacky, because Bitbucket doesn't provide us a PR id

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -49,9 +49,13 @@ module Danger
       def setup_danger_branches
         base_branch = self.pr_json[:toRef][:id].sub("refs/heads/", "")
         base_commit = self.pr_json[:toRef][:latestCommit]
+        # Support for older versions of Bitbucket Server
+        base_commit = self.pr_json[:toRef][:latestChangeset] if self.pr_json[:fromRef].has_key? :latestChangeset
         head_branch = self.pr_json[:fromRef][:id].sub("refs/heads/", "")
         head_commit = self.pr_json[:fromRef][:latestCommit]
-
+        # Support for older versions of Bitbucket Server
+        head_commit = self.pr_json[:fromRef][:latestChangeset] if self.pr_json[:fromRef].has_key? :latestChangeset
+        
         # Next, we want to ensure that we have a version of the current branch at a known location
         scm.ensure_commitish_exists_on_branch! base_branch, base_commit
         self.scm.exec "branch #{EnvironmentManager.danger_base_branch} #{base_commit}"

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -50,12 +50,12 @@ module Danger
         base_branch = self.pr_json[:toRef][:id].sub("refs/heads/", "")
         base_commit = self.pr_json[:toRef][:latestCommit]
         # Support for older versions of Bitbucket Server
-        base_commit = self.pr_json[:toRef][:latestChangeset] if self.pr_json[:fromRef].has_key? :latestChangeset
+        base_commit = self.pr_json[:toRef][:latestChangeset] if self.pr_json[:fromRef].key? :latestChangeset
         head_branch = self.pr_json[:fromRef][:id].sub("refs/heads/", "")
         head_commit = self.pr_json[:fromRef][:latestCommit]
         # Support for older versions of Bitbucket Server
-        head_commit = self.pr_json[:fromRef][:latestChangeset] if self.pr_json[:fromRef].has_key? :latestChangeset
-        
+        head_commit = self.pr_json[:fromRef][:latestChangeset] if self.pr_json[:fromRef].key? :latestChangeset
+
         # Next, we want to ensure that we have a version of the current branch at a known location
         scm.ensure_commitish_exists_on_branch! base_branch, base_commit
         self.scm.exec "branch #{EnvironmentManager.danger_base_branch} #{base_commit}"

--- a/spec/lib/danger/ci_sources/teamcity_spec.rb
+++ b/spec/lib/danger/ci_sources/teamcity_spec.rb
@@ -209,6 +209,64 @@ RSpec.describe Danger::TeamCity do
     end
   end
 
+  context "with Bitbucket Server" do
+      before do
+          valid_env["BITBUCKETSERVER_REPO_SLUG"] = "foo/bar"
+          valid_env["BITBUCKETSERVER_PULL_REQUEST_ID"] = "42"
+          valid_env["BITBUCKETSERVER_REPO_URL"] = "git@bitbucketserver.com:danger/danger.git"
+      end
+
+      describe ".validates_as_ci?" do
+          it "validates when required env variables are set" do
+              expect(described_class.validates_as_ci?(valid_env)).to be true
+          end
+
+          it "validates even when `BITBUCKETSERVER_PULL_REQUEST_ID` is missing" do
+              valid_env["BITBUCKETSERVER_PULL_REQUEST_ID"] = nil
+              expect(described_class.validates_as_ci?(valid_env)).to be true
+          end
+
+          it "validates even when `BITBUCKETSERVER_PULL_REQUEST_ID` is empty" do
+              valid_env["BITBUCKETSERVER_PULL_REQUEST_ID"] = ""
+              expect(described_class.validates_as_ci?(valid_env)).to be true
+          end
+
+          it "doesn't validate when required env variables are not set" do
+              expect(described_class.validates_as_ci?(invalid_env)).to be false
+          end
+      end
+
+      describe ".validates_as_pr?" do
+          it "validates when the required variables are set" do
+              expect(described_class.validates_as_pr?(valid_env)).to be true
+          end
+
+          it "doesn't validate if `BITBUCKETSERVER_PULL_REQUEST_ID` is missing" do
+              valid_env["BITBUCKETSERVER_PULL_REQUEST_ID"] = nil
+              expect(described_class.validates_as_pr?(valid_env)).to be false
+          end
+
+          it "doesn't validate_as_pr if `BITBUCKETSERVER_PULL_REQUEST_ID` is the empty string" do
+              valid_env["BITBUCKETSERVER_PULL_REQUEST_ID"] = ""
+              expect(described_class.validates_as_pr?(valid_env)).to be false
+          end
+      end
+
+      describe "#new" do
+          it "sets the repo_slug" do
+              expect(source.repo_slug).to eq("foo/bar")
+          end
+
+          it "sets the repo_url" do
+              expect(source.repo_url).to eq("git@bitbucketserver.com:danger/danger.git")
+          end
+
+          it "sets the pull_request_id" do
+              expect(source.pull_request_id).to eq(42)
+          end
+      end
+  end
+
   describe "#supported_request_sources" do
     it "supports GitHub" do
       expect(source.supported_request_sources).to include(Danger::RequestSources::GitHub)
@@ -220,6 +278,10 @@ RSpec.describe Danger::TeamCity do
 
     it "supports Bitbucket Cloud" do
       expect(source.supported_request_sources).to include(Danger::RequestSources::BitbucketCloud)
+    end
+    
+    it "supports Bitbucket Server" do
+        expect(source.supported_request_sources).to include(Danger::RequestSources::BitbucketServer)
     end
   end
 end


### PR DESCRIPTION
Added support for Bitbucket Server to TeamCity CI. Because TeamCity doesn't setup all the required variables those need be added to the ENVIRONMENT variables.
Tested it on our TeamCity and Bitbucket Server setup and it is working if all the required variables are set. Also added support for older versions of Bitbucket Server API which provide latestChangeset instead of latestCommit.