### PR TITLE
Add dry_run command and associated ci_source and request_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -->
 
 ## master
+* Adds `dry_run` command to allow running danger on localhost without actual PR/MR [@otaznik-net](https://github.com/otaznik-net)
 
 ## 5.6.7
 

--- a/lib/danger/ci_source/local_only_git_repo.rb
+++ b/lib/danger/ci_source/local_only_git_repo.rb
@@ -1,0 +1,47 @@
+require "git"
+require "danger/request_sources/local_only"
+
+module Danger
+  # ### CI Setup
+  #
+  # For setting up LocalOnlyGitRepo there is not much needed. Either `--base` and `--head` need to be specified or
+  # origin/master is expected for base and HEAD for head
+  #
+  class LocalOnlyGitRepo < CI
+    attr_accessor :base_commit, :head_commit
+    HEAD_VAR = "DANGER_LOCAL_HEAD".freeze
+    BASE_VAR = "DANGER_LOCAL_BASE".freeze
+
+    def self.validates_as_ci?(env)
+      env.key? "DANGER_USE_LOCAL_ONLY_GIT"
+    end
+
+    def self.validates_as_pr?(_env)
+      false
+    end
+
+    def git
+      @git ||= GitRepo.new
+    end
+
+    def run_git(command)
+      git.exec(command).encode("UTF-8", "binary", invalid: :replace, undef: :replace, replace: "")
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= [Danger::RequestSources::LocalOnly]
+    end
+
+    def initialize(env = {})
+      @env = env
+
+      # expects --base/--head specified OR origin/master to be base and HEAD head
+      self.base_commit = env[BASE_VAR] || run_git("rev-parse --abbrev-ref origin/master")
+      self.head_commit = env[HEAD_VAR] || run_git("rev-parse --abbrev-ref HEAD")
+    end
+
+    private
+
+    attr_reader :env
+  end
+end

--- a/lib/danger/commands/dry_run.rb
+++ b/lib/danger/commands/dry_run.rb
@@ -1,0 +1,54 @@
+require "danger/commands/local_helpers/pry_setup"
+require "fileutils"
+
+module Danger
+  class DryRun < Runner
+    self.summary = "Dry-Run the Dangerfile locally, so you could check some violations before sending real PR/MR."
+    self.command = "dry_run"
+
+    def self.options
+      [
+        ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
+      ]
+    end
+
+    def initialize(argv)
+      show_help = true if argv.arguments == ["-h"]
+
+      # Currently CLAide doesn't support short option like -h https://github.com/CocoaPods/CLAide/pull/60
+      # when user pass in -h, mimic the behavior of passing in --help.
+      argv = CLAide::ARGV.new ["--help"] if show_help
+
+      super
+
+      if argv.flag?("pry", false)
+        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path)
+      end
+    end
+
+    def validate!
+      super
+      unless @dangerfile_path
+        help! "Could not find a Dangerfile."
+      end
+    end
+
+    def run
+      ENV["DANGER_USE_LOCAL_ONLY_GIT"] = "YES"
+      ENV["DANGER_LOCAL_HEAD"] = @head if @head
+      ENV["DANGER_LOCAL_BASE"] = @base if @base
+
+      env = EnvironmentManager.new(ENV, cork)
+      dm = Dangerfile.new(env, cork)
+
+      exit 1 if dm.run(
+        Danger::EnvironmentManager.danger_base_branch,
+        Danger::EnvironmentManager.danger_head_branch,
+        @dangerfile_path,
+        nil,
+        nil,
+        nil
+      )
+    end
+  end
+end

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -2,6 +2,7 @@ module Danger
   class Runner < CLAide::Command
     require "danger/commands/init"
     require "danger/commands/local"
+    require "danger/commands/dry_run"
     require "danger/commands/systems"
     require "danger/commands/pr"
 

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -11,6 +11,7 @@ require "danger/danger_core/plugins/dangerfile_gitlab_plugin"
 require "danger/danger_core/plugins/dangerfile_bitbucket_server_plugin"
 require "danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin"
 require "danger/danger_core/plugins/dangerfile_vsts_plugin"
+require "danger/danger_core/plugins/dangerfile_local_only_plugin"
 
 module Danger
   class Dangerfile
@@ -38,7 +39,7 @@ module Danger
 
     # The ones that everything would break without
     def self.essential_plugin_classes
-      [DangerfileMessagingPlugin, DangerfileGitPlugin, DangerfileDangerPlugin, DangerfileGitHubPlugin, DangerfileGitLabPlugin, DangerfileBitbucketServerPlugin, DangerfileBitbucketCloudPlugin, DangerfileVSTSPlugin]
+      [DangerfileMessagingPlugin, DangerfileGitPlugin, DangerfileDangerPlugin, DangerfileGitHubPlugin, DangerfileGitLabPlugin, DangerfileBitbucketServerPlugin, DangerfileBitbucketCloudPlugin, DangerfileVSTSPlugin, DangerfileLocalOnlyPlugin]
     end
 
     # Both of these methods exist on all objects

--- a/lib/danger/danger_core/plugins/dangerfile_local_only_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_local_only_plugin.rb
@@ -1,0 +1,42 @@
+require "danger/plugin_support/plugin"
+
+# Danger
+module Danger
+  # Handles interacting with local only plugin inside a Dangerfile.
+  # It is support pluggin for dry_run command and does not expose any methods.
+  # But you can still use other plugins like git
+  #
+  # @example Check that added lines contains agreed form of words 
+  #
+  #       git.diff.each do |chunk|
+  #         chunk.patch.lines.grep(/^+/).each do |added_line|
+  #           if added_line.gsub!(/(?<cancel>cancel)(?<rest>[^l[[:space:]][[:punct:]]]+)/i, '>>\k<cancel>-l-\k<rest><<')
+  #             fail "Single 'L' for cancellation-alike words in '#{added_line}'" 
+  #           end
+  #         end
+  #       end
+  #
+  # @see  danger/danger
+  # @tags core, local_only
+  #
+  class DangerfileLocalOnlyPlugin < Plugin
+    # So that this init can fail.
+    def self.new(dangerfile)
+      return nil if dangerfile.env.request_source.class != Danger::RequestSources::LocalOnly
+      super
+    end
+
+    def initialize(dangerfile)
+      super(dangerfile)
+
+      @local_repo = dangerfile.env.request_source
+    end
+
+    # The instance name used in the Dangerfile
+    # @return [String]
+    #
+    def self.instance_name
+      "local_repo"
+    end
+  end
+end

--- a/lib/danger/request_sources/local_only.rb
+++ b/lib/danger/request_sources/local_only.rb
@@ -1,0 +1,53 @@
+# coding: utf-8
+
+require "danger/helpers/comments_helper"
+require "danger/helpers/comment"
+
+module Danger
+  module RequestSources
+    class LocalOnly < RequestSource
+      include Danger::Helpers::CommentsHelper
+      attr_accessor :mr_json, :commits_json
+
+      def self.env_vars
+        ["DANGER_LOCAL_ONLY"]
+      end
+
+      def initialize(ci_source, environment)
+        self.ci_source = ci_source
+        self.environment = environment
+      end
+
+      def validates_as_ci?
+        true
+      end
+
+      def validates_as_api_source?
+        true
+      end
+
+      def scm
+        @scm ||= GitRepo.new
+      end
+
+      def setup_danger_branches
+        # Check that discovered values really exists
+        [ci_source.base_commit, ci_source.head_commit].each do |commit|
+          raise "Specified commit '#{commit}' not found" if scm.exec("rev-parse --quiet --verify #{commit}").empty?
+        end
+
+        self.scm.exec "branch #{EnvironmentManager.danger_base_branch} #{ci_source.base_commit}"
+        self.scm.exec "branch #{EnvironmentManager.danger_head_branch} #{ci_source.head_commit}"
+      end
+
+      def fetch_details; end
+
+      def update_pull_request!(_hash_needed); end
+
+      # @return [String] The organisation name, is nil if it can't be detected
+      def organisation
+        nil
+      end
+    end
+  end
+end

--- a/spec/lib/danger/ci_sources/ci_source_spec.rb
+++ b/spec/lib/danger/ci_sources/ci_source_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Danger::CI do
       expect(described_class.available_ci_sources.map(&:to_s)).to match_array(
         [
           "Danger::LocalGitRepo",
+          "Danger::LocalOnlyGitRepo",
           "Danger::Bitrise",
           "Danger::Buddybuild",
           "Danger::Buildkite",

--- a/spec/lib/danger/ci_sources/local_only_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_only_git_repo_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require "danger/ci_source/local_only_git_repo"
+
+RSpec.describe Danger::LocalOnlyGitRepo do
+  def run_in_repo
+    Dir.mktmpdir do |dir|
+      Dir.chdir dir do
+        `git init`
+        `git remote add origin .`
+        File.open(dir + "/file1", "w") {}
+        `git add .`
+        `git commit -m "adding file1"`
+        `git fetch`
+        `git checkout -b feature_branch`
+        File.open(dir + "/file2", "w") {}
+        `git add .`
+        `git commit -m "adding file2"`
+
+        yield
+      end
+    end
+  end
+
+  let(:valid_env) do
+    {
+      "DANGER_USE_LOCAL_ONLY_GIT" => "true"
+    }
+  end
+
+  let(:invalid_env) do
+    {
+      "CIRCLE" => "true"
+    }
+  end
+
+  def source(env)
+    described_class.new(env)
+  end
+
+  describe "validates_as_ci?" do
+    context "when run as danger dry_run" do
+      it "validates as CI source" do
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+    end
+
+    it "does not validate as CI source outside danger dry_run" do
+      expect(described_class.validates_as_ci?(invalid_env)).to be false
+    end
+  end
+
+  describe "#new" do
+    it "sets base_commit" do
+      run_in_repo do
+        expect(source(valid_env).base_commit).to eq("origin/master")
+      end
+    end
+
+    it "sets head_commit" do
+      run_in_repo do
+        expect(source(valid_env).head_commit).to eq("feature_branch")
+      end
+    end
+  end
+end

--- a/spec/lib/danger/commands/dry_run_spec.rb
+++ b/spec/lib/danger/commands/dry_run_spec.rb
@@ -1,0 +1,24 @@
+require "danger/commands/dry_run"
+require "open3"
+
+RSpec.describe Danger::DryRun do
+  context "prints help" do
+    it "danger dry_run --help flag prints help" do
+      stdout, = Open3.capture3("danger dry_run -h")
+      expect(stdout).to include "Usage"
+    end
+
+    it "danger dry_run -h prints help" do
+      stdout, = Open3.capture3("danger dry-run -h")
+      expect(stdout).to include "Usage"
+    end
+  end
+
+  describe ".options" do
+    it "contains extra options for local command" do
+      result = described_class.options
+
+      expect(result).to include ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
+    end
+  end
+end

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Danger::Dangerfile, host: :github do
     expect(results[:warnings]).to eq(["A warning"])
   end
 
-
   it "allows failure" do
     code = "fail 'fail1'\n" \
            "failure 'fail2'\n"

--- a/spec/lib/danger/request_sources/local_only.rb
+++ b/spec/lib/danger/request_sources/local_only.rb
@@ -1,0 +1,50 @@
+# coding: utf-8
+
+require "erb"
+
+require "danger/request_sources/local_only"
+
+RSpec.describe Danger::RequestSources::LocalOnly, host: :local do
+  let(:ci) { instance_double("Danger::LocalOnlyGitRepo", base_commit: "origin/master", head_commit: "feature_branch") }
+  let(:subject) { described_class.new(ci, {}) }
+
+  describe "validation" do
+    it "validates as an API source" do
+      expect(subject.validates_as_api_source?).to be_truthy
+    end
+
+    it "validates as CI" do
+      expect(subject.validates_as_ci?).to be_truthy
+    end
+  end
+
+  describe "scm" do
+    it "Sets up the scm" do
+      expect(subject.scm).to be_kind_of(Danger::GitRepo)
+    end
+  end
+
+  describe "#setup_danger_branches" do
+    before do
+      allow(subject.scm).to receive(:exec).and_return("found_some")
+    end
+
+    context "when specified head is missing" do
+      before { expect(subject.scm).to receive(:exec).and_return("") }
+
+      it "raises an error" do
+        expect { subject.setup_danger_branches } .to raise_error("Specified commit 'origin/master' not found")
+      end
+    end
+
+    it "sets danger_head to feature_branch" do
+      expect(subject.scm).to receive(:exec).with(/^branch.*head.*feature_branch/).and_return("feature_branch")
+      subject.setup_danger_branches
+    end
+
+    it "sets danger_base to origin/master" do
+      expect(subject.scm).to receive(:exec).with(%r{^branch.*base.*origin/master}).and_return("origin/master")
+      subject.setup_danger_branches
+    end
+  end
+end


### PR DESCRIPTION
motivation is ability to run danger against local only repo
in condition when there is no actual PR/MR created (or is not available
to danger).