### PR TITLE
Amend diff position caluculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ## 5.9.0
 
 * Add `git.tags` to get a list of existing Git tags [@hotbott](https://github.com/hotbott)
-* Amend diff position caluculation when diff includes `No newline` annotation [@colorbox](https://github.com/colorbox)
+* Fix diff position caluculation when diff includes `No newline` annotation [@colorbox](https://github.com/colorbox)
 
 ## 5.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## 5.9.0
 
 * Add `git.tags` to get a list of existing Git tags [@hotbott](https://github.com/hotbott)
+* Amend diff position caluculation when diff includes `No newline` annotation [@colorbox](https://github.com/colorbox)
 
 ## 5.8.2
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -400,6 +400,7 @@ module Danger
           # We need to count how many diff lines are between us and
           # the line we're looking for
           position += 1
+          position += 1 if line.eql?("\\ No newline at end of file\n")
 
           next unless match
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -381,6 +381,8 @@ module Danger
         file_line = nil
 
         diff_lines.drop(file_start).each do |line|
+          # If the line has No newline annotation, position need increment
+          position += 1 if line.eql?("\ No newline at end of file\n")
           # If we found the start of another file diff, we went too far
           break if line.match file_header_regexp
 
@@ -400,7 +402,6 @@ module Danger
           # We need to count how many diff lines are between us and
           # the line we're looking for
           position += 1
-          position += 1 if line.eql?("\\ No newline at end of file\n")
 
           next unless match
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -381,8 +381,11 @@ module Danger
         file_line = nil
 
         diff_lines.drop(file_start).each do |line|
-          # If the line has No newline annotation, position need increment
-          position += 1 if line.eql?("\ No newline at end of file\n")
+          # If the line has `No newline` annotation, position need increment
+          if line.eql?("\ No newline at end of file\n")
+            position += 1
+            next
+          end
           # If we found the start of another file diff, we went too far
           break if line.match file_header_regexp
 

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -604,5 +604,26 @@ index 0000000..0000001 100644
         is_expected.to eq(2)
       end
     end
+
+    context "when diff contain `No newline` annotation before added lines" do
+      let(:diff_lines) do
+        <<-DIFF.each_line.to_a
+diff --git a/#{file_path} b/#{file_path}
+index 0000000..0000001 100644
+--- a/#{file_path}
++++ b/#{file_path}
+@@ -1 +1,3 @@
+-foo
+\ No newline at end of file
++foo
++bar
++baz
+        DIFF
+      end
+
+      it "returns correct position" do
+        is_expected.to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem
`find_position_in_diff` method returns wrong position when there are some addition codes after `No newline...` annotation in diff.

Because `find_position_in_diff` method doesn't consider about annotation.

## Solution
Add extra position increments when the line is `No newline...` annotation.
