### PR TITLE
Removing `--all` option for `git merge-base`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Fix GitLab `html_link` url's for external repos. [@sogame](https://github.com/sogame)
+* Removing `--all` option for `git merge-base` [@tbrand](https://github.com/tbrand)
 
 ## 5.5.10
 

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -165,7 +165,7 @@ module Git
     # Use git-merge-base https://git-scm.com/docs/git-merge-base to
     # find as good common ancestors as possible for a merge
     def merge_base(commit1, commit2, *other_commits)
-      Open3.popen2("git", "merge-base", "--all", commit1, commit2, *other_commits) { |_stdin, stdout, _wait_thr| stdout.read.rstrip }
+      Open3.popen2("git", "merge-base", commit1, commit2, *other_commits) { |_stdin, stdout, _wait_thr| stdout.read.rstrip }
     end
   end
 end


### PR DESCRIPTION
A patch for fixing
- https://github.com/danger/danger/issues/965
- https://github.com/danger/danger/issues/904
- https://github.com/danger/danger/issues/966

I've tried this patch in my environment and it solves all of the crashes.