### PR TITLE
Notes which CI is used when exiting with an invalid PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Enable Bitbucket Cloud for Bitrise CI [@masahide318](https://github.com/masahide318)
+* Notes which CI is used when exiting with an invalid PR [@dbgrandi](https://github.com/dbgrandi)
 
 ## 5.5.12
 

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -60,7 +60,8 @@ module Danger
     # Could we determine that the CI source is inside a PR?
     def validate_pr!(cork)
       unless EnvironmentManager.pr?(system_env)
-        cork.puts "Not a Pull Request - skipping `danger` run".yellow
+        ci_name = EnvironmentManager.local_ci_source(system_env).name.split('::').last
+        cork.puts "Not a #{ci_name} Pull Request - skipping `danger` run".yellow
         exit(0)
       end
     end

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -60,7 +60,7 @@ module Danger
     # Could we determine that the CI source is inside a PR?
     def validate_pr!(cork)
       unless EnvironmentManager.pr?(system_env)
-        ci_name = EnvironmentManager.local_ci_source(system_env).name.split('::').last
+        ci_name = EnvironmentManager.local_ci_source(system_env).name.split("::").last
         cork.puts "Not a #{ci_name} Pull Request - skipping `danger` run".yellow
         exit(0)
       end

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Danger::Executor, use: :ci_helper do
         with_localgitrepo_setup do |system_env|
           ui = testing_ui
           expect { described_class.new(system_env).validate!(ui) }.to raise_error(SystemExit)
-          expect(ui.string).to include("Not a Pull Request - skipping `danger` run")
+          expect(ui.string).to include("Not a LocalGitRepo Pull Request - skipping `danger` run")
         end
       end
 
@@ -111,7 +111,7 @@ RSpec.describe Danger::Executor, use: :ci_helper do
         not_a_pull_request do |system_env|
           ui = testing_ui
           expect { described_class.new(system_env).validate!(ui) }.to raise_error(SystemExit)
-          expect(ui.string).to include("Not a Pull Request - skipping `danger` run")
+          expect(ui.string).to include("Not a Travis Pull Request - skipping `danger` run")
         end
       end
     end


### PR DESCRIPTION
Hiya 👋 

When danger runs and finds a valid CI environment, but does not find a valid PR, you end up with a failure message like `Not a Pull Request - skipping 'danger' run`

This PR injects the CI name into that error message. e.g. `Not a Travis Pull Request - skipping 'danger' run`, to add a little more context.

Handy for debugging on non-supported CIs. Yep, there are still a few of those left. :)