### PR TITLE
fix `--no-ansi` behavior for commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix `--no-ansi` behavior for decoloring output [@otaznik-net](https://github.com/otaznik-net)
+
 ## 5.6.6
 
 * Adds `failure` as an alias to `fail` without incurring the wrath of default rubocop [@orta](https://github.com/orta)

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -42,6 +42,7 @@ module Danger
       @danger_id = argv.option("danger_id", "danger")
       @cork = Cork::Board.new(silent: argv.option("silent", false),
                               verbose: argv.option("verbose", false))
+      adjust_colored2_output(argv)
       super
     end
 
@@ -74,6 +75,15 @@ module Danger
         fail_on_errors: @fail_on_errors,
         remove_previous_comments: @remove_previous_comments
       )
+    end
+
+    private
+
+    def adjust_colored2_output(argv)
+      # disable/enable colored2 output
+      # consider it execution wide to avoid need to wrap #run and maintain state
+      # ARGV#options is non-destructive way to check flags
+      Colored2.public_send(argv.options.fetch("ansi", true) ? "enable!" : "disable!")
     end
   end
 end

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -38,6 +38,30 @@ RSpec.describe Danger::Runner do
     end
   end
 
+  context "colored output" do
+    before do
+      expect(Danger::Executor).to receive(:new) { executor }
+      expect(executor).to receive(:run) { "Colored message".red }
+    end
+    after { Colored2.enable! } # reset to expected value to avoid false positives in other tests
+
+    let(:argv) { [] }
+    let(:runner) { described_class.new(CLAide::ARGV.new(argv)) }
+    let(:executor) { double("Executor") }
+
+    it "adds ansi codes to strings" do
+      expect(runner.run).to eq "\e[31mColored message\e[0m"
+    end
+
+    context "when no-ansi is specified" do
+      let(:argv) { ["--no-ansi"] }
+
+      it "does not add ansi codes to strings" do
+        expect(runner.run).to eq "Colored message"
+      end
+    end
+  end
+
   describe "#run" do
     it "invokes Executor" do
       argv = CLAide::ARGV.new([])


### PR DESCRIPTION
colored2 seems to be used as drop in replacement for colored. It works
great unless you want to disable ansi codes in output as `ansi` flag is
handled by CLAide and not by Danger. Added
`Danger::Runner#adjust_colored2_output` is called from initializer
as that is only place common for commands. Otherwise some wrapper of
Runner#run will be needed (which does not seems worth it).