### PR TITLE
Security Updates for rubocop, take 2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -148,3 +148,6 @@ Security/YAMLLoad:
 
 Style/RaiseArgs:
   Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,14 +24,14 @@ Lint/UselessAssignment:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
 
 # HoundCI doesn't like this rule
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
 
 # We allow !! as it's an easy way to convert ot boolean
@@ -116,7 +116,7 @@ Style/IfInsideElse:
 Style/BlockComments:
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
 # FIXME: 25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 
 ## master
 
-* Improve Jenkins CI error handling when no ENV passed in - Juanito Fatas
-* Update rubocop and yard dependencies for vulnerabilities - Juanito Fatas
+* Improve Jenkins CI error handling when no ENV passed in - #954 Juanito Fatas
+* Update rubocop and yard dependencies for vulnerabilities - #955 Juanito Fatas
+* Update rubocop and yard dependencies for vulnerabilities - #957 Juanito Fatas
 
 ## 5.5.9
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -36,12 +36,12 @@ end
 core_plugins_docs = `bundle exec danger plugins lint lib/danger/danger_core/plugins/*.rb --warnings-as-errors`
 
 # If it failed, fail the build, and include markdown with the output error.
-# unless $?.success?
+unless $?.success?
   # We want to strip ANSI colors for our markdown, and make paths relative
-#   colourless_error = core_plugins_docs.gsub(/\e\[(\d+)(;\d+)*m/, "")
-#   markdown("### Core Docs Errors \n\n#{colourless_error}")
-#   fail("Failing due to documentation issues, see below.", sticky: false)
-# end
+  colourless_error = core_plugins_docs.gsub(/\e\[(\d+)(;\d+)*m/, "")
+  markdown("### Core Docs Errors \n\n#{colourless_error}")
+  fail("Failing due to documentation issues, see below.", sticky: false)
+end
 
 # Oddly enough, it's quite possible to do some testing of Danger, inside Danger
 # So, you can ignore these, if you're looking at the Dangerfile to get ideas.

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,20 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "bundler", "~> 1.10"
 gem "chandler" if RUBY_VERSION != "2.0.0"
 gem "danger-gitlab"
-
 gem "danger-junit", "~> 0.5"
-gem "rspec_junit_formatter", git: "https://github.com/JuanitoFatas/rspec_junit_formatter.git", branch: "dump-rspec_junit_formatter-failed-examples"
-
-gem "rubocop", "0.44.1"
+gem "guard", "~> 2.14"
+gem "guard-rspec", "~> 4.7"
+gem "guard-rubocop", "~> 1.2"
+gem "listen", "3.0.7"
+gem "pry", "~> 0.10"
+gem "pry-byebug"
+gem "rake", "~> 10.0"
+gem "rspec", "~> 3.4"
+gem "rspec_junit_formatter", "~> 0.2"
+gem "rubocop", "~> 0.49.0"
+gem "simplecov", "~> 0.12.0"
+gem "webmock", "~> 2.1"
+gem "yard", "~> 0.9.11"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -31,22 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "terminal-table", "~> 1"
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "no_proxy_fix"
-
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "rspec_junit_formatter", "~> 0.2"
-  spec.add_development_dependency "webmock", "~> 2.1"
-  spec.add_development_dependency "pry", "~> 0.10"
-  spec.add_development_dependency "pry-byebug"
-
-  spec.add_development_dependency "rubocop", "~> 0.49.0"
-  spec.add_development_dependency "yard", "~> 0.9.11"
-
-  spec.add_development_dependency "listen", "3.0.7"
-  spec.add_development_dependency "guard", "~> 2.14"
-  spec.add_development_dependency "guard-rspec", "~> 4.7"
-  spec.add_development_dependency "guard-rubocop", "~> 1.2"
-  spec.add_development_dependency "simplecov", "~> 0.12.0"
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -295,12 +295,12 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       )
 
       summary = <<COMMENT
-<!--
-  1 Error: This is an error
-  1 Warning: Violations that are very very ...
-  1 Message: This is a message
-  1 Markdown
--->
+  <!--
+    1 Error: This is an error
+    1 Warning: Violations that are very very ...
+    1 Message: This is a message
+    1 Markdown
+  -->
 COMMENT
 
       expect(comment).to include(summary)

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -295,12 +295,12 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       )
 
       summary = <<COMMENT
-  <!--
-    1 Error: This is an error
-    1 Warning: Violations that are very very ...
-    1 Message: This is a message
-    1 Markdown
-  -->
+<!--
+  1 Error: This is an error
+  1 Warning: Violations that are very very ...
+  1 Message: This is a message
+  1 Markdown
+-->
 COMMENT
 
       expect(comment).to include(summary)


### PR DESCRIPTION
I still see warnings while visit danger/danger:

<img width="996" alt="screen shot 2018-02-09 at 16 35 45" src="https://user-images.githubusercontent.com/1000669/36016633-5376972c-0db7-11e8-8658-47e14185523e.png">

that's because we specify two rubocop in gemspec and Gemfile. Let's specify all dev dependencies in Gemfile.

This PR:

- move dev dependencies to Gemfile, sort alphabatically
- Let's try turn the plugins lint back on, disabled in #942
- Rubocop updates for 0.49.1