### PR TITLE
Fix a multistage `import_dangerfile` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix a Fix a multistage `import_dangerfile` error [@tbrand](https://github.com/tbrand)
+
 ## 5.5.11
 
 * Fix GitLab `html_link` url's for external repos. [@sogame](https://github.com/sogame)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 
-* Fix a Fix a multistage `import_dangerfile` error [@tbrand](https://github.com/tbrand)
+* Fix a multistage `import_dangerfile` error [@tbrand](https://github.com/tbrand)
 
 ## 5.5.11
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -465,7 +465,6 @@ module Danger
       def file_url(organisation: nil, repository: nil, branch: nil, path: nil)
         organisation ||= self.organisation
 
-        return @download_url unless @download_url.nil?
         begin
           # Retrieve the download URL (default branch on nil param)
           contents = client.contents("#{organisation}/#{repository}", path: path, ref: branch)


### PR DESCRIPTION
Forks.

The problem is occurred when I use multistage `import_dangerfile` like this.

My Dangerfile
```ruby
danger.import_dangerfile(github: "tbrand/danger1")
```

Dangerfile at `tbrand/danger1`
```ruby
danger.import_dangerfile(github: "tbrand/danger2")
```

Dangerfile at `tbrand/danger2`
```ruby
message "hello"
```

When I execute `danger pr` for it, it falls into infinite loop.

After debugging, I've found that this line disturbs updating `@download_url`.
https://github.com/danger/danger/blob/dbfd46e6350ae5dd30ca3ebcc0872d6b68f1a6cf/lib/danger/request_sources/github/github.rb#L468

So `github.rb#file_url` always returns the same url even if the actual `@download_url` is updated.

The history of the line is here.
https://github.com/danger/danger/pull/772

I may know you've lost a motivation for fixing ruby's danger... :cry:
But it's quite helpful for me if you take a look at this. :smile: