### PR TITLE
Update `ruby-git/ruby-git` to 1.5

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "claide", "~> 1.0"
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
-  spec.add_runtime_dependency "git", "~> 1"
+  spec.add_runtime_dependency "git", "~> 1.5"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday-http-cache", "~> 1.0"


### PR DESCRIPTION
I've fixed a bug on diff on `ruby-git/ruby-git` for danger.
It's occurred when diff contains multibyte chars.

Could you apply it?
It's release on v1.5.0.

- [the patch](https://github.com/ruby-git/ruby-git/pull/369)