### PR TITLE
Protect against 'path' reassignment when evaling dangerfile

### DIFF
--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -197,9 +197,7 @@ module Danger
       instance_eval do
         # rubocop:disable Lint/RescueException
         begin
-          # rubocop:disable Eval
-          eval(contents, nil, path.to_s)
-          # rubocop:enable Eval
+          eval_file(contents, path)
         rescue Exception => e
           message = "Invalid `#{path.basename}` file: #{e.message}"
           raise DSLError.new(message, path, e.backtrace, contents)
@@ -294,6 +292,10 @@ module Danger
     end
 
     private
+
+    def eval_file(contents, path)
+      eval(contents, nil, path.to_s) # rubocop:disable Eval
+    end
 
     def print_list(title, rows)
       unless rows.empty?

--- a/spec/fixtures/dangerfile_with_error_and_path_reassignment
+++ b/spec/fixtures/dangerfile_with_error_and_path_reassignment
@@ -1,0 +1,3 @@
+# This will fail
+path = 'asdf'
+abc

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -330,6 +330,31 @@ RSpec.describe Danger::Dangerfile, host: :github do
         end.to raise_error(Danger::DSLError)
       end
 
+      it "doesn't crash if path is reassigned" do
+        path = Pathname.new(File.join("spec", "fixtures", "dangerfile_with_error_and_path_reassignment"))
+        env_manager = double("Danger::EnvironmentManager", {
+          pr?: false,
+          clean_up: true,
+          fill_environment_vars: true,
+          ensure_danger_branches_are_setup: false
+        })
+        scm = double("Danger::GitRepo", {
+          class: Danger::GitRepo,
+          diff_for_folder: true
+        })
+        request_source = double("Danger::RequestSources::GitHub")
+        dm = Danger::Dangerfile.new(env_manager, testing_ui)
+
+        allow(env_manager).to receive(:scm) { scm }
+        allow(env_manager).to receive(:request_source) { request_source }
+
+        expect(request_source).to receive(:update_pull_request!)
+
+        expect do
+          dm.run("custom_danger_base", "custom_danger_head", path, 1, false, false)
+        end.to raise_error(Danger::DSLError)
+      end
+
       after { allow(Danger).to receive(:danger_outdated?).and_call_original }
     end
   end


### PR DESCRIPTION
Move eval into seperate method to prevent local variable reassignment.
If the eval rescue is hit and path has been reassigned Danger will crash.
This doesn't address any concerns around a malicious Dangerfile rewriting methods.

#trivial