### PR TITLE
Decouple remove_previos_comments logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## master
 
+## 5.6.8
+
+* Fix `--remove-previous-comments` for gitlab
+
 ## 5.6.7
 
 * Fix `--no-ansi` behavior for decoloring output [@otaznik-net](https://github.com/otaznik-net)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## 5.6.8
 
-* Fix `--remove-previous-comments` for gitlab
+* Fix `--remove-previous-comments` for gitlab [@joesss](https://github.com/JoeSSS)
 
 ## 5.6.7
 

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -119,7 +119,7 @@ module Danger
       def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
         editable_comments = mr_comments.select { |comment| comment.generated_by_danger?(danger_id) }
 
-        should_create_new_comment = new_comment || editable_comments.empty? || remove_previous_comments
+        should_create_new_comment = new_comment || editable_comments.empty?
 
         if should_create_new_comment
           previous_violations = {}
@@ -127,9 +127,12 @@ module Danger
           comment = editable_comments.first.body
           previous_violations = parse_comment(comment)
         end
-
-        if (previous_violations.empty? && (warnings + errors + messages + markdowns).empty?) || remove_previous_comments
-          # Just remove the comment, if there's nothing to say or --remove-previous-comments CLI was set.
+        
+        # Remove previous comment, if there's --remove-previous-comments CLI was set.
+        delete_old_comments!(danger_id: danger_id) if remove_previous_comments
+          
+        if (previous_violations.empty? && (warnings + errors + messages + markdowns).empty?)
+          # Just remove the comment, if there's nothing to say
           delete_old_comments!(danger_id: danger_id)
         else
           body = generate_comment(warnings: warnings,


### PR DESCRIPTION
Decouple `remove_previos_comments` logic from the logic of having nothing to say

Fixing an issue from https://github.com/danger/danger/pull/949#issuecomment-425128457

cc @znacloud : I do not use gitlab. So it would be very nice if you can verify this patch.