### PR TITLE
Fix crash on nil lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Fix a multistage `import_dangerfile` error [@tbrand](https://github.com/tbrand)
 * Fixing typo: `ArraySublcass` -> `ArraySubclass` [@ivantse](https://github.com/ivantse)
+* Fix crash when having messages with nil line on GitHub [@fwal](https://github.com/fwal)
 
 ## 5.5.11
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -489,8 +489,8 @@ module Danger
 
       def inline_violations_group(warnings: [], errors: [], messages: [], markdowns: [])
         cmp = proc do |a, b|
-          next -1 unless a.file
-          next 1 unless b.file
+          next -1 unless a.file && a.line
+          next 1 unless b.file && b.line
 
           next a.line <=> b.line if a.file == b.file
           next a.file <=> b.file


### PR DESCRIPTION
Initially reported in #924

Having multiple messages with the same file but at least one without line would cause sorting to crash as `nil <=> 1` is `nil`.

```ruby
# This was fine
warn("A warning", file: "A.file", line: nil) 

# This crashed
warn("A warning", file: "A.file", line: 1)
warn("A warning", file: "A.file", line: nil)
```