### PR TITLE
Allow two slashes in URL slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Fix to detect not Pull Request on CircleCI. [@kompiro](https://github.com/kompiro)
+* Add support for two slashes in repository slug like `organisation/team/repository` (for GitLab) [@dstranz](https://github.com/dstranz)
 
 ## 5.6.2
 

--- a/lib/danger/ci_source/support/find_repo_info_from_url.rb
+++ b/lib/danger/ci_source/support/find_repo_info_from_url.rb
@@ -3,7 +3,7 @@ require "danger/ci_source/support/repo_info"
 module Danger
   class FindRepoInfoFromURL
     REGEXP = %r{
-      https?://[^/]+/
+      ://[^/]+/
       (?<slug>[^/]+(/[^/]+){1,2})
       (/(pull|merge_requests|pull-requests)/)
       (?<id>\d+)

--- a/lib/danger/ci_source/support/find_repo_info_from_url.rb
+++ b/lib/danger/ci_source/support/find_repo_info_from_url.rb
@@ -3,7 +3,8 @@ require "danger/ci_source/support/repo_info"
 module Danger
   class FindRepoInfoFromURL
     REGEXP = %r{
-      (?<slug>[^/]+/[^/]+)
+      https?://[^/]+/
+      (?<slug>[^/]+(/[^/]+){1,2})
       (/(pull|merge_requests|pull-requests)/)
       (?<id>\d+)
     }x

--- a/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
+++ b/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe Danger::FindRepoInfoFromURL do
         id: "42"
       )
     end
+
+    it "works with two trailing slashes" do
+      result = described_class.new("https://gitlab.com/gitlab-org/gitlab-group/gitlab-ce/merge_requests/42/").call
+
+      expect(result).to have_attributes(
+        slug: "gitlab-org/gitlab-group/gitlab-ce",
+        id: "42"
+      )
+    end
   end
 
   context "Bitbucket" do


### PR DESCRIPTION
Fix for issue described in #968 - correct slug detection for repository with following url:
`https://git.myhost.com/ORGANISATION/TEAM/REPOSITORY_NAME` allowed by GitLab.

I cannot simply add new regexp group `(/[^/]+){1,2}` because then it will also match part of domain name, so I added `://[^/]+/` at the beginning to catch only url path.