### PR TITLE
Fix gitlab source for #import_dangerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -->
 
 ## master
+* Fixes importing a Dangerfile from a GitLab repository [@koffeinfrei](https://github.com/koffeinfrei/)
 * Adds `dry_run` command to allow running danger on localhost without actual PR/MR [@otaznik-net](https://github.com/otaznik-net)
 
 ## 5.6.7

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -172,6 +172,13 @@ module Danger
       def organisation
         nil # TODO: Implement this
       end
+
+      # @return [String] A URL to the specific file, ready to be downloaded
+      def file_url(organisation: nil, repository: nil, branch: nil, path: nil)
+        branch ||= 'master'
+
+        "https://#{host}/#{organisation}/#{repository}/raw/#{branch}/#{path}"
+      end
     end
   end
 end

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -296,5 +296,22 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
         end
       end
     end
+
+    describe "#file_url" do
+      it "returns a valid URL with the minimum parameters" do
+        url = subject.file_url(organisation: "artsy", repository: "danger", path: "Dangerfile")
+        expect(url).to eq("https://gitlab.com/artsy/danger/raw/master/Dangerfile")
+      end
+
+      it "returns a valid URL with more parameters" do
+        url = subject.file_url(repository: "danger", organisation: "artsy", branch: "master", path: "path/Dangerfile")
+        expect(url).to eq("https://gitlab.com/artsy/danger/raw/master/path/Dangerfile")
+      end
+
+      it "returns a valid fallback URL" do
+        url = subject.file_url(repository: "danger", organisation: "teapot", path: "Dangerfile")
+        expect(url).to eq("https://gitlab.com/teapot/danger/raw/master/Dangerfile")
+      end
+    end
   end
 end


### PR DESCRIPTION
Implements the method `Danger::RequestSources::GitLab#file_url` such that importing a danger file from a GitLab repository works. Example: 

```ruby
danger.import_dangerfile(gitlab: "ruby-grape/danger")
```

This is documented at https://danger.systems/reference.html but currently doesn't work due to the missing implementation.

Fixes https://github.com/danger/danger/issues/877