### PR TITLE
[GitLab] Create a new comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## master
 
+* Fix `--new-comment` for GitLab to actually create the new comment instead of
+  updating an old one. [@AlexDenisov](https://github.com/AlexDenisov)
+  Original issue: https://github.com/danger/danger/issues/1084
+
 ## 5.14.0
 
 * Add `--fail-if-no-pr` flag, breaks builds if no PR is found [@ghiculescu](https://github.com/ghiculescu)

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -133,7 +133,7 @@ module Danger
                                  danger_id: danger_id,
                                   template: "gitlab")
 
-          if editable_comments.empty?
+          if editable_comments.empty? or should_create_new_comment
             client.create_merge_request_comment(
               ci_source.repo_slug, ci_source.pull_request_id, body
             )

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
             messages: violations_factory(["Test message"]),
             template: "gitlab"
           )
-          stub_request(:put, "https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/merge_requests/1/notes/13471894").with(
+          stub_request(:post, "https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/merge_requests/1/notes").with(
             body: {
               body: body
             },


### PR DESCRIPTION
Current implementation of GitLab request source does not create a new comment
when requested via the `--new-comment` CLI option, but rather updates the old
one.

This patch fixes the issue by checking whether new comment is requested
before updating Pull Request.

Preliminary discussion of this issue is here:
https://github.com/danger/danger/issues/1084