### PR TITLE
Update screwdriver ci initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Update [Screwdriver CI] to parse repo_slug/repo_url correctly. [@fandyfyf](https://github.com/fandyfyf) 
+
 ## 5.6.1
 
 * Use HTTPS links where applicable. [@allewun](https://github.com/allewun)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 
-* Update [Screwdriver CI] to parse repo_slug/repo_url correctly. [@fandyfyf](https://github.com/fandyfyf) 
+* Update Screwdriver CI to parse repo_slug/repo_url correctly. [@fandyfyf](https://github.com/fandyfyf) 
 
 ## 5.6.1
 

--- a/lib/danger/ci_source/screwdriver.rb
+++ b/lib/danger/ci_source/screwdriver.rb
@@ -37,8 +37,8 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_slug = env["SCM_URL"].split(":").last.gsub(".git", "")
-      self.repo_url = env["SCM_URL"]
+      self.repo_slug = env["SCM_URL"].split(":").last.gsub(".git", "").split("#",2).first
+      self.repo_url = env["SCM_URL"].split("#",2).first
       if env["SD_PULL_REQUEST"].to_i > 0
         self.pull_request_id = env["SD_PULL_REQUEST"]
       end

--- a/lib/danger/ci_source/screwdriver.rb
+++ b/lib/danger/ci_source/screwdriver.rb
@@ -37,8 +37,8 @@ module Danger
     end
 
     def initialize(env)
-      self.repo_slug = env["SCM_URL"].split(":").last.gsub(".git", "").split("#",2).first
-      self.repo_url = env["SCM_URL"].split("#",2).first
+      self.repo_slug = env["SCM_URL"].split(":").last.gsub(".git", "").split("#", 2).first
+      self.repo_url = env["SCM_URL"].split("#", 2).first
       if env["SD_PULL_REQUEST"].to_i > 0
         self.pull_request_id = env["SD_PULL_REQUEST"]
       end

--- a/spec/lib/danger/ci_sources/screwdriver_spec.rb
+++ b/spec/lib/danger/ci_sources/screwdriver_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Danger::Screwdriver do
     {
         "SCREWDRIVER" => "true",
         "SD_PULL_REQUEST" => "42",
-        "SCM_URL" => "git@github.com:danger/danger"
+        "SCM_URL" => "git@github.com:danger/danger.git#branch"
     }
   end
 
@@ -42,7 +42,7 @@ RSpec.describe Danger::Screwdriver do
     it "sets the required attributes" do
       expect(source.repo_slug).to eq("danger/danger")
       expect(source.pull_request_id).to eq("42")
-      expect(source.repo_url).to eq("git@github.com:danger/danger")
+      expect(source.repo_url).to eq("git@github.com:danger/danger.git")
     end
   end
 end


### PR DESCRIPTION
SCM_URL usually include a branch name

Ex. `git@github.com:danger/danger.git#branch`

repo_slug -> `danger/danger`
repo_url -> `git@github.com:danger/danger.git`

with the current logic, Danger will pick up a wrong repo_slug which causes failure.
