### PR TITLE
Adds failure as the recommended way to express a blocking error in a Dangerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 
 ## master
 
+* Adds `failure` as an alias to `fail` without incurring the wrath of default rubocop [@orta](https://github.com/orta)
+
 ## 5.6.5
 
 * Update the git gem so that Danger handles multi-byte chars correctly [@tbrand](https://github.com/tbrand)
-
 
 ## 5.6.4
 

--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
@@ -16,15 +16,15 @@ module Danger
   #
   # @example Ensure that labels have been used on the PR
   #
-  #          fail "Please add labels to this PR" if bitbucket_cloud.pr_labels.empty?
+  #          failure "Please add labels to this PR" if bitbucket_cloud.pr_labels.empty?
   #
   # @example Ensure there is a summary for a PR
   #
-  #          fail "Please provide a summary in the Pull Request description" if bitbucket_cloud.pr_body.length < 5
+  #          failure "Please provide a summary in the Pull Request description" if bitbucket_cloud.pr_body.length < 5
   #
   # @example Only accept PRs to the develop branch
   #
-  #          fail "Please re-submit this PR to develop, we may have already fixed your issue." if bitbucket_cloud.branch_for_base != "develop"
+  #          failure "Please re-submit this PR to develop, we may have already fixed your issue." if bitbucket_cloud.branch_for_base != "develop"
   #
   # @example Highlight when a celebrity makes a pull request
   #

--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_server_plugin.rb
@@ -16,15 +16,15 @@ module Danger
   #
   # @example Ensure that labels have been used on the PR
   #
-  #          fail "Please add labels to this PR" if bitbucket_server.pr_labels.empty?
+  #          failure "Please add labels to this PR" if bitbucket_server.pr_labels.empty?
   #
   # @example Ensure there is a summary for a PR
   #
-  #          fail "Please provide a summary in the Pull Request description" if bitbucket_server.pr_body.length < 5
+  #          failure "Please provide a summary in the Pull Request description" if bitbucket_server.pr_body.length < 5
   #
   # @example Only accept PRs to the develop branch
   #
-  #          fail "Please re-submit this PR to develop, we may have already fixed your issue." if bitbucket_server.branch_for_base != "develop"
+  #          failure "Please re-submit this PR to develop, we may have already fixed your issue." if bitbucket_server.branch_for_base != "develop"
   #
   # @example Highlight when a celebrity makes a pull request
   #

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -14,11 +14,11 @@ module Danger
   # @example Don't allow a file to be deleted
   #
   #          deleted = git.deleted_files.include? "my/favourite.file"
-  #          fail "Don't delete my precious" if deleted
+  #          failure "Don't delete my precious" if deleted
   #
   # @example Fail really big diffs
   #
-  #          fail "We cannot handle the scale of this PR" if git.lines_of_code > 50_000
+  #          failure "We cannot handle the scale of this PR" if git.lines_of_code > 50_000
   #
   # @example Warn when there are merge commits in the diff
   #

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -14,7 +14,7 @@ module Danger
   #
   # @example Ensure that labels have been used on the PR
   #
-  #          fail "Please add labels to this PR" if github.pr_labels.empty?
+  #          failure "Please add labels to this PR" if github.pr_labels.empty?
   #
   # @example Check if a user is in a specific GitHub org, and message them if so
   #
@@ -24,11 +24,11 @@ module Danger
   #
   # @example Ensure there is a summary for a PR
   #
-  #          fail "Please provide a summary in the Pull Request description" if github.pr_body.length < 5
+  #          failure "Please provide a summary in the Pull Request description" if github.pr_body.length < 5
   #
   # @example Only accept PRs to the develop branch
   #
-  #          fail "Please re-submit this PR to develop, we may have already fixed your issue." if github.branch_for_base != "develop"
+  #          failure "Please re-submit this PR to develop, we may have already fixed your issue." if github.branch_for_base != "develop"
   #
   # @example Note when PRs don't reference a milestone, which goes away when it does
   #

--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -14,7 +14,7 @@ module Danger
   #
   # @example Ensure that labels have been applied to the MR.
   #
-  #          fail "Please add labels to this MR" if gitlab.mr_labels.empty?
+  #          failure "Please add labels to this MR" if gitlab.mr_labels.empty?
   #
   # @example Ensure that all MRs have an assignee.
   #
@@ -22,11 +22,11 @@ module Danger
   #
   # @example Ensure there is a summary for a MR.
   #
-  #          fail "Please provide a summary in the Merge Request description" if gitlab.mr_body.length < 5
+  #          failure "Please provide a summary in the Merge Request description" if gitlab.mr_body.length < 5
   #
   # @example Only accept MRs to the develop branch.
   #
-  #          fail "Please re-submit this MR to develop, we may have already fixed your issue." if gitlab.branch_for_merge != "develop"
+  #          failure "Please re-submit this MR to develop, we may have already fixed your issue." if gitlab.branch_for_merge != "develop"
   #
   # @example Note when MRs don't reference a milestone, make the warning stick around on subsequent runs
   #

--- a/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
@@ -17,12 +17,12 @@ module Danger
   #
   # message 'Hello', 'World', file: "Dangerfile", line: 1
   # warn ['This', 'is', 'warning'], file: "Dangerfile", line: 1
-  # fail 'Ooops', 'bad bad error', sticky: false
+  # failure 'Ooops', 'bad bad error', sticky: false
   # markdown '# And', '# Even', '# Markdown', file: "Dangerfile", line: 1
   #
-  # By default, using `fail` would fail the corresponding build. Either via an API call, or
-  # via the return value for the danger command. If you have linters with errors for this call
-  # you can use `messaging.fail` instead.
+  # By default, using `failure` would fail the corresponding build. Either via an API call, or
+  # via the return value for the danger command. Older code examples use `fail` which is an alias
+  # of `failure`, but the default Rubocop settings would have an issue with it.
   #
   # You can optionally add `file` and `line` to provide inline feedback on a PR in GitHub, note that
   # only feedback inside the PR's diff will show up inline. Others will appear inside the main comment.
@@ -33,13 +33,13 @@ module Danger
   #
   # @example Failing a build
   #
-  #          fail "This build didn't pass tests"
-  #          fail "Ooops!", "Something bad happend"
-  #          fail ["This is example", "with array"]
+  #          failure "This build didn't pass tests"
+  #          failure "Ooops!", "Something bad happend"
+  #          failure ["This is example", "with array"]
   #
   # @example Failing a build, and note that on subsequent runs
   #
-  #          fail("This build didn't pass tests", sticky: true)
+  #          failure("This build didn't pass tests", sticky: true)
   #
   # @example Passing a warning
   #
@@ -177,6 +177,8 @@ module Danger
         @errors << Violation.new(failure, sticky, file, line) if failure
       end
     end
+
+    alias_method :failure, :fail
 
     # @!group Reporting
     # A list of all messages passed to Danger, including

--- a/lib/danger/danger_core/plugins/dangerfile_vsts_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_vsts_plugin.rb
@@ -16,11 +16,11 @@ module Danger
   #
   # @example Ensure there is a summary for a PR
   #
-  #          fail "Please provide a summary in the Pull Request description" if vsts.pr_body.length < 5
+  #          failure "Please provide a summary in the Pull Request description" if vsts.pr_body.length < 5
   #
   # @example Only accept PRs to the develop branch
   #
-  #          fail "Please re-submit this PR to develop, we may have already fixed your issue." if vsts.branch_for_base != "develop"
+  #          failure "Please re-submit this PR to develop, we may have already fixed your issue." if vsts.branch_for_base != "develop"
   #
   # @example Highlight when a celebrity makes a pull request
   #

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe Danger::Dangerfile, host: :github do
     expect(results[:warnings]).to eq(["A warning"])
   end
 
+
+  it "allows failure" do
+    code = "fail 'fail1'\n" \
+           "failure 'fail2'\n"
+    dm = testing_dangerfile
+    dm.parse Pathname.new(""), code
+    results = dm.status_report
+
+    expect(results[:errors]).to eq(["fail1", "fail2"])
+  end
+
   describe "#print_results" do
     it "Prints out 3 lists" do
       code = "message 'A message'\n" \
@@ -123,7 +134,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
       dm = testing_dangerfile
       methods = dm.core_dsl_attributes.map { |hash| hash[:methods] }.flatten.sort
 
-      expect(methods).to eq %i(fail markdown message status_report violation_report warn)
+      expect(methods).to eq %i(fail failure markdown message status_report violation_report warn)
     end
 
     # These are things that require scoped access


### PR DESCRIPTION
I ended up adding a dangerfile to one of our ruby apps, and obviously this was the right fit https://github.com/artsy/exchange/pull/168 - but the default rubocop settings don't want you writing `fail`. 

I originally aliased `raise` - like mentioned in https://github.com/danger/danger/issues/1006 but it didn't feel right, so I chatted with @yuki24 added `failure` as an option, and made it the default in all the docs. 