### PR TITLE
Support dots in repo names for Bitrise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ junit-results.xml
 
 # our forked RSpec JUnit Formatter
 /.xml_dump_failures
+
+# Mac OS
+.DS_Store
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!--
 
-// Please add your own contribution below inside the Master section, no need to 
+// Please add your own contribution below inside the Master section, no need to
 // set a version number, that happens during a deploy.
 //
 // These docs are aimed at users rather than danger developers, so please limit technical
@@ -10,11 +10,11 @@
 
 ## master
 
-* Fix handling of Github repos slugs with dots in them (for Bitrise CI). [@provTheodoreNewell](https://github.com/provTheodoreNewell)
+* Fix handling of Github repo slugs with dots in them (for Bitrise CI). [@provTheodoreNewell](https://github.com/provTheodoreNewell)
 
 ## 5.5.8
 
-* Add `--remove-previous-comments` functionality, which means that a you can make a new comment
+* Add `--remove-previous-comments` functionality, which means that a you can make a new comment 
   at the bottom of the code review conversation. [@JoeS](https://github.com/joesss)
 
 ## 5.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 
 ## master
 
+* Fix handling of Github repos slugs with dots in them (for Bitrise CI). [@provTheodoreNewell](https://github.com/provTheodoreNewell)
+
 ## 5.5.8
 
-* Add `--remove-previous-comments` functionality, which means that a you can make a new comment 
+* Add `--remove-previous-comments` functionality, which means that a you can make a new comment
   at the bottom of the code review conversation. [@JoeS](https://github.com/joesss)
 
 ## 5.5.7

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -40,7 +40,7 @@ module Danger
       self.pull_request_id = env["BITRISE_PULL_REQUEST"]
       self.repo_url = env["GIT_REPOSITORY_URL"]
 
-      repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+.*?)(?:.git)?$})
+      repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/]+?)(\.git$|$)})
       self.repo_slug = repo_matches[2] unless repo_matches.nil?
     end
   end

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -40,7 +40,7 @@ module Danger
       self.pull_request_id = env["BITRISE_PULL_REQUEST"]
       self.repo_url = env["GIT_REPOSITORY_URL"]
 
-      repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+)(?:.git)?$})
+      repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/.]+.*?)(?:.git)?$})
       self.repo_slug = repo_matches[2] unless repo_matches.nil?
     end
   end

--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe Danger::Bitrise do
     }
   end
 
-  let(:alternate_valid_env) do
-    {
-      "BITRISE_PULL_REQUEST" => "4",
-      "BITRISE_IO" => "true",
-      "GIT_REPOSITORY_URL" => "git@github.com:artsy/artsy.github.io"
-    }
-  end
-
   let(:invalid_env) do
     {
       "CIRCLE" => "true"
@@ -25,15 +17,9 @@ RSpec.describe Danger::Bitrise do
 
   let(:source) { described_class.new(valid_env) }
 
-  let(:alternate_source) { described_class.new(alternate_valid_env) }
-
   describe ".validates_as_pr?" do
     it "validates when the required env variables are set" do
       expect(described_class.validates_as_pr?(valid_env)).to be true
-    end
-
-    it "validates when the required env variables are set with periods in repo name" do
-      expect(described_class.validates_as_pr?(alternate_valid_env)).to be true
     end
 
     it "does not validate when the required env variables are not set" do
@@ -51,10 +37,6 @@ RSpec.describe Danger::Bitrise do
       expect(described_class.validates_as_ci?(valid_env)).to be true
     end
 
-    it "validates when the required env variables are set with periods in repo name" do
-      expect(described_class.validates_as_pr?(alternate_valid_env)).to be true
-    end
-
     it "does not validate when the required env variables are not set" do
       expect(described_class.validates_as_ci?(invalid_env)).to be false
     end
@@ -70,9 +52,11 @@ RSpec.describe Danger::Bitrise do
       expect(source.repo_slug).to eq("artsy/eigen")
     end
 
-    it "sets the repo_slug with periods in the repo name" do
-      expect(alternate_source.repo_slug).to eq("artsy/artsy.github.io")
+    it "sets the repo_slug from a repo with dots in it", host: :github do
+      valid_env["GIT_REPOSITORY_URL"] = "git@github.com:artsy/artsy.github.io"
+      expect(source.repo_slug).to eq("artsy/artsy.github.io")
     end
+
 
     it "sets the pull_request_id" do
       expect(source.pull_request_id).to eq("4")
@@ -81,11 +65,6 @@ RSpec.describe Danger::Bitrise do
     it "sets the repo_url", host: :github do
       with_git_repo(origin: "git@github.com:artsy/eigen") do
         expect(source.repo_url).to eq("git@github.com:artsy/eigen")
-      end
-    end
-    it "sets the repo_url with periods in the repo name", host: :github do
-      with_git_repo(origin: "git@github.com:artsy/artsy.github.io") do
-        expect(alternate_source.repo_url).to eq("git@github.com:artsy/artsy.github.io")
       end
     end
   end

--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Danger::Bitrise do
     }
   end
 
+  let(:alternate_valid_env) do
+    {
+      "BITRISE_PULL_REQUEST" => "4",
+      "BITRISE_IO" => "true",
+      "GIT_REPOSITORY_URL" => "git@github.com:artsy/artsy.github.io"
+    }
+  end
+
   let(:invalid_env) do
     {
       "CIRCLE" => "true"
@@ -17,9 +25,15 @@ RSpec.describe Danger::Bitrise do
 
   let(:source) { described_class.new(valid_env) }
 
+  let(:alternate_source) { described_class.new(alternate_valid_env) }
+
   describe ".validates_as_pr?" do
     it "validates when the required env variables are set" do
       expect(described_class.validates_as_pr?(valid_env)).to be true
+    end
+
+    it "validates when the required env variables are set with periods in repo name" do
+      expect(described_class.validates_as_pr?(alternate_valid_env)).to be true
     end
 
     it "does not validate when the required env variables are not set" do
@@ -37,6 +51,10 @@ RSpec.describe Danger::Bitrise do
       expect(described_class.validates_as_ci?(valid_env)).to be true
     end
 
+    it "validates when the required env variables are set with periods in repo name" do
+      expect(described_class.validates_as_pr?(alternate_valid_env)).to be true
+    end
+
     it "does not validate when the required env variables are not set" do
       expect(described_class.validates_as_ci?(invalid_env)).to be false
     end
@@ -52,6 +70,10 @@ RSpec.describe Danger::Bitrise do
       expect(source.repo_slug).to eq("artsy/eigen")
     end
 
+    it "sets the repo_slug with periods in the repo name" do
+      expect(alternate_source.repo_slug).to eq("artsy/artsy.github.io")
+    end
+
     it "sets the pull_request_id" do
       expect(source.pull_request_id).to eq("4")
     end
@@ -59,6 +81,11 @@ RSpec.describe Danger::Bitrise do
     it "sets the repo_url", host: :github do
       with_git_repo(origin: "git@github.com:artsy/eigen") do
         expect(source.repo_url).to eq("git@github.com:artsy/eigen")
+      end
+    end
+    it "sets the repo_url with periods in the repo name", host: :github do
+      with_git_repo(origin: "git@github.com:artsy/artsy.github.io") do
+        expect(alternate_source.repo_url).to eq("git@github.com:artsy/artsy.github.io")
       end
     end
   end


### PR DESCRIPTION
Applies the regex fix from #922 to the Bitrise CI initialization to support repository names with dots in them, like `artsy/artsy.github.io`.

This resolves #928.