### PR TITLE
Add support for App Center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Add support for Visual Studio App Center [@rishabhtayal](https://github.com/rishabhtayal) / [@cojoj](https://github.com/cojoj)
+
 ## 5.14.0
 
 * Add `--fail-if-no-pr` flag, breaks builds if no PR is found [@ghiculescu](https://github.com/ghiculescu)

--- a/lib/danger/ci_source/appcenter.rb
+++ b/lib/danger/ci_source/appcenter.rb
@@ -1,0 +1,55 @@
+# https://docs.microsoft.com/en-us/appcenter/build/custom/variables/
+require "uri"
+require "danger/request_sources/github/github"
+
+module Danger
+  # ### CI Setup
+  #
+  # Add a script step to your appcenter-post-build.sh:
+  #
+  # ``` shell
+  #   #!/usr/bin/env bash
+  #   bundle install
+  #   bundle exec danger
+  # ```
+  #
+  # ### Token Setup
+  #
+  # Add the `DANGER_GITHUB_API_TOKEN` to your environment variables.
+  #
+  class Appcenter < CI
+    def self.validates_as_ci?(env)
+      env.key? "APPCENTER_BUILD_ID"
+    end
+
+    def self.validates_as_pr?(env)
+      return env["BUILD_REASON"] == "PullRequest"
+    end
+
+    def self.owner_for_github(env)
+      URI.parse(env["BUILD_REPOSITORY_URI"]).path.split("/")[1]
+    end
+
+    def self.repo_identifier_for_github(env)
+      repo_name = env["BUILD_REPOSITORY_NAME"]
+      owner = owner_for_github(env)
+      "#{owner}/#{repo_name}"
+    end
+
+    # Hopefully it's a temporary workaround (same as in Codeship integration) because App Center
+    # doesn't expose PR's ID. There's a future request https://github.com/Microsoft/appcenter/issues/79
+    def self.pr_from_env(env)
+      Danger::RequestSources::GitHub.new(nil, env).get_pr_from_branch(repo_identifier_for_github(env), env["BUILD_SOURCEBRANCHNAME"], owner_for_github(env))
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+    end
+
+    def initialize(env)
+      self.pull_request_id = self.class.pr_from_env(env)
+      self.repo_url = env["BUILD_REPOSITORY_URI"]
+      self.repo_slug = self.class.repo_identifier_for_github(env)
+    end
+  end
+end

--- a/spec/lib/danger/ci_sources/ci_source_spec.rb
+++ b/spec/lib/danger/ci_sources/ci_source_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Danger::CI do
         [
           "Danger::LocalGitRepo",
           "Danger::LocalOnlyGitRepo",
+          "Danger::Appcenter",
           "Danger::BitbucketPipelines",
           "Danger::Bitrise",
           "Danger::Buddybuild",


### PR DESCRIPTION
Added Visual Studio App Center as a new CI source. It's a copy of #1057, but with resolved missing PR id. It's also heavily based on solution introduced in #892.

I haven't added any tests, because I have no clue how to do it in order to fake the networking and `DANGER_GITHUB_API_TOKEN` 😢

I hope this will be just a _temporary_ solution and soon we'd get a proper PR ID directly in App Center's environmental variables. I've created a [feature request in their repo](https://github.com/Microsoft/appcenter/issues/79).