### PR TITLE
Fix array sublcass typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Fix a multistage `import_dangerfile` error [@tbrand](https://github.com/tbrand)
+* Fixing typo: `ArraySublcass` -> `ArraySubclass` [@ivantse](https://github.com/ivantse)
 
 ## 5.5.11
 

--- a/lib/danger/core_ext/file_list.rb
+++ b/lib/danger/core_ext/file_list.rb
@@ -2,7 +2,7 @@ require "danger/helpers/array_subclass"
 
 module Danger
   class FileList
-    include Helpers::ArraySublcass
+    include Helpers::ArraySubclass
 
     # Information about pattern: http://ruby-doc.org/core-2.2.0/File.html#method-c-fnmatch
     # e.g. "**/something.*" for any file called something with any extension

--- a/lib/danger/helpers/array_subclass.rb
+++ b/lib/danger/helpers/array_subclass.rb
@@ -1,6 +1,6 @@
 module Danger
   module Helpers
-    module ArraySublcass
+    module ArraySubclass
       include Comparable
 
       def initialize(array)

--- a/spec/lib/danger/helpers/array_subclass_spec.rb
+++ b/spec/lib/danger/helpers/array_subclass_spec.rb
@@ -1,6 +1,6 @@
-RSpec.describe Danger::Helpers::ArraySublcass do
-  class List; include Danger::Helpers::ArraySublcass; end
-  class OtherList; include Danger::Helpers::ArraySublcass; end
+RSpec.describe Danger::Helpers::ArraySubclass do
+  class List; include Danger::Helpers::ArraySubclass; end
+  class OtherList; include Danger::Helpers::ArraySubclass; end
 
   it "acts as array" do
     first_list = List.new([1, 2, 3])


### PR DESCRIPTION
Previously, the helper was named `ArraySublcass`. This renames it to `ArraySubclass`.