### PR TITLE
Update ruby versions in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ cache:
     - bundle
 
 rvm:
-  - 2.4.0
-  - 2.3.3
-  - 2.1.9
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
+  - 2.2.10
+  - 2.1.10
   - 2.0
 
 bundler_args: "--without documentation --path bundle"


### PR DESCRIPTION
## Description
This pull request updated ruby versions in travis.yml
The latest ruby version is 2.5.3.

ruby version reference: https://www.ruby-lang.org/en/downloads/releases/