### PR TITLE
BitbucketServerAPI Error Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Update `BitbucketServerAPI` error message to include response body [@cnoon](https://github.com/cnoon)
+
 ## 5.8.0
 
 * Add AppVeyor support [@tumugin](https://github.com/tumugin)

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -76,11 +76,11 @@ module Danger
           http.request(req)
         end
 
-        # show error to the user when BitBucket Server returned an error
+        # show error to the user when Bitbucket Server returned an error
         case res
         when Net::HTTPClientError, Net::HTTPServerError
           # HTTP 4xx - 5xx
-          abort "\nError posting comment to BitBucket Server: #{res.code} (#{res.message})\n\n"
+          abort "\nError posting comment to Bitbucket Server: #{res.code} (#{res.message}) - #{res.body}\n\n"
         end
       end
 


### PR DESCRIPTION
This PR updates the error message thrown by Danger when posting a comment to Bitbucket Server and receiving a 4XX or 5XX status code. 

---

### Problem Statement

We've been spinning up new projects left and right at Nike with Danger (thanks for the fantastic project BTW! 🍻 ). When spinning up new projects, we tend to have plugins like SwiftLint misconfigured a bit which can end up triggering large numbers of warnings in Danger. This generally results in the following error thrown by Danger:

```
Error posting comment to Bitbucket Server: 400 ()
```

As you can see, this doesn't give us much to go on. We have no idea why the 400 is being thrown. Room for improvement!

---

### Solution

By appending the response body to the error message, we are able to see why Bitbucket Server is throwing the 400 status code:

```
Error posting comment to Bitbucket Server: 400 () - {"errors":[{"context":"text","message":"Please enter a non-empty value less than 32768 characters","exceptionName":null}]}
```

With this change, we'll be able to see that the payload we're sending to Bitbucket is too large. As far as I can tell, the CHANGELOG entry should be sufficient for this PR. If you'd like me to update anything else, please don't hesitate to ask.

Thanks!