### PR TITLE
Danger pr now supports Bitbucket Server Pull Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ## 5.9.0
 
 * Add `git.tags` to get a list of existing Git tags [@hotbott](https://github.com/hotbott)
+* `danger pr` now supports Bitbucket Server repos [@jmromanos](https://github.com/jmromanos) 
 
 ## 5.8.2
 

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -33,7 +33,7 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      @supported_request_sources ||= [Danger::RequestSources::GitHub,Danger::RequestSources::BitbucketServer]
     end
 
     def initialize(env = {})

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -33,7 +33,7 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub,Danger::RequestSources::BitbucketServer]
+      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::BitbucketServer]
     end
 
     def initialize(env = {})

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -89,7 +89,9 @@ module Danger
           PullRequestFinder.new(
             remote_info.id,
             remote_info.slug,
-            remote: true
+            remote: true,
+            remote_url: env["LOCAL_GIT_PR_URL"],
+            env: env
           ).call
         else
           PullRequestFinder.new(

--- a/lib/danger/ci_source/support/find_repo_info_from_url.rb
+++ b/lib/danger/ci_source/support/find_repo_info_from_url.rb
@@ -8,16 +8,30 @@ module Danger
       (/(pull|merge_requests|pull-requests)/)
       (?<id>\d+)
     }x
+    
+    # Regex used to extract info from Bitbucket server URLs, as they use a quite different format
+    REGEXPBB = %r{
+      (?:[\/:])projects
+      \/([^\/.]+)
+      \/repos\/([^\/.]+)
+      \/pull-requests
+      \/(\d+)
+    }x
 
     def initialize(url)
       @url = url
     end
 
     def call
-      matched = url.match(REGEXP)
+      matched = url.match(REGEXPBB)
 
       if matched
-        RepoInfo.new(matched[:slug], matched[:id])
+        RepoInfo.new("#{matched[1]}/#{matched[2]}", matched[3])
+      else
+        matched = url.match(REGEXP)
+        if matched
+          RepoInfo.new(matched[:slug], matched[:id])  
+      end  
       end
     end
 

--- a/lib/danger/ci_source/support/find_repo_info_from_url.rb
+++ b/lib/danger/ci_source/support/find_repo_info_from_url.rb
@@ -8,7 +8,7 @@ module Danger
       (/(pull|merge_requests|pull-requests)/)
       (?<id>\d+)
     }x
-    
+
     # Regex used to extract info from Bitbucket server URLs, as they use a quite different format
     REGEXPBB = %r{
       (?:[\/:])projects
@@ -30,8 +30,8 @@ module Danger
       else
         matched = url.match(REGEXP)
         if matched
-          RepoInfo.new(matched[:slug], matched[:id])  
-      end  
+          RepoInfo.new(matched[:slug], matched[:id])
+        end
       end
     end
 

--- a/lib/danger/ci_source/support/find_repo_info_from_url.rb
+++ b/lib/danger/ci_source/support/find_repo_info_from_url.rb
@@ -39,13 +39,8 @@ module Danger
       else
         matched = url.match(REGEXP)
         if matched
-<<<<<<< HEAD
           RepoInfo.new(matched[:slug], matched[:id])
         end
-=======
-          RepoInfo.new(matched[:slug], matched[:id])  
-      end  
->>>>>>> bea8e4a44a1faa3bc5dd053dac5f51e3a77f0a2a
       end
     end
 

--- a/lib/danger/ci_source/support/pull_request_finder.rb
+++ b/lib/danger/ci_source/support/pull_request_finder.rb
@@ -10,7 +10,7 @@ module Danger
       @repo_slug = repo_slug
       @remote = to_boolean(remote)
       @remote_url = remote_url
-      @env = env 
+      @env = env
     end
 
     def call
@@ -62,7 +62,7 @@ module Danger
     end
 
     def generate_remote_pull_request
-      if remote_url =~ /\/pull-requests\//
+      if remote_url =~ %r{/pull-requests/}
         RemotePullRequest.new(
           remote_pull_request[:id].to_s,
           remote_pull_request[:fromRef][:latestCommit],
@@ -75,7 +75,7 @@ module Danger
           remote_pull_request.base.sha
         )
       end
-    end  
+    end
 
     def remote_pull_request
       @_remote_pull_request ||= begin
@@ -125,7 +125,7 @@ module Danger
     end
 
     def client
-      if remote_url =~ /\/pull-requests\//
+      if remote_url =~ %r{/pull-requests/}
         require "danger/request_sources/bitbucket_server_api"
         project, slug = repo_slug.split("/")
         RequestSources::BitbucketServerAPI.new(project, slug, specific_pull_request_id, env)

--- a/lib/danger/ci_source/support/pull_request_finder.rb
+++ b/lib/danger/ci_source/support/pull_request_finder.rb
@@ -4,11 +4,13 @@ require "danger/ci_source/support/no_pull_request"
 
 module Danger
   class PullRequestFinder
-    def initialize(specific_pull_request_id, repo_slug = nil, remote: false, git_logs: "")
+    def initialize(specific_pull_request_id, repo_slug = nil, remote: false, git_logs: "", remote_url: "", env: nil)
       @specific_pull_request_id = specific_pull_request_id
       @git_logs = git_logs
       @repo_slug = repo_slug
       @remote = to_boolean(remote)
+      @remote_url = remote_url
+      @env = env 
     end
 
     def call
@@ -19,7 +21,7 @@ module Danger
 
     private
 
-    attr_reader :specific_pull_request_id, :git_logs, :repo_slug, :remote
+    attr_reader :specific_pull_request_id, :git_logs, :repo_slug, :remote, :remote_url, :env
 
     def to_boolean(maybe_string)
       ["true", "1", "yes", "y", true].include?(maybe_string)
@@ -47,11 +49,7 @@ module Danger
         elsif only_squash_and_merged_pull_request_present?
           LocalPullRequest.new(most_recent_squash_and_merged_pull_request)
         elsif remote && remote_pull_request
-          RemotePullRequest.new(
-            remote_pull_request.number.to_s,
-            remote_pull_request.head.sha,
-            remote_pull_request.base.sha
-          )
+          generate_remote_pull_request
         else
           NoPullRequest.new
         end
@@ -62,6 +60,22 @@ module Danger
     def pull_request_ref
       !specific_pull_request_id.empty? ? "##{specific_pull_request_id}" : "#\\d+".freeze
     end
+
+    def generate_remote_pull_request
+      if remote_url =~ /\/pull-requests\//
+        RemotePullRequest.new(
+          remote_pull_request[:id].to_s,
+          remote_pull_request[:fromRef][:latestCommit],
+          remote_pull_request[:toRef][:latestCommit]
+        )
+      else
+        RemotePullRequest.new(
+          remote_pull_request.number.to_s,
+          remote_pull_request.head.sha,
+          remote_pull_request.base.sha
+        )
+      end
+    end  
 
     def remote_pull_request
       @_remote_pull_request ||= begin
@@ -111,8 +125,14 @@ module Danger
     end
 
     def client
-      require "octokit"
-      Octokit::Client.new(access_token: ENV["DANGER_GITHUB_API_TOKEN"], api_endpoint: api_url)
+      if remote_url =~ /\/pull-requests\//
+        require "danger/request_sources/bitbucket_server_api"
+        project, slug = repo_slug.split("/")
+        RequestSources::BitbucketServerAPI.new(project, slug, specific_pull_request_id, env)
+      else
+        require "octokit"
+        Octokit::Client.new(access_token: ENV["DANGER_GITHUB_API_TOKEN"], api_endpoint: api_url)
+      end
     end
 
     def api_url

--- a/lib/danger/commands/local_helpers/local_setup.rb
+++ b/lib/danger/commands/local_helpers/local_setup.rb
@@ -10,21 +10,21 @@ module Danger
     def setup(verbose: false)
       source = dm.env.ci_source
       if source.nil? or source.repo_slug.empty?
-        cork.puts "danger local failed because it only works with GitHub projects at the moment. Sorry.".red
+        cork.puts "danger local failed because it only works with GitHub and Bitbucket server projects at the moment. Sorry.".red
         exit 0
       end
       gh = dm.env.request_source
       # We can use tokenless here, as it's running on someone's computer
-      # and is IP locked, as opposed to on the CI.
-      if (gh.instance_of? Danger::RequestSources::GitHub)
+      # and is IP locked, as opposed to on the CI. Only for Github PRs
+      if gh.instance_of? Danger::RequestSources::GitHub
         gh.support_tokenless_auth = true
-      end  
-      
-      if (gh.instance_of? Danger::RequestSources::GitHub)
-        cork.puts "Running your Dangerfile against this PR - https://#{gh.host}/#{source.repo_slug}/pull/#{source.pull_request_id}"
+      end
+
+      if gh.instance_of? Danger::RequestSources::BitbucketServer
+        cork.puts "Running your Dangerfile against this PR - #{gh.host}/projects/#{source.repo_slug.split('/').first}/repos/#{source.repo_slug.split('/').last}/pull-requests/#{source.pull_request_id}"
       else
-        cork.puts "Running your Dangerfile against this PR - #{gh.host}/projects/#{source.repo_slug.split("/").first}/repos/#{source.repo_slug.split("/").last}/pull-requests/#{source.pull_request_id}"
-      end  
+        cork.puts "Running your Dangerfile against this PR - https://#{gh.host}/#{source.repo_slug}/pull/#{source.pull_request_id}"
+      end
 
       unless verbose
         cork.puts "Turning on --verbose"

--- a/lib/danger/commands/local_helpers/local_setup.rb
+++ b/lib/danger/commands/local_helpers/local_setup.rb
@@ -13,13 +13,18 @@ module Danger
         cork.puts "danger local failed because it only works with GitHub projects at the moment. Sorry.".red
         exit 0
       end
-
       gh = dm.env.request_source
       # We can use tokenless here, as it's running on someone's computer
       # and is IP locked, as opposed to on the CI.
-      gh.support_tokenless_auth = true
-
-      cork.puts "Running your Dangerfile against this PR - https://#{gh.host}/#{source.repo_slug}/pull/#{source.pull_request_id}"
+      if (gh.instance_of? Danger::RequestSources::GitHub)
+        gh.support_tokenless_auth = true
+      end  
+      
+      if (gh.instance_of? Danger::RequestSources::GitHub)
+        cork.puts "Running your Dangerfile against this PR - https://#{gh.host}/#{source.repo_slug}/pull/#{source.pull_request_id}"
+      else
+        cork.puts "Running your Dangerfile against this PR - #{gh.host}/projects/#{source.repo_slug.split("/").first}/repos/#{source.repo_slug.split("/").last}/pull-requests/#{source.pull_request_id}"
+      end  
 
       unless verbose
         cork.puts "Turning on --verbose"

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -31,6 +31,10 @@ module Danger
         @username && !@username.empty? && @password && !@password.empty?
       end
 
+      def pull_request(repo_slug, pr_id)
+        fetch_pr_json
+      end
+
       def fetch_pr_json
         uri = URI(pr_api_endpoint)
         fetch_json(uri)

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -31,7 +31,7 @@ module Danger
         @username && !@username.empty? && @password && !@password.empty?
       end
 
-      def pull_request(repo_slug, pr_id)
+      def pull_request(*)
         fetch_pr_json
       end
 

--- a/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
+++ b/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
@@ -74,4 +74,25 @@ RSpec.describe Danger::FindRepoInfoFromURL do
       end
     end
   end
+
+  context "Bitbucket Server" do
+    it "works" do
+      result = described_class.new("https://tools.adidas-group.com/bitbucket/projects/MA/repos/ios-fanatics/pull-requests/1946").call
+
+      expect(result).to have_attributes(
+        slug: "MA/ios-fanatics",
+        id: "1946"
+      )
+    end
+    
+    it "works with http + trailing slash" do
+      result = described_class.new("http://tools.adidas-group.com/bitbucket/projects/MA/repos/ios-fanatics/pull-requests/1946/").call
+
+      expect(result).to have_attributes(
+        slug: "MA/ios-fanatics",
+        id: "1946"
+      )
+    
+    end
+  end    
 end

--- a/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
+++ b/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
@@ -77,18 +77,18 @@ RSpec.describe Danger::FindRepoInfoFromURL do
 
   context "Bitbucket Server" do
     it "works" do
-      result = described_class.new("https://tools.adidas-group.com/bitbucket/projects/MA/repos/ios-fanatics/pull-requests/1946").call
+      result = described_class.new("https://example.com/bitbucket/projects/Test/repos/test/pull-requests/1946").call
 
       expect(result).to have_attributes(
-        slug: "MA/ios-fanatics",
+        slug: "Test/test",
         id: "1946"
       )
     end
     it "works with http + trailing slash" do
-      result = described_class.new("http://tools.adidas-group.com/bitbucket/projects/MA/repos/ios-fanatics/pull-requests/1946/").call
+      result = described_class.new("http://example.com/bitbucket/projects/Test/repos/test/pull-requests/1946/").call
 
       expect(result).to have_attributes(
-        slug: "MA/ios-fanatics",
+        slug: "Test/test",
         id: "1946"
       )
     end

--- a/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
+++ b/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
@@ -84,11 +84,6 @@ RSpec.describe Danger::FindRepoInfoFromURL do
         id: "1946"
       )
     end
-<<<<<<< HEAD
-
-=======
-    
->>>>>>> bea8e4a44a1faa3bc5dd053dac5f51e3a77f0a2a
     it "works with http + trailing slash" do
       result = described_class.new("http://tools.adidas-group.com/bitbucket/projects/MA/repos/ios-fanatics/pull-requests/1946/").call
 
@@ -96,12 +91,6 @@ RSpec.describe Danger::FindRepoInfoFromURL do
         slug: "MA/ios-fanatics",
         id: "1946"
       )
-<<<<<<< HEAD
     end
   end
-=======
-    
-    end
-  end    
->>>>>>> bea8e4a44a1faa3bc5dd053dac5f51e3a77f0a2a
 end

--- a/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
+++ b/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Danger::FindRepoInfoFromURL do
         id: "1946"
       )
     end
-    
+
     it "works with http + trailing slash" do
       result = described_class.new("http://tools.adidas-group.com/bitbucket/projects/MA/repos/ios-fanatics/pull-requests/1946/").call
 
@@ -92,7 +92,6 @@ RSpec.describe Danger::FindRepoInfoFromURL do
         slug: "MA/ios-fanatics",
         id: "1946"
       )
-    
     end
-  end    
+  end
 end


### PR DESCRIPTION
This PR adds support for Bitbucket Server PRs in danger pr command. 

This is a highly desired feature in our team at Adidas, as some members wanted to test some changes in our Dangerfiles locally without being required to open new pull requests to test in our CI environment 