### PR TITLE
Enable BitBucket Cloud for Circle CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Improve Jenkins CI error handling when no ENV passed in - #954 Juanito Fatas
 * Update rubocop and yard dependencies for vulnerabilities - #955 Juanito Fatas
 * Update rubocop and yard dependencies for vulnerabilities - #957 Juanito Fatas
+* Enable BitBucket Cloud for Circle CI. [@andrewlord1990](https://github.com/andrewlord1990)
 
 ## 5.5.9
 

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -53,7 +53,7 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::BitbucketCloud]
     end
 
     def initialize(env)

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -119,5 +119,9 @@ RSpec.describe Danger::CircleCI do
     it "supports GitHub" do
       expect(source.supported_request_sources).to include(Danger::RequestSources::GitHub)
     end
+
+    it "supports BitBucket Cloud" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::BitbucketCloud)
+    end
   end
 end


### PR DESCRIPTION
Circle CI supports BitBucket Cloud.

For Danger, it should be as simple as adding it as a supported request source on Circle CI, as it is already checking the environment variables.