### PR TITLE
Fix GitLab "html_link" for external repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix GitLab `html_link` url's for external repos. [@sogame](https://github.com/sogame)
+
 ## 5.5.10
 
 * Improve Jenkins CI error handling when no ENV passed in - #954 Juanito Fatas

--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -193,7 +193,7 @@ module Danger
       paths = [paths] unless paths.kind_of?(Array)
       commit = head_commit
       same_repo = mr_json["project_id"] == mr_json["source_project_id"]
-      sender_repo = env.ci_source.repo_slug.split("/").first + "/" + mr_author
+      sender_repo = mr_author + "/" + env.ci_source.repo_slug.split("/")[1]
       repo = same_repo ? env.ci_source.repo_slug : sender_repo
       host = @gitlab.host
 


### PR DESCRIPTION
The url for GitLab repos follows the structure `https://{host}/{user}/{project_name}`.

Currently, when submitting a PR from an external repo, `html_link` creates a url like `https://{host}/{orig_repo_user}/{external_repo_user}` instead of `https://{host}/{external_repo_user}/{project_name}`.

This PR tries to fix it.