### PR TITLE
Add AppVeyor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Add AppVeyor support [@tumugin](https://github.com/tumugin)
+
 ## 5.7.1
 
 * Add CodeBuild support [@s-faychatelard](https://github.com/s-faychatelard)

--- a/lib/danger/ci_source/appveyor.rb
+++ b/lib/danger/ci_source/appveyor.rb
@@ -1,0 +1,60 @@
+# https://www.appveyor.com/docs/build-configuration/
+module Danger
+  # ### CI Setup
+  #
+  # Install dependencies and add a danger step to your `appveyor.yml`.
+  # ```yaml
+  # install:
+  # - cmd: >-
+  #     set PATH=C:\Ruby25-x64\bin;%PATH%
+  #
+  #     bundle install
+  # after_test:
+  # - cmd: >-
+  #     bundle exec danger
+  # ```
+  #
+  # ### Token Setup
+  #
+  # For public repositories, add your plain token to environment variables in `appveyor.yml`.
+  # Encrypted environment variables will not be decrypted on PR builds.
+  # see here: https://www.appveyor.com/docs/build-configuration/#secure-variables
+  # ```yaml
+  # environment:
+  #   DANGER_GITHUB_API_TOKEN: <YOUR_TOKEN_HERE>
+  # ```
+  #
+  # For private repositories, enter your token in `Settings>Environment>Environment variables>Add variable` and turn on `variable encryption`.
+  # You will see encrypted variable text in `Settings>Export YAML` so just copy to your `appveyor.yml`.
+  # ```yaml
+  # environment:
+  #   DANGER_GITHUB_API_TOKEN:
+  #     secure: <YOUR_ENCRYPTED_TOKEN_HERE>
+  # ```
+  #
+  class AppVeyor < CI
+    def self.validates_as_ci?(env)
+      env.key? "APPVEYOR"
+    end
+
+    def self.validates_as_pr?(env)
+      return false unless env.key? "APPVEYOR_PULL_REQUEST_NUMBER"
+      env["APPVEYOR_PULL_REQUEST_NUMBER"].to_i > 0
+    end
+
+    def initialize(env)
+      self.repo_slug = env["APPVEYOR_REPO_NAME"]
+      self.pull_request_id = env["APPVEYOR_PULL_REQUEST_NUMBER"]
+      self.repo_url = GitRepo.new.origins # AppVeyor doesn't provide a repo url env variable for now
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= [
+        Danger::RequestSources::GitHub,
+        Danger::RequestSources::BitbucketCloud,
+        Danger::RequestSources::BitbucketServer,
+        Danger::RequestSources::GitLab
+      ]
+    end
+  end
+end

--- a/spec/lib/danger/ci_sources/appveyor_spec.rb
+++ b/spec/lib/danger/ci_sources/appveyor_spec.rb
@@ -1,0 +1,65 @@
+require "danger/ci_source/appveyor"
+
+RSpec.describe Danger::AppVeyor do
+  let(:valid_env) do
+    {
+      "APPVEYOR_PULL_REQUEST_NUMBER" => "2",
+      "APPVEYOR" => "true",
+      "APPVEYOR_REPO_NAME" => "artsy/eigen"
+    }
+  end
+
+  let(:invalid_env) do
+    {
+      "BITRISE_IO" => "true"
+    }
+  end
+
+  let(:source) { described_class.new(valid_env) }
+
+  describe ".validates_as_pr?" do
+    it "validates when the required env variables are set" do
+      expect(described_class.validates_as_pr?(valid_env)).to be true
+    end
+
+    it "does not validate when the required env variables are not set" do
+      expect(described_class.validates_as_pr?(invalid_env)).to be false
+    end
+
+    it "does not validate when there isn't a PR" do
+      valid_env["APPVEYOR_PULL_REQUEST_NUMBER"] = nil
+      expect(described_class.validates_as_pr?(valid_env)).to be false
+    end
+  end
+
+  describe ".validates_as_ci?" do
+    it "validates when the required env variables are set" do
+      expect(described_class.validates_as_ci?(valid_env)).to be true
+    end
+
+    it "does not validate when the required env variables are not set" do
+      expect(described_class.validates_as_ci?(invalid_env)).to be false
+    end
+
+    it "validates even when there is no PR" do
+      valid_env["APPVEYOR_PULL_REQUEST_NUMBER"] = nil
+      expect(described_class.validates_as_ci?(valid_env)).to be true
+    end
+  end
+
+  describe "#new" do
+    it "sets the repo_slug" do
+      expect(source.repo_slug).to eq("artsy/eigen")
+    end
+
+    it "sets the pull_request_id" do
+      expect(source.pull_request_id).to eq("2")
+    end
+
+    it "sets the repo_url", host: :github do
+      with_git_repo(origin: "git@github.com:artsy/eigen") do
+        expect(source.repo_url).to eq("git@github.com:artsy/eigen")
+      end
+    end
+  end
+end

--- a/spec/lib/danger/ci_sources/ci_source_spec.rb
+++ b/spec/lib/danger/ci_sources/ci_source_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Danger::CI do
           "Danger::TeamCity",
           "Danger::Travis",
           "Danger::VSTS",
-          "Danger::XcodeServer"
+          "Danger::XcodeServer",
+          "Danger::AppVeyor"
         ]
       )
     end


### PR DESCRIPTION
This PR adds AppVeyor support. You can now use Danger in AppVeyor(Both on Windows/Linux image).