### PR TITLE
Replacing spaces with %20 in VSTS host urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 * Fixes importing a Dangerfile from a GitLab repository [@koffeinfrei](https://github.com/koffeinfrei/)
 * Adds `dry_run` command to allow running danger on localhost without actual PR/MR [@otaznik-net](https://github.com/otaznik-net)
+* VSTS URLs can have spaces in them which doesnt work when they are parsed by URI. Spaces are replaced by %20.
 
 ## 5.6.7
 

--- a/lib/danger/request_sources/vsts_api.rb
+++ b/lib/danger/request_sources/vsts_api.rb
@@ -23,6 +23,7 @@ module Danger
         end
 
         self.pr_api_endpoint = "#{host}/_apis/git/repositories/#{slug}/pullRequests/#{pull_request_id}"
+        self.pr_api_endpoint = self.pr_api_endpoint.gsub(" ", "%20")
       end
 
       def supports_comments?


### PR DESCRIPTION
In VSTS you can have spaces in the URL to the repository, however URI doesn't support this. The solution I have implemented is to simply replace these spaces with %20 which is what VSTS itself does.