### PR TITLE
Run "danger pr" for Bitbucket Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 <!-- Your new comment below here, and above the most recent release -->
 
+* `danger pr` now supports Bitbucket Cloud repos [@RicardoBelchior](https://github.com/RicardoBelchior)
+
 ## 5.11.1
 
 * Fix duplicated REGEXPBB warning [@jmromanos](https://github.com/jmromanos)

--- a/lib/danger/ci_source/local_git_repo.rb
+++ b/lib/danger/ci_source/local_git_repo.rb
@@ -33,7 +33,7 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::BitbucketServer]
+      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::BitbucketServer, Danger::RequestSources::BitbucketCloud]
     end
 
     def initialize(env = {})

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -8,7 +8,7 @@ require "no_proxy_fix"
 
 module Danger
   class PR < Runner
-    self.summary = "Run the Dangerfile locally against Pull Requests (works with forks, too). Does not post to the PR.".freeze
+    self.summary = "Run the Dangerfile locally against Pull Requests (works with forks, too). Does not post to the PR. Usage: danger pr <URL>".freeze
     self.command = "pr".freeze
 
     def self.options
@@ -45,6 +45,9 @@ module Danger
       super
       unless @dangerfile_path
         help! "Could not find a Dangerfile."
+      end
+      unless @pr_url
+        help! "Could not find a pull-request. Usage: danger pr <URL>"
       end
     end
 

--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
@@ -97,7 +97,7 @@ module Danger
     # @return [String]
     #
     def pr_author
-      @bs.pr_json[:author][:user][:slug].to_s
+      @bs.pr_json[:author][:username]
     end
 
     # @!group PR Commit Metadata
@@ -105,7 +105,7 @@ module Danger
     # @return [String]
     #
     def branch_for_base
-      @bs.pr_json[:toRef][:displayId].to_s
+      @bs.pr_json[:destination][:branch][:name]
     end
 
     # @!group PR Commit Metadata
@@ -113,7 +113,7 @@ module Danger
     # @return [String]
     #
     def pr_link
-      @bs.pr_json[:links][:self].flat_map { |l| l[:href] }.first.to_s
+      @bs.pr_json[:links][:self][:href]
     end
 
     # @!group PR Commit Metadata
@@ -121,7 +121,7 @@ module Danger
     # @return [String]
     #
     def branch_for_head
-      @bs.pr_json[:fromRef][:displayId].to_s
+      @bs.pr_json[:destination][:branch][:name]
     end
 
     # @!group PR Commit Metadata
@@ -129,7 +129,7 @@ module Danger
     # @return [String]
     #
     def base_commit
-      @bs.pr_json[:toRef][:latestCommit].to_s
+      @bs.pr_json[:destination][:commit][:hash]
     end
 
     # @!group PR Commit Metadata
@@ -137,63 +137,8 @@ module Danger
     # @return [String]
     #
     def head_commit
-      @bs.pr_json[:fromRef][:latestCommit].to_s
+      @bs.pr_json[:source][:commit][:hash]
     end
 
-    # @!group Bitbucket Cloud Misc
-    # Returns a list of HTML anchors for a file, or files in the head repository.
-    # It returns a string of multiple anchors if passed an array.
-    # @param    [String or Array<String>] paths
-    #           A list of strings to convert to github anchors
-    # @param    [Bool] full_path
-    #           Shows the full path as the link's text, defaults to `true`.
-    #
-    # @return [String]
-    #
-    def html_link(paths, full_path: true)
-      create_link(paths, full_path) { |href, text| create_html_link(href, text) }
-    end
-
-    # @!group Bitbucket Cloud Misc
-    # Returns a list of Markdown links for a file, or files in the head repository.
-    # It returns a string of multiple links if passed an array.
-    # @param    [String or Array<String>] paths
-    #           A list of strings to convert to Markdown links
-    # @param    [Bool] full_path
-    #           Shows the full path as the link's text, defaults to `true`.
-    #
-    # @return [String]
-    #
-    def markdown_link(paths, full_path: true)
-      create_link(paths, full_path) { |href, text| create_markdown_link(href, text) }
-    end
-
-    private
-
-    def create_link(paths, full_path)
-      paths = [paths] unless paths.kind_of?(Array)
-      commit = head_commit
-      repo = pr_json[:fromRef][:repository][:links][:self].flat_map { |l| l[:href] }.first
-
-      paths = paths.map do |path|
-        path, line = path.split("#")
-        url_path = path.start_with?("/") ? path : "/#{path}"
-        text = full_path ? path : File.basename(path)
-        url_path.gsub!(" ", "%20")
-        line_ref = line ? "##{line}" : ""
-        yield("#{repo}#{url_path}?at=#{commit}#{line_ref}", text)
-      end
-
-      return paths.first if paths.count < 2
-      paths.first(paths.count - 1).join(", ") + " & " + paths.last
-    end
-
-    def create_html_link(href, text)
-      "<a href='#{href}'>#{text}</a>"
-    end
-
-    def create_markdown_link(href, text)
-      "[#{text}](#{href})"
-    end
   end
 end

--- a/spec/fixtures/bitbucket_cloud_api/pr_response.json
+++ b/spec/fixtures/bitbucket_cloud_api/pr_response.json
@@ -35,7 +35,7 @@ HTTP/1.1 200 OK
       "href": "https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080/statuses"
     }
   },
-  "title": "This is a danger test",
+  "title": "This is a danger test for bitbucket cloud",
   "close_source_branch": false,
   "reviewers": [],
   "destination": {

--- a/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
+++ b/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Danger::FindRepoInfoFromURL do
 
   context "Bitbucket" do
     context "bitbucket.org" do
-      it "works" do
+      it "works with regular url" do
         result = described_class.new("https://bitbucket.org/ged/ruby-pg/pull-requests/42").call
 
         expect(result).to have_attributes(
@@ -61,6 +61,33 @@ RSpec.describe Danger::FindRepoInfoFromURL do
           id: "42"
         )
       end
+
+      it "works with another url" do
+        result = described_class.new("https://bitbucket.org/some-org/awesomerepo/pull-requests/1324").call
+
+        expect(result).to have_attributes(
+          slug: "some-org/awesomerepo",
+          id: "1324"
+        )
+      end
+
+      it "works with trailing slash" do
+        result = described_class.new("https://bitbucket.org/some-org/awesomerepo/pull-requests/1324/").call
+
+        expect(result).to have_attributes(
+          slug: "some-org/awesomerepo",
+          id: "1324"
+        )
+      end
+
+      it "works with trailing information" do
+        result = described_class.new("https://bitbucket.org/some-org/awesomerepo/pull-requests/1324/update-compile-targetsdk-to-28/diff").call
+
+        expect(result).to have_attributes(
+          slug: "some-org/awesomerepo",
+          id: "1324"
+        )
+      end  
     end
 
     context "bitbucket.com" do

--- a/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
@@ -1,12 +1,13 @@
 require "danger/ci_source/support/pull_request_finder"
 
 RSpec.describe Danger::PullRequestFinder do
-  def finder(pull_request_id: "", logs: nil, repo_slug: "danger/danger", remote: "false")
+  def finder(pull_request_id: "", logs: nil, repo_slug: "danger/danger", remote: "false", remote_url: "")
     described_class.new(
       pull_request_id,
       repo_slug,
       remote: remote,
-      git_logs: logs
+      git_logs: logs,
+      remote_url: remote_url
     )
   end
 
@@ -128,4 +129,33 @@ RSpec.describe Danger::PullRequestFinder do
       end
     end
   end
+
+  describe "#find_scm_provider" do
+
+  def find_scm_provider(url)
+    finder(remote: "true").send(:find_scm_provider, url)
+  end
+
+    it "detects url for bitbucket cloud" do
+      url = "https://bitbucket.org/ged/ruby-pg/pull-requests/42"
+      expect(find_scm_provider(url)).to eq :bitbucket_cloud
+    end
+
+    it "detects url for bitbucket server" do
+      url = "https://example.com/bitbucket/projects/Test/repos/test/pull-requests/1946"
+      expect(find_scm_provider(url)).to eq :bitbucket_server
+    end
+
+    it "detects url for bitbucket github" do
+      url = "http://www.github.com/torvalds/linux/pull/42"
+      expect(find_scm_provider(url)).to eq :github
+    end
+
+    it "defaults to github when unknown url" do
+      url = "http://www.default-url.com/"
+      expect(find_scm_provider(url)).to eq :github
+    end
+
+  end
+
 end

--- a/spec/lib/danger/commands/pr_spec.rb
+++ b/spec/lib/danger/commands/pr_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Danger::PR do
     it "returns the summary for PR command" do
       result = described_class.summary
 
-      expect(result).to eq "Run the Dangerfile locally against Pull Requests (works with forks, too). Does not post to the PR."
+      expect(result).to eq "Run the Dangerfile locally against Pull Requests (works with forks, too). Does not post to the PR. Usage: danger pr <URL>"
     end
   end
 

--- a/spec/lib/danger/plugins/dangerfile_bitbucket_cloud_plugin_spec.rb
+++ b/spec/lib/danger/plugins/dangerfile_bitbucket_cloud_plugin_spec.rb
@@ -1,0 +1,65 @@
+# coding: utf-8
+
+RSpec.describe Danger::DangerfileBitbucketCloudPlugin, host: :bitbucket_cloud do
+  let(:dangerfile) { testing_dangerfile }
+  let(:plugin) { described_class.new(dangerfile) }
+
+  before do
+    stub_pull_request
+  end
+
+  describe "plugin" do
+    before do
+      dangerfile.env.request_source.fetch_details
+    end
+
+    describe "#pr_json" do
+      it "has a non empty json" do
+        expect(plugin.pr_json).to be_truthy
+      end
+    end
+
+    describe "#pr_title" do
+      it "has a fetched title" do
+        expect(plugin.pr_title).to eq("This is a danger test for bitbucket cloud")
+      end
+    end
+
+    describe "#pr_author" do
+      it "has a fetched author" do
+        expect(plugin.pr_author).to eq("AName")
+      end
+    end
+
+    describe "#pr_link" do
+      it "has a fetched link to it self" do
+        expect(plugin.pr_link).to eq("https://api.bitbucket.org/2.0/repositories/ios/fancyapp/pullrequests/2080")
+      end
+    end
+
+    describe "#branch_for_base" do
+      it "has a fetched branch for base" do
+        expect(plugin.branch_for_base).to eq("develop")
+      end
+    end
+
+    describe "#branch_for_head" do
+      it "has a fetched branch for head" do
+        expect(plugin.branch_for_head).to eq("develop")
+      end
+    end
+
+    describe "#base_commit" do
+      it "has a fetched base commit" do
+        expect(plugin.base_commit).to eq("9c823062cf99")
+      end
+    end
+
+    describe "#head_commit" do
+      it "has a fetched head commit" do
+        expect(plugin.head_commit).to eq("b6f5656b6ac9")
+      end
+    end
+
+  end
+end

--- a/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
@@ -28,6 +28,42 @@ RSpec.describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud
     end
   end
 
+  describe "#pull_request_id" do
+    it "gets set from pull_request_id" do
+      api = described_class.new("org/repo", 1, nil, stub_env)
+
+      expect(api.pull_request_id).to eq(1)
+    end
+  end
+
+  describe "#host" do
+    it "gets set from host" do
+      api = described_class.new("org/repo", 1, nil, stub_env)
+
+      expect(api.host).to eq("https://bitbucket.org/")
+    end
+  end
+  
+  describe "#credentials_given" do
+    it "#fetch_json raise error when missing credentials" do
+      empty_env = {}
+      api = described_class.new("ios/fancyapp", "123", nil, empty_env)
+      expect { api.pull_request }.to raise_error
+    end
+
+    it "#post raise error when missing credentials" do
+      empty_env = {}
+      api = described_class.new("ios/fancyapp", "123", nil, empty_env)
+      expect { api.post("http://post-url.org", {}) }.to raise_error
+    end
+
+    it "#delete raise error when missing credentials" do
+      empty_env = {}
+      api = described_class.new("ios/fancyapp", "123", nil, empty_env)
+      expect { api.delete("http://delete-url.org") }.to raise_error
+    end
+  end
+
   describe "#fetch_pr_id" do
     it "gets called if pull_request_id is nil" do
       stub_pull_requests
@@ -36,4 +72,5 @@ RSpec.describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud
       expect(api.pull_request_id).to eq(2080)
     end
   end
+
 end

--- a/spec/lib/danger/request_sources/bitbucket_cloud_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_cloud_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Danger::RequestSources::BitbucketCloud, host: :bitbucket_cloud do
 
     describe "#pr_json[:title]" do
       it "has fetched the pull requests title" do
-        expect(bs.pr_json[:title]).to eq("This is a danger test")
+        expect(bs.pr_json[:title]).to eq("This is a danger test for bitbucket cloud")
       end
     end
   end


### PR DESCRIPTION
Adding changes to `danger pr` command in order to allow running on bitbucket cloud repositories.

There's a few things I was unsure, but since the tests still passed, I kept going. Also my ruby skills are not great, so feel free to criticise..

For example, file `lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb` seemed very buggy, mostly being a copy paste from the bitbucket_server equivalent.

The method `#find_scm_provider` is not great but I followed a similar technique to what was previously being done to detect bitbucket server urls. I suppose changing that would involve a bigger refactor on the `pr` command.

And that was it.. I was able to run this locally, so I suppose it works. Let me know if you need any other changes.
