### PR TITLE
Add "Fail if no PR" flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Add `--fail-if-no-pr` flag, breaks builds if no PR is found [@ghiculescu](https://github.com/ghiculescu)
+
 ## 5.13.0
 
 * Add support for Bitbucket Pipelines [@HelloCore](https://github.com/HelloCore)

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -38,6 +38,7 @@ module Danger
       @base = argv.option("base")
       @head = argv.option("head")
       @fail_on_errors = argv.option("fail-on-errors", false)
+      @fail_if_no_pr = argv.option("fail-if-no-pr", false)
       @new_comment = argv.flag?("new-comment")
       @remove_previous_comments = argv.flag?("remove-previous-comments")
       @danger_id = argv.option("danger_id", "danger")
@@ -59,6 +60,7 @@ module Danger
         ["--base=[master|dev|stable]", "A branch/tag/commit to use as the base of the diff"],
         ["--head=[master|dev|stable]", "A branch/tag/commit to use as the head"],
         ["--fail-on-errors=<true|false>", "Should always fail the build process, defaults to false"],
+        ["--fail-if-no-pr=<true|false>", "Should fail the build process if no PR is found (useful for CircleCI), defaults to false"],
         ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"],
         ["--danger_id=<id>", "The identifier of this Danger instance"],
         ["--new-comment", "Makes Danger post a new comment instead of editing its previous one"],
@@ -74,6 +76,7 @@ module Danger
         danger_id: @danger_id,
         new_comment: @new_comment,
         fail_on_errors: @fail_on_errors,
+        fail_if_no_pr: @fail_if_no_pr,
         remove_previous_comments: @remove_previous_comments
       )
     end

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -19,7 +19,7 @@ module Danger
       cork ||= Cork::Board.new(silent: false, verbose: false)
 
       # Run some validations
-      validate!(cork, fail_if_no_pr)
+      validate!(cork, fail_if_no_pr: fail_if_no_pr)
 
       # OK, we now know that Danger can run in this enviroment
       env ||= EnvironmentManager.new(system_env, cork)

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -13,12 +13,13 @@ module Danger
             danger_id: nil,
             new_comment: nil,
             fail_on_errors: nil,
+            fail_if_no_pr: nil,
             remove_previous_comments: nil)
       # Create a silent Cork instance if cork is nil, as it's likely a test
       cork ||= Cork::Board.new(silent: false, verbose: false)
 
       # Run some validations
-      validate!(cork)
+      validate!(cork, fail_if_no_pr)
 
       # OK, we now know that Danger can run in this enviroment
       env ||= EnvironmentManager.new(system_env, cork)
@@ -41,9 +42,9 @@ module Danger
       exit(1) if fail_on_errors && ran_status
     end
 
-    def validate!(cork)
+    def validate!(cork, fail_if_no_pr: false)
       validate_ci!
-      validate_pr!(cork)
+      validate_pr!(cork, fail_if_no_pr)
     end
 
     private
@@ -58,11 +59,12 @@ module Danger
     end
 
     # Could we determine that the CI source is inside a PR?
-    def validate_pr!(cork)
+    def validate_pr!(cork, fail_if_no_pr)
       unless EnvironmentManager.pr?(system_env)
         ci_name = EnvironmentManager.local_ci_source(system_env).name.split("::").last
         cork.puts "Not a #{ci_name} Pull Request - skipping `danger` run".yellow
-        exit(0)
+
+        exit(fail_if_no_pr ? 1 : 0)
       end
     end
 

--- a/spec/lib/danger/commands/runner_spec.rb
+++ b/spec/lib/danger/commands/runner_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Danger::Runner do
         "@base" => nil,
         "@head" => nil,
         "@fail_on_errors" => false,
+        "@fail_if_no_pr" => false,
         "@danger_id" => "danger",
         "@new_comment" => nil
       )
@@ -76,6 +77,7 @@ RSpec.describe Danger::Runner do
         danger_id: "danger",
         new_comment: nil,
         fail_on_errors: false,
+        fail_if_no_pr: false,
         remove_previous_comments: nil
       )
 
@@ -94,6 +96,7 @@ RSpec.describe Danger::Runner do
             "--danger_id=my-danger-id",
             "--new-comment",
             "--fail-on-errors=true",
+            "--fail-if-no-pr=true",
             "--remove-previous-comments"
           ]
         )
@@ -108,6 +111,7 @@ RSpec.describe Danger::Runner do
           danger_id: "my-danger-id",
           new_comment: true,
           fail_on_errors: "true",
+          fail_if_no_pr: "true",
           remove_previous_comments: true
         )
 


### PR DESCRIPTION
Flag is disabled by default, but can be opted in which might be handy for Circle CI users, or any other CI system where you can't guarantee Danger will run for each PR. Fixes https://github.com/danger/danger/issues/1080
