### PR TITLE
Fix to detect not Pull Request on CircleCI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix to detect not Pull Request on CircleCI. [@kompiro](https://github.com/kompiro)
+
 ## 5.6.2
 
 * Update Screwdriver CI to parse repo_slug/repo_url correctly. [@fandyfyf](https://github.com/fandyfyf) 

--- a/lib/danger/ci_source/circle_api.rb
+++ b/lib/danger/ci_source/circle_api.rb
@@ -16,8 +16,13 @@ module Danger
 
       if url.nil? && !env["CIRCLE_PROJECT_USERNAME"].nil? && !env["CIRCLE_PROJECT_REPONAME"].nil?
         repo_slug = env["CIRCLE_PROJECT_USERNAME"] + "/" + env["CIRCLE_PROJECT_REPONAME"]
-        token = env["DANGER_CIRCLE_CI_API_TOKEN"]
-        url = fetch_pull_request_url(repo_slug, env["CIRCLE_BUILD_NUM"], token)
+        if !env["CIRCLE_PR_NUMBER"].nil?
+          host = env["DANGER_GITHUB_HOST"] || 'github.com'
+          url = "https://" + host + "/" + repo_slug + "/pull/" + env["CIRCLE_PR_NUMBER"]
+        else
+          token = env["DANGER_CIRCLE_CI_API_TOKEN"]
+          url = fetch_pull_request_url(repo_slug, env["CIRCLE_BUILD_NUM"], token)
+        end
       end
       url
     end

--- a/spec/lib/danger/ci_sources/circle_api_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_api_spec.rb
@@ -1,6 +1,56 @@
 require "danger/ci_source/circle_api"
 
 RSpec.describe Danger::CircleAPI do
+  context "with `CIRCLE_PR_NUMBER`" do
+    let(:valid_env) {
+      {
+        "CIRCLE_BUILD_NUM" => "1500",
+        "DANGER_CIRCLE_CI_API_TOKEN" => "token2",
+        "CIRCLE_PROJECT_USERNAME" => "artsy",
+        "CIRCLE_PROJECT_REPONAME" => "eigen",
+        "CIRCLE_PR_NUMBER" => "800"
+      }
+    }
+
+    it "returns correct attributes" do
+      result = Danger::CircleCI.new(valid_env)
+    
+      expect(result).to have_attributes(
+        repo_slug: "artsy/eigen",
+        pull_request_id: "800"
+      )
+    end
+
+    context "and set `DANGER_GITHUB_HOST`" do
+      it "returns correct attributes" do
+        env = valid_env.merge!({ "DANGER_GITHUB_HOST" => "git.foobar.com" })
+        result = Danger::CircleCI.new(env)
+    
+        expect(result).to have_attributes(
+          repo_slug: "artsy/eigen",
+          pull_request_id: "800"
+        )
+      end
+    end
+  end
+  
+  it "uses CIRCLE_PR_NUMBER if avaliable" do
+    env = {
+      "CIRCLE_BUILD_NUM" => "1500",
+      "DANGER_CIRCLE_CI_API_TOKEN" => "token2",
+      "CIRCLE_PROJECT_USERNAME" => "artsy",
+      "CIRCLE_PROJECT_REPONAME" => "eigen",
+      "CIRCLE_PR_NUMBER" => "800"
+    }
+    
+    result = Danger::CircleCI.new(env)
+
+    expect(result).to have_attributes(
+      repo_slug: "artsy/eigen",
+      pull_request_id: "800"
+    )
+  end
+
   it "gets out a repo slug, pull request number and commit refs when PR url is not found" do
     env = {
       "CIRCLE_BUILD_NUM" => "1500",
@@ -34,7 +84,7 @@ RSpec.describe Danger::CircleAPI do
 
     expect(result).to eq("https://github.com/artsy/eigen/pull/2606")
   end
-
+  
   it "uses Circle CI API to grab the url if available" do
     env = {
       "CIRCLE_BUILD_NUM" => "1500",

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -48,15 +48,28 @@ RSpec.describe Danger::CircleCI do
     end
 
     context "with missing `CI_PULL_REQUEST` and `CIRCLE_PULL_REQUEST`" do
-      before do
-        valid_env["CI_PULL_REQUEST"] = nil
-        valid_env["DANGER_CIRCLE_CI_API_TOKEN"] = "testtoken"
-        build_response = JSON.parse(fixture("circle_build_response"), symbolize_names: true)
-        allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with("artsy/eigen", "1500", "testtoken").and_return(build_response)
+      context "and with `CIRCLE_PR_NUMBER`" do
+        before do
+          valid_env["CI_PULL_REQUEST"] = nil
+          valid_env["DANGER_CIRCLE_CI_API_TOKEN"] = "testtoken"
+          valid_env["CIRCLE_PR_NUMBER"] = "800"
+        end
+        
+        it "validates when required env variables are set" do
+          expect(described_class.validates_as_pr?(valid_env)).to be true
+        end
       end
-
-      it "validates when required env variables are set" do
-        expect(described_class.validates_as_pr?(valid_env)).to be true
+      context "and with missing `CIRCLE_PR_NUMBER`" do
+        before do
+          valid_env["CI_PULL_REQUEST"] = nil
+          valid_env["DANGER_CIRCLE_CI_API_TOKEN"] = "testtoken"
+          build_response = JSON.parse(fixture("circle_build_response"), symbolize_names: true)
+          allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with("artsy/eigen", "1500", "testtoken").and_return(build_response)
+        end
+  
+        it "validates when required env variables are set" do
+          expect(described_class.validates_as_pr?(valid_env)).to be true
+        end
       end
     end
 


### PR DESCRIPTION
Fix #994 

CircleCI provides env `CIRCLE_PR_NUMBER`. so we can use it to build pr_url.
Please read #994. I made the issue. 