### PR TITLE
Fix Danger::GitLabCI to use CI_PROJECT_PATH instead of CI_PROJECT_ID for its #repo_slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Use HTTPS links where applicable. [@allewun](https://github.com/allewun)
+* Fix `Danger::GitLabCI` to use `CI_PROJECT_PATH` instead of `CI_PROJECT_ID` for its `#repo_slug`. [@rymai](https://github.com/rymai)
 
 ## 5.6.0
 

--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -192,15 +192,11 @@ module Danger
     def html_link(paths, full_path: true)
       paths = [paths] unless paths.kind_of?(Array)
       commit = head_commit
-      same_repo = mr_json["project_id"] == mr_json["source_project_id"]
-      sender_repo = mr_author + "/" + env.ci_source.repo_slug.split("/")[1]
-      repo = same_repo ? env.ci_source.repo_slug : sender_repo
-      host = @gitlab.host
 
       paths = paths.map do |path|
         url_path = path.start_with?("/") ? path : "/#{path}"
         text = full_path ? path : File.basename(path)
-        create_link("https://#{host}/#{repo}/blob/#{commit}#{url_path}", text)
+        create_link("#{env.ci_source.project_url}/blob/#{commit}#{url_path}", text)
       end
 
       return paths.first if paths.count < 2

--- a/spec/fixtures/gitlab_api/merge_requests_response.json
+++ b/spec/fixtures/gitlab_api/merge_requests_response.json
@@ -5,7 +5,7 @@ Content-Type: application/json
 Content-Length: 1507
 Cache-Control: max-age=0, private, must-revalidate
 Etag: W/"e810a3b50890dd0a5823597abbbf9fc9"
-Link: <https://gitlab.com/api/v4/projects/k0nserv/danger-test/merge_requests?state=opened&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v4/projects/k0nserv/danger-test/merge_requests?state=opened&page=1&per_page=20>; rel="last"
+Link: <https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/merge_requests?state=opened&page=1&per_page=20>; rel="first", <https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/merge_requests?state=opened&page=1&per_page=20>; rel="last"
 Status: 200 OK
 Vary: Origin
 X-Next-Page:

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -1,33 +1,27 @@
 require "danger/ci_source/gitlab_ci"
 
 RSpec.describe Danger::GitLabCI, host: :gitlab do
-  context "valid envrionment" do
-    let(:gitlab_env) do
-      {
-        "GITLAB_CI" => "1",
-        "CI_MERGE_REQUEST_ID" => "28493",
-        "CI_PROJECT_ID" => "danger/danger"
-      }
-    end
+  context "valid environment" do
+    let(:env) { stub_env.merge("CI_MERGE_REQUEST_ID" => 28493) }
 
     let(:ci_source) do
-      described_class.new(gitlab_env)
+      described_class.new(env)
     end
 
     describe ".validates_as_ci?" do
       it "is valid" do
-        expect(described_class.validates_as_ci?(gitlab_env)).to be(true)
+        expect(described_class.validates_as_ci?(env)).to be(true)
       end
     end
 
     describe ".validates_as_pr?" do
       it "is valid" do
-        expect(described_class.validates_as_pr?(gitlab_env)).to be(true)
+        expect(described_class.validates_as_pr?(env)).to be(true)
       end
     end
 
     describe ".determine_merge_request_id" do
-      context "when CI_MERGE_REQUEST_ID present in envrionment" do
+      context "when CI_MERGE_REQUEST_ID present in environment" do
         it "returns CI_MERGE_REQUEST_ID" do
           expect(described_class.determine_merge_request_id({
             "CI_MERGE_REQUEST_ID" => 1
@@ -35,18 +29,18 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
         end
       end
 
-      context "when CI_COMMIT_SHA not present in envrionment" do
+      context "when CI_COMMIT_SHA not present in environment" do
         it "returns 0" do
           expect(described_class.determine_merge_request_id({})).to eq(0)
         end
       end
 
-      context "when CI_COMMIT_SHA present in envrionment" do
+      context "when CI_COMMIT_SHA present in environment" do
         it "uses gitlab api to find merge request id" do
-          stub_merge_requests("merge_requests_response", "danger%2Fdanger")
+          stub_merge_requests("merge_requests_response", "k0nserv%2Fdanger-test")
 
           expect(described_class.determine_merge_request_id({
-            "CI_PROJECT_ID" => "danger/danger",
+            "CI_PROJECT_PATH" => "k0nserv/danger-test",
             "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
             "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
           })).to eq(3)
@@ -62,11 +56,19 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
 
     describe "#initialize" do
       it "sets the repo_slug" do
-        expect(ci_source.repo_slug).to eq("danger/danger")
+        expect(ci_source.repo_slug).to eq("k0nserv/danger-test")
       end
+    end
 
+    describe "#project_url" do
+      it "sets the project_url" do
+        expect(ci_source.project_url).to eq(env["CI_PROJECT_URL"])
+      end
+    end
+
+    describe "#pull_request_id" do
       it "sets the pull_request_id" do
-        expect(ci_source.pull_request_id).to eq("28493")
+        expect(ci_source.pull_request_id).to eq(env["CI_MERGE_REQUEST_ID"])
       end
     end
   end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
-  let(:dangerfile) { testing_dangerfile }
+  let(:env) { stub_env.merge("CI_MERGE_REQUEST_ID" => 593_728) }
+  let(:dangerfile) { testing_dangerfile(env) }
   let(:plugin) { described_class.new(dangerfile) }
   before do
     stub_merge_request(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,9 +71,9 @@ def testing_ui
 end
 # rubocop:enable Lint/NestedMethodDefinition
 
-def testing_dangerfile
-  env = Danger::EnvironmentManager.new(stub_env, testing_ui)
-  dm = Danger::Dangerfile.new(env, testing_ui)
+def testing_dangerfile(env = stub_env)
+  env_manager = Danger::EnvironmentManager.new(env, testing_ui)
+  dm = Danger::Dangerfile.new(env_manager, testing_ui)
 end
 
 def fixture_txt(file)

--- a/spec/support/ci_helper.rb
+++ b/spec/support/ci_helper.rb
@@ -52,7 +52,7 @@ module Danger
         system_env = {
           "GITLAB_CI" => "true",
           "CI_MERGE_REQUEST_ID" => "42",
-          "CI_PROJECT_ID" => "danger/danger"
+          "CI_PROJECT_PATH" => "danger/danger"
         }
 
         yield(system_env)

--- a/spec/support/gitlab_helper.rb
+++ b/spec/support/gitlab_helper.rb
@@ -10,20 +10,20 @@ module Danger
 
       def stub_env
         {
-          "DRONE" => true,
-          "DRONE_REPO_OWNER" => "k0nserv",
-          "DRONE_REPO_NAME" => "danger-test",
-          "DRONE_PULL_REQUEST" => "593728",
+          "GITLAB_CI" => "1",
+          "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
+          "CI_PROJECT_PATH" => "k0nserv/danger-test",
+          "CI_PROJECT_URL" => "https://gitlab.com/k0nserv/danger-test",
           "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
         }
       end
 
-      def stub_ci
-        Danger::Drone.new(stub_env)
+      def stub_ci(env = stub_env)
+        Danger::GitLabCI.new(env)
       end
 
-      def stub_request_source
-        Danger::RequestSources::GitLab.new(stub_ci, stub_env)
+      def stub_request_source(env = stub_env)
+        Danger::RequestSources::GitLab.new(stub_ci(env), env)
       end
 
       def stub_merge_requests(fixture, slug)


### PR DESCRIPTION
This fixes a few issues with the GitLab integration:

- In GitLab, `ENV["CI_PROJECT_ID"]` returns the project's ID, not its path/slug. `ENV["CI_PROJECT_PATH"]` should be used instead, see https://docs.gitlab.com/ee/ci/variables/README.html.
- Unfortunately, the stubbed environment was setting `ENV["CI_PROJECT_ID"]` with a project slug (e.g. `danger/danger`). That's why the specs passed even though the feature was broken. The environment stubbing is now fixed.
- `Danger::DangerfileGitLabPlugin#html_link` has been simplified to use `ENV["CI_PROJECT_URL"]`.

Fixes #969.