### PR TITLE
Update Bitrise CI to parse repo_slug with two slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Update Bitrise CI to parse repo_slug with two slashes [@dstranz](https://github.com/dstranz)
+
 ## 5.6.3
 
 * Fix to detect not Pull Request on CircleCI. [@kompiro](https://github.com/kompiro)

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -41,7 +41,7 @@ module Danger
       self.pull_request_id = env["BITRISE_PULL_REQUEST"]
       self.repo_url = env["GIT_REPOSITORY_URL"]
 
-      repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/]+?)(\.git$|$)})
+      repo_matches = self.repo_url.match(%r{([\/:])(([^\/]+\/){1,2}[^\/]+?)(\.git$|$)})
       self.repo_slug = repo_matches[2] unless repo_matches.nil?
     end
   end

--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe Danger::Bitrise do
       expect(source.repo_slug).to eq("artsy/artsy.github.io")
     end
 
+    it "sets the repo_slug from a repo with two slashes in it", host: :github do
+      valid_env["GIT_REPOSITORY_URL"] = "git@github.com:artsy/ios/artsy.github.io"
+      expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
+    end
+
+
+    it "sets the repo_slug from a repo https url", host: :github do
+      valid_env["GIT_REPOSITORY_URL"] = "https://github.com/artsy/ios/artsy.github.io"
+      expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
+    end
+
     it "sets the pull_request_id" do
       expect(source.pull_request_id).to eq("4")
     end


### PR DESCRIPTION
Extension for #1002 Pull Request to support 2 slashes repo_slug also on Bitrise.io CI.