### PR TITLE
Fix diff range detection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix diff range detection logic [@r7kamura](https://github.com/r7kamura)
+
 ## 5.8.1
 
 * Update `BitbucketServerAPI` error message to include response body [@cnoon](https://github.com/cnoon)

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -369,7 +369,7 @@ module Danger
       end
 
       def find_position_in_diff(diff_lines, message, kind)
-        range_header_regexp = /@@ -([0-9]+),([0-9]+) \+(?<start>[0-9]+)(,(?<end>[0-9]+))? @@.*/
+        range_header_regexp = /@@ -([0-9]+)(,([0-9]+))? \+(?<start>[0-9]+)(,(?<end>[0-9]+))? @@.*/
         file_header_regexp = %r{^diff --git a/.*}
 
         pattern = "+++ b/" + message.file + "\n"

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -561,4 +561,48 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
     end
   end
+
+  describe "#find_position_in_diff" do
+    subject do
+      github.find_position_in_diff(diff_lines, message, kind)
+    end
+
+    let(:diff_lines) do
+      <<-DIFF.each_line.to_a
+diff --git a/#{file_path} b/#{file_path}
+index 0000000..0000001 100644
+--- a/#{file_path}
++++ b/#{file_path}
+@@ -1 +1,2 @@
+-foo
++bar
++baz
+      DIFF
+    end
+
+    let(:file_path) do
+      "dummy"
+    end
+
+    let(:github) do
+      described_class.new(stub_ci, "DANGER_GITHUB_API_TOKEN" => "hi")
+    end
+
+    let(:kind) do
+      :dummy
+    end
+
+    let(:message) do
+      double(
+        file: file_path,
+        line: 1,
+      )
+    end
+
+    context "when the lines count for the original file is omitted" do
+      it "returns correct position" do
+        is_expected.to eq(2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

I added the following line into my Dangerfile, and created a pull request including this change.

```rb
# Dangerfile
warn("foo", file: "Dangerfile", line: 1)
```

### Expected

An inline-comment should be posted on the diff for Dangerfile#L1.

### Actual

A normal comment was posted like this:

![image](https://user-images.githubusercontent.com/111689/48792910-cd1d4880-ed38-11e8-9a18-b9ce033f8bad.png)

## Solution

In many versions of GNU diff, each range can omit the comma and trailing value, in which case the value is 1. (See https://en.wikipedia.org/wiki/Diff for more details about this.)

Here is an example of the omission. Look at `@@ -1 +1,8 @@`.

![image](https://user-images.githubusercontent.com/111689/48792423-9430a400-ed37-11e8-82d0-fd7826a77b5f.png)

I changed the regex pattern in Danger::RequestSources::GitHub#find_position_in_diff so that it supports the omitted format on the range for the original file too.

```rb
range_header_regexp = /@@ -([0-9]+),([0-9]+) \+(?<start>[0-9]+)(,(?<end>[0-9]+))? @@.*/
                                   ^^^^^^^^^
```

I think this case occurs when we prepended some lines into the head of an existing file.