### PR TITLE
Fix bug with jenkins PR detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 ## master
 
 <!-- Your new comment below here -->
+## 5.10.3
+
+* Fix issue in `Jenkins` lib with PR detection logic [@serg-kovalev](https://github.com/serg-kovalev)
+
 
 ## 5.10.2
 
@@ -22,7 +26,7 @@
 
 ## 5.10.0
 
-* `danger pr` now supports Bitbucket Server repos [@jmromanos](https://github.com/jmromanos) 
+* `danger pr` now supports Bitbucket Server repos [@jmromanos](https://github.com/jmromanos)
 
 ## 5.9.1
 

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -59,7 +59,7 @@ module Danger
 
     def self.validates_as_pr?(env)
       id = pull_request_id(env)
-      !id.nil? && !id.empty?
+      !id.nil? && !id.empty? && !!id.match(%r{^\d+$})
     end
 
     def supported_request_sources

--- a/lib/danger/version.rb
+++ b/lib/danger/version.rb
@@ -1,4 +1,4 @@
 module Danger
-  VERSION = "5.10.2".freeze
+  VERSION = "5.10.3".freeze
   DESCRIPTION = "Like Unit Tests, but for your Team Culture.".freeze
 end

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe Danger::Jenkins do
         valid_env["ghprbPullId"] = ""
         expect(described_class.validates_as_pr?(valid_env)).to be false
       end
+
+      it "doesn't validate_as_pr if `ghprbPullId` is not a number" do
+        valid_env["ghprbPullId"] = "false"
+        expect(described_class.validates_as_pr?(valid_env)).to be false
+      end
     end
 
     describe "#new" do


### PR DESCRIPTION
Fix for PR detection logic in Jenkins lib.

I faced with the following issue:
```
18:02:14 /bundle_cache/gems/octokit-4.13.0/lib/octokit/response/raise_error.rb:16:in `on_complete': GET https://github.site_url/api/v3/repos/path/to/app/pulls/false: 404 - Not Found // See: https://developer.github.com/enterprise/2.14/v3/pulls/#get-a-single-pull-request (Octokit::NotFound)
```

This PR fixes the issue above ^^