### PR TITLE
Add --remove-previous-comments functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Add `--remove-previous-comments` functionality. [@JoeS](https://github.com/joesss)
+
 ## 5.5.7
 
 * Add Bitbucket Server support for Bitrise CI. [@copini](https://github.com/copini)

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -58,6 +58,7 @@ module Danger
           Danger::EnvironmentManager.danger_head_branch,
           @dangerfile_path,
           nil,
+          nil,
           nil
         )
       end

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -63,6 +63,7 @@ module Danger
           Danger::EnvironmentManager.danger_head_branch,
           @dangerfile_path,
           nil,
+          nil,
           nil
         )
       end

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -38,6 +38,7 @@ module Danger
       @head = argv.option("head")
       @fail_on_errors = argv.option("fail-on-errors", false)
       @new_comment = argv.flag?("new-comment")
+      @comment_at_tail = argv.flag?("comment-at-tail")
       @danger_id = argv.option("danger_id", "danger")
       @cork = Cork::Board.new(silent: argv.option("silent", false),
                               verbose: argv.option("verbose", false))
@@ -58,7 +59,8 @@ module Danger
         ["--fail-on-errors=<true|false>", "Should always fail the build process, defaults to false"],
         ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"],
         ["--danger_id=<id>", "The identifier of this Danger instance"],
-        ["--new-comment", "Makes Danger post a new comment instead of editing its previous one"]
+        ["--new-comment", "Makes Danger post a new comment instead of editing its previous one"],
+        ["--comment-at-tail", "Removes old comment and create a new one"]
       ].concat(super)
     end
 
@@ -69,7 +71,8 @@ module Danger
         dangerfile_path: @dangerfile_path,
         danger_id: @danger_id,
         new_comment: @new_comment,
-        fail_on_errors: @fail_on_errors
+        fail_on_errors: @fail_on_errors,
+        comment_at_tail: @comment_at_tail
       )
     end
   end

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -38,7 +38,7 @@ module Danger
       @head = argv.option("head")
       @fail_on_errors = argv.option("fail-on-errors", false)
       @new_comment = argv.flag?("new-comment")
-      @comment_at_tail = argv.flag?("comment-at-tail")
+      @remove_previous_comments = argv.flag?("remove-previous-comments")
       @danger_id = argv.option("danger_id", "danger")
       @cork = Cork::Board.new(silent: argv.option("silent", false),
                               verbose: argv.option("verbose", false))
@@ -60,7 +60,7 @@ module Danger
         ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"],
         ["--danger_id=<id>", "The identifier of this Danger instance"],
         ["--new-comment", "Makes Danger post a new comment instead of editing its previous one"],
-        ["--comment-at-tail", "Removes old comment and create a new one"]
+        ["--remove-previous-comments", "Removes all previous comment and create a new one in the end of the list"]
       ].concat(super)
     end
 
@@ -72,7 +72,7 @@ module Danger
         danger_id: @danger_id,
         new_comment: @new_comment,
         fail_on_errors: @fail_on_errors,
-        comment_at_tail: @comment_at_tail
+        remove_previous_comments: @remove_previous_comments
       )
     end
   end

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -242,7 +242,7 @@ module Danger
       violation_report[:errors].count > 0
     end
 
-    def post_results(danger_id, new_comment)
+    def post_results(danger_id, new_comment, comment_at_tail)
       violations = violation_report
 
       env.request_source.update_pull_request!(
@@ -251,7 +251,8 @@ module Danger
         messages: violations[:messages].uniq,
         markdowns: status_report[:markdowns].uniq,
         danger_id: danger_id,
-        new_comment: new_comment
+        new_comment: new_comment,
+        overwrite_comment: comment_at_tail
       )
     end
 
@@ -260,7 +261,7 @@ module Danger
       env.scm.diff_for_folder(".".freeze, from: base_branch, to: head_branch)
     end
 
-    def run(base_branch, head_branch, dangerfile_path, danger_id, new_comment)
+    def run(base_branch, head_branch, dangerfile_path, danger_id, new_comment, comment_at_tail)
       # Setup internal state
       init_plugins
       env.fill_environment_vars
@@ -275,7 +276,7 @@ module Danger
         # Push results to the API
         # Pass along the details of the run to the request source
         # to send back to the code review site.
-        post_results(danger_id, new_comment) unless danger_id.nil?
+        post_results(danger_id, new_comment, comment_at_tail) unless danger_id.nil?
 
         # Print results in the terminal
         print_results

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -242,7 +242,7 @@ module Danger
       violation_report[:errors].count > 0
     end
 
-    def post_results(danger_id, new_comment, comment_at_tail)
+    def post_results(danger_id, new_comment, remove_previous_comments)
       violations = violation_report
 
       env.request_source.update_pull_request!(
@@ -252,7 +252,7 @@ module Danger
         markdowns: status_report[:markdowns].uniq,
         danger_id: danger_id,
         new_comment: new_comment,
-        overwrite_comment: comment_at_tail
+        remove_previous_comments: remove_previous_comments
       )
     end
 
@@ -261,7 +261,7 @@ module Danger
       env.scm.diff_for_folder(".".freeze, from: base_branch, to: head_branch)
     end
 
-    def run(base_branch, head_branch, dangerfile_path, danger_id, new_comment, comment_at_tail)
+    def run(base_branch, head_branch, dangerfile_path, danger_id, new_comment, remove_previous_comments)
       # Setup internal state
       init_plugins
       env.fill_environment_vars
@@ -276,7 +276,7 @@ module Danger
         # Push results to the API
         # Pass along the details of the run to the request source
         # to send back to the code review site.
-        post_results(danger_id, new_comment, comment_at_tail) unless danger_id.nil?
+        post_results(danger_id, new_comment, remove_previous_comments) unless danger_id.nil?
 
         # Print results in the terminal
         print_results

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -12,7 +12,8 @@ module Danger
             dangerfile_path: nil,
             danger_id: nil,
             new_comment: nil,
-            fail_on_errors: nil)
+            fail_on_errors: nil,
+            comment_at_tail: nil)
       # Create a silent Cork instance if cork is nil, as it's likely a test
       cork ||= Cork::Board.new(silent: false, verbose: false)
 
@@ -29,7 +30,8 @@ module Danger
           head_branch(head),
           dangerfile_path,
           danger_id,
-          new_comment
+          new_comment,
+          comment_at_tail
         )
       end
 

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -13,7 +13,7 @@ module Danger
             danger_id: nil,
             new_comment: nil,
             fail_on_errors: nil,
-            comment_at_tail: nil)
+            remove_previous_comments: nil)
       # Create a silent Cork instance if cork is nil, as it's likely a test
       cork ||= Cork::Board.new(silent: false, verbose: false)
 
@@ -31,7 +31,7 @@ module Danger
           dangerfile_path,
           danger_id,
           new_comment,
-          comment_at_tail
+          remove_previous_comments
         )
       end
 

--- a/lib/danger/request_sources/bitbucket_cloud.rb
+++ b/lib/danger/request_sources/bitbucket_cloud.rb
@@ -64,8 +64,8 @@ module Danger
         nil
       end
 
-      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false)
-        delete_old_comments(danger_id: danger_id) unless new_comment
+      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
+        delete_old_comments(danger_id: danger_id) if !new_comment || remove_previous_comments
 
         comment = generate_description(warnings: warnings, errors: errors)
         comment += "\n\n"

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -70,8 +70,8 @@ module Danger
         nil
       end
 
-      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false)
-        delete_old_comments(danger_id: danger_id) unless new_comment
+      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
+        delete_old_comments(danger_id: danger_id) if !new_comment || remove_previous_comments
 
         comment = generate_description(warnings: warnings, errors: errors)
         comment += "\n\n"

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -179,7 +179,7 @@ module Danger
         main_violations_sum = main_violations.values.inject(:+)
 
         if (previous_violations.empty? && main_violations_sum.empty?) || remove_previous_comments
-          # Just remove the comment, if there's nothing to say of --remove-previous-comments CLI was set.
+          # Just remove the comment, if there's nothing to say or --remove-previous-comments CLI was set.
           delete_old_comments!(danger_id: danger_id)
         end
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -140,12 +140,12 @@ module Danger
       end
 
       # Sending data to GitHub
-      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, comment_at_tail: false)
+      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
         comment_result = {}
         editable_comments = issue_comments.select { |comment| comment.generated_by_danger?(danger_id) }
         last_comment = editable_comments.last
         should_create_new_comment = new_comment || last_comment.nil?
-        should_remove_comments = comment_at_tail || last_comment.nil?
+        should_remove_comments = remove_previous_comments || last_comment.nil?
 
         previous_violations =
           if should_create_new_comment

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -119,8 +119,7 @@ module Danger
       def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
         editable_comments = mr_comments.select { |comment| comment.generated_by_danger?(danger_id) }
 
-        should_create_new_comment = new_comment || editable_comments.empty?
-        should_remove_comments = remove_previous_comments || editable_comments.empty?
+        should_create_new_comment = new_comment || editable_comments.empty? || remove_previous_comments
 
         if should_create_new_comment
           previous_violations = {}
@@ -129,8 +128,8 @@ module Danger
           previous_violations = parse_comment(comment)
         end
 
-        if (previous_violations.empty? && (warnings + errors + messages + markdowns).empty?) || should_remove_comments
-          # Just remove the comment, if there"s nothing to say of --remove-previous-comments CLI was set.
+        if (previous_violations.empty? && (warnings + errors + messages + markdowns).empty?) || remove_previous_comments
+          # Just remove the comment, if there's nothing to say of --remove-previous-comments CLI was set.
           delete_old_comments!(danger_id: danger_id)
         else
           body = generate_comment(warnings: warnings,

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -116,10 +116,11 @@ module Danger
         GetIgnoredViolation.new(self.mr_json.description).call
       end
 
-      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false)
+      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
         editable_comments = mr_comments.select { |comment| comment.generated_by_danger?(danger_id) }
 
         should_create_new_comment = new_comment || editable_comments.empty?
+        should_remove_comments = remove_previous_comments || editable_comments.empty?
 
         if should_create_new_comment
           previous_violations = {}
@@ -128,8 +129,8 @@ module Danger
           previous_violations = parse_comment(comment)
         end
 
-        if previous_violations.empty? && (warnings + errors + messages + markdowns).empty?
-          # Just remove the comment, if there"s nothing to say.
+        if (previous_violations.empty? && (warnings + errors + messages + markdowns).empty?) || should_remove_comments
+          # Just remove the comment, if there"s nothing to say of --remove-previous-comments CLI was set.
           delete_old_comments!(danger_id: danger_id)
         else
           body = generate_comment(warnings: warnings,

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -129,7 +129,7 @@ module Danger
         end
 
         if (previous_violations.empty? && (warnings + errors + messages + markdowns).empty?) || remove_previous_comments
-          # Just remove the comment, if there's nothing to say of --remove-previous-comments CLI was set.
+          # Just remove the comment, if there's nothing to say or --remove-previous-comments CLI was set.
           delete_old_comments!(danger_id: danger_id)
         else
           body = generate_comment(warnings: warnings,

--- a/lib/danger/request_sources/vsts.rb
+++ b/lib/danger/request_sources/vsts.rb
@@ -86,7 +86,7 @@ module Danger
                         previous_violations: {},
                                   danger_id: danger_id,
                                    template: "vsts")
-        if new_comment
+        if new_comment || remove_previous_comments
           post_new_comment(comment)
         else
           update_old_comment(comment, danger_id: danger_id)

--- a/lib/danger/request_sources/vsts.rb
+++ b/lib/danger/request_sources/vsts.rb
@@ -72,7 +72,7 @@ module Danger
         nil
       end
 
-      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false)
+      def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
         unless @api.supports_comments?
           return
         end

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe Danger::Runner do
         dangerfile_path: "Dangerfile",
         danger_id: "danger",
         new_comment: nil,
-        fail_on_errors: false
+        fail_on_errors: false,
+        remove_previous_comments: nil
       )
 
       runner.run
@@ -68,7 +69,8 @@ RSpec.describe Danger::Runner do
             "--dangerfile=MyDangerfile",
             "--danger_id=my-danger-id",
             "--new-comment",
-            "--fail-on-errors=true"
+            "--fail-on-errors=true",
+            "--remove-previous-comments"
           ]
         )
         runner = described_class.new(argv)
@@ -81,7 +83,8 @@ RSpec.describe Danger::Runner do
           dangerfile_path: "MyDangerfile",
           danger_id: "my-danger-id",
           new_comment: true,
-          fail_on_errors: "true"
+          fail_on_errors: "true",
+          remove_previous_comments: true
         )
 
         runner.run

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
 
       expect(request_source).to receive(:update_pull_request!)
 
-      dm.post_results("danger-identifier", nil)
+      dm.post_results("danger-identifier", nil, nil)
     end
 
     it "delegates unique entries" do
@@ -265,10 +265,11 @@ RSpec.describe Danger::Dangerfile, host: :github do
         messages: [anything(), anything()],
         markdowns: [],
         danger_id: 'danger-identifier',
-        new_comment: nil
+        new_comment: nil,
+        remove_previous_comments: nil
       )
 
-      dm.post_results("danger-identifier", nil)
+      dm.post_results("danger-identifier", nil, nil)
     end
   end
 
@@ -315,7 +316,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
         expect(request_source).to receive(:update_pull_request!)
 
         expect do
-          dm.run("custom_danger_base", "custom_danger_head", path, 1, false)
+          dm.run("custom_danger_base", "custom_danger_head", path, 1, false, false)
         end.to raise_error(Danger::DSLError)
       end
 


### PR DESCRIPTION
This PR adds `--remove-previous-comments` CLI flag. The flag can be used in order to get the new danger comments in the tail of the PR and remove previous comments, so the PR looks bot so spammy.

Closes #948