### PR TITLE
Move rubocop to Rake task and autocorrect errors #trivial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ script:
   # Tests use real git commands
   - git config --global user.email "danger@example.com"
   - git config --global user.name "Danger McShane"
-  - echo "Linting"
-  - bundle exec rubocop -v
-  - bundle exec rubocop lib
   - echo "Running Tests"
   - bundle exec rake spec
   - echo "Linting the documentation for Danger's internal plugins"

--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,13 @@ begin
   require "bundler/gem_tasks"
   require "rspec/core/rake_task"
   RSpec::Core::RakeTask.new(:specs)
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
 rescue LoadError
   puts "Please use `bundle exec` to get all the rake commands"
 end
 
-task default: :spec
+task default: %w(rubocop spec)
 
 desc "Danger's tests"
 task :spec do

--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe Danger::Bitrise do
       expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
     end
 
-
     it "sets the repo_slug from a repo https url", host: :github do
       valid_env["GIT_REPOSITORY_URL"] = "https://github.com/artsy/ios/artsy.github.io"
       expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")

--- a/spec/lib/danger/ci_sources/circle_api_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_api_spec.rb
@@ -2,7 +2,7 @@ require "danger/ci_source/circle_api"
 
 RSpec.describe Danger::CircleAPI do
   context "with `CIRCLE_PR_NUMBER`" do
-    let(:valid_env) {
+    let(:valid_env) do
       {
         "CIRCLE_BUILD_NUM" => "1500",
         "DANGER_CIRCLE_CI_API_TOKEN" => "token2",
@@ -10,11 +10,11 @@ RSpec.describe Danger::CircleAPI do
         "CIRCLE_PROJECT_REPONAME" => "eigen",
         "CIRCLE_PR_NUMBER" => "800"
       }
-    }
+    end
 
     it "returns correct attributes" do
       result = Danger::CircleCI.new(valid_env)
-    
+
       expect(result).to have_attributes(
         repo_slug: "artsy/eigen",
         pull_request_id: "800"
@@ -25,7 +25,7 @@ RSpec.describe Danger::CircleAPI do
       it "returns correct attributes" do
         env = valid_env.merge!({ "DANGER_GITHUB_HOST" => "git.foobar.com" })
         result = Danger::CircleCI.new(env)
-    
+
         expect(result).to have_attributes(
           repo_slug: "artsy/eigen",
           pull_request_id: "800"
@@ -33,7 +33,7 @@ RSpec.describe Danger::CircleAPI do
       end
     end
   end
-  
+
   it "uses CIRCLE_PR_NUMBER if avaliable" do
     env = {
       "CIRCLE_BUILD_NUM" => "1500",
@@ -42,7 +42,7 @@ RSpec.describe Danger::CircleAPI do
       "CIRCLE_PROJECT_REPONAME" => "eigen",
       "CIRCLE_PR_NUMBER" => "800"
     }
-    
+
     result = Danger::CircleCI.new(env)
 
     expect(result).to have_attributes(
@@ -84,7 +84,7 @@ RSpec.describe Danger::CircleAPI do
 
     expect(result).to eq("https://github.com/artsy/eigen/pull/2606")
   end
-  
+
   it "uses Circle CI API to grab the url if available" do
     env = {
       "CIRCLE_BUILD_NUM" => "1500",

--- a/spec/lib/danger/ci_sources/circle_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Danger::CircleCI do
           valid_env["DANGER_CIRCLE_CI_API_TOKEN"] = "testtoken"
           valid_env["CIRCLE_PR_NUMBER"] = "800"
         end
-        
+
         it "validates when required env variables are set" do
           expect(described_class.validates_as_pr?(valid_env)).to be true
         end
@@ -66,7 +66,7 @@ RSpec.describe Danger::CircleCI do
           build_response = JSON.parse(fixture("circle_build_response"), symbolize_names: true)
           allow_any_instance_of(Danger::CircleAPI).to receive(:fetch_build).with("artsy/eigen", "1500", "testtoken").and_return(build_response)
         end
-  
+
         it "validates when required env variables are set" do
           expect(described_class.validates_as_pr?(valid_env)).to be true
         end

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -2,7 +2,7 @@ require "danger/ci_source/gitlab_ci"
 
 RSpec.describe Danger::GitLabCI, host: :gitlab do
   context "valid environment" do
-    let(:env) { stub_env.merge("CI_MERGE_REQUEST_ID" => 28493) }
+    let(:env) { stub_env.merge("CI_MERGE_REQUEST_ID" => 28_493) }
 
     let(:ci_source) do
       described_class.new(env)

--- a/spec/lib/danger/ci_sources/screwdriver_spec.rb
+++ b/spec/lib/danger/ci_sources/screwdriver_spec.rb
@@ -1,4 +1,4 @@
-#require "danger/ci_source/screwdriver"
+# require "danger/ci_source/screwdriver"
 
 RSpec.describe Danger::Screwdriver do
   let(:valid_env) do
@@ -33,10 +33,10 @@ RSpec.describe Danger::Screwdriver do
     end
 
     it "does not validate when the required repo url is not set" do
-        valid_env["SCM_URL"] = nil
-        expect(described_class.validates_as_pr?(valid_env)).to be false
-      end
+      valid_env["SCM_URL"] = nil
+      expect(described_class.validates_as_pr?(valid_env)).to be false
     end
+  end
 
   describe ".new" do
     it "sets the required attributes" do


### PR DESCRIPTION
moves rubocop to a Rake task and autocorrects associated errors