### PR TITLE
Extract repo_slug using ssh and http(s) regex on jenkins ci to fix #1049

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 <!-- Your new comment below here -->
 
+## 5.11.0
+
+* Support multiple gitlab groups using jenkins ci extracting `repo_slug` [@kyaak](https://github.com/kyaak)
+
 ## 5.10.1
 
 * Fix wrong test and implementation about `No newline` annotation [@colorbox](https://github.com/colorbox)

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -78,14 +78,35 @@ module Danger
 
       self.repo_url = self.class.repo_url(env)
       self.pull_request_id = self.class.pull_request_id(env)
+      self.repo_slug = self.class.repo_slug(self.repo_url)
+    end
 
-      repo_matches = self.repo_url.match(%r{(?:[\/:])projects\/([^\/.]+)\/repos\/([^\/.]+)}) # Bitbucket Server
-      if repo_matches
-        self.repo_slug = "#{repo_matches[1]}/#{repo_matches[2]}"
-      else
-        repo_matches = self.repo_url.match(%r{([\/:])([^\/]+\/[^\/]+)$})
-        self.repo_slug = repo_matches[2].gsub(/\.git$/, "") unless repo_matches.nil?
-      end
+    def self.repo_slug(repo_url)
+      slug = self.slug_ssh(repo_url)
+      slug = self.slug_http(repo_url) unless slug
+      slug = self.slug_bitbucket(repo_url) unless slug
+      slug = self.slug_fallback(repo_url) unless slug
+      return slug.gsub(/\.git$/, "") unless slug.nil?
+    end
+
+    def self.slug_bitbucket(repo_url)
+      repo_matches = repo_url.match(%r{(?:[\/:])projects\/([^\/.]+)\/repos\/([^\/.]+)})
+      return "#{repo_matches[1]}/#{repo_matches[2]}" if repo_matches
+    end
+
+    def self.slug_ssh(repo_url)
+      repo_matches = repo_url.match(%r{^git@.+:(.+)})
+      return repo_matches[1] if repo_matches
+    end
+
+    def self.slug_http(repo_url)
+      repo_matches = repo_url.match(%r{^https?.+(?>\.\w*\d*\/)(.+.git$)})
+      return repo_matches[1] if repo_matches
+    end
+
+    def self.slug_fallback(repo_url)
+      repo_matches = repo_url.match(%r{([\/:])([^\/]+\/[^\/]+)$})
+      return repo_matches[2]
     end
 
     def self.pull_request_id(env)

--- a/lib/danger/version.rb
+++ b/lib/danger/version.rb
@@ -1,4 +1,4 @@
 module Danger
-  VERSION = "5.10.1".freeze
+  VERSION = "5.11.0".freeze
   DESCRIPTION = "Like Unit Tests, but for your Team Culture.".freeze
 end

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -262,6 +262,24 @@ RSpec.describe Danger::Jenkins do
 
         expect(source.repo_slug).to eq("DANGER/danger")
       end
+
+      it "gets out a repo slug with multiple groups ssh" do
+        valid_env["GIT_URL"] = "git@gitlab.com:danger/systems/danger.git"
+
+        expect(source.repo_slug).to eq("danger/systems/danger")
+      end
+
+      it "gets out a repo slug with multiple groups http" do
+        valid_env["GIT_URL"] = "http://gitlab.com/danger/systems/danger.git"
+
+        expect(source.repo_slug).to eq("danger/systems/danger")
+      end
+
+      it "gets out a repo slug with multiple groups https" do
+        valid_env["GIT_URL"] = "https://gitlab.com/danger/systems/danger.git"
+
+        expect(source.repo_slug).to eq("danger/systems/danger")
+      end
     end
   end
 


### PR DESCRIPTION
Fix #1049 
Add a custom ssh and https regex to jenkins ci to support multiple sub groups  (gitlab env).
Keep bitbucket regex for change url env.
Keep old regex as fallback - supports only one parent for the repository.