### PR TITLE
Fix crash when messages are nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 -->
 
 ## master
+
+* Fix crash when messages are nil. [@allewun](https://github.com/allewun)
 * Add support for [Screwdriver CI](http://screwdriver.cd) - [@dbgrandi](https://github.com/dbgrandi)
 
 ## 5.5.13

--- a/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
@@ -107,7 +107,7 @@ module Danger
     # @!group Core
     # Print out a generate message on the PR
     #
-    # @param    [String, Array<String> message
+    # @param    [String, Array<String>] message
     #           The message to present to the user
     # @param    [Boolean] sticky
     #           Whether the message should be kept after it was fixed,
@@ -124,14 +124,14 @@ module Danger
       line = options.fetch(:line, nil)
 
       messages.flatten.each do |message|
-        @messages << Violation.new(message, sticky, file, line)
+        @messages << Violation.new(message, sticky, file, line) if message
       end
     end
 
     # @!group Core
     # Specifies a problem, but not critical
     #
-    # @param    [String, Array<String> message
+    # @param    [String, Array<String>] message
     #           The message to present to the user
     # @param    [Boolean] sticky
     #           Whether the message should be kept after it was fixed,
@@ -149,14 +149,14 @@ module Danger
 
       warnings.flatten.each do |warning|
         next if should_ignore_violation(warning)
-        @warnings << Violation.new(warning, sticky, file, line)
+        @warnings << Violation.new(warning, sticky, file, line) if warning
       end
     end
 
     # @!group Core
     # Declares a CI blocking error
     #
-    # @param    [String, Array<String> message
+    # @param    [String, Array<String>] message
     #           The message to present to the user
     # @param    [Boolean] sticky
     #           Whether the message should be kept after it was fixed,
@@ -174,7 +174,7 @@ module Danger
 
       failures.flatten.each do |failure|
         next if should_ignore_violation(failure)
-        @errors << Violation.new(failure, sticky, file, line)
+        @errors << Violation.new(failure, sticky, file, line) if failure
       end
     end
 

--- a/spec/lib/danger/danger_core/plugins/dangerfile_messaging_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_messaging_plugin_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe Danger::DangerfileMessagingPlugin, host: :github do
       expect(messages.last.file).to eq("foo.rb")
       expect(messages.last.line).to eq(1)
     end
+
+    it "does nothing when given a nil message" do
+      dangerfile.parse(nil, "message(nil)")
+      messages = added_messages(dangerfile, :messages)
+
+      expect(messages).to be_empty
+    end
   end
 
   describe "#warn" do
@@ -98,6 +105,13 @@ RSpec.describe Danger::DangerfileMessagingPlugin, host: :github do
       expect(warnings.last.file).to eq("foo.rb")
       expect(warnings.last.line).to eq(1)
     end
+
+    it "does nothing when given a nil warning" do
+      dangerfile.parse(nil, "warn(nil)")
+      warnings = added_messages(dangerfile, :warnings)
+
+      expect(warnings).to be_empty
+    end
   end
 
   describe "#fail" do
@@ -130,6 +144,13 @@ RSpec.describe Danger::DangerfileMessagingPlugin, host: :github do
       expect(failures.last.message).to eq("bye")
       expect(failures.last.file).to eq("foo.rb")
       expect(failures.last.line).to eq(1)
+    end
+
+    it "does nothing when given a nil failure" do
+      dangerfile.parse(nil, "fail(nil)")
+      failures = added_messages(dangerfile, :errors)
+
+      expect(failures).to be_empty
     end
   end
 


### PR DESCRIPTION
If `nil` is unexpectedly passed to `message|warn|fail`, Danger will crash. While the Dangerfile should resolve this so that it doesn't happen in the first place, it's probably safer to do nothing IMO.