### PR TITLE
gitlab: use CI_API_V4_URL from GitLab 11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!--
 
-// Please add your own contribution below inside the Master section, no need to
+// Please add your own contribution below inside the "master" section, no need to
 // set a version number, that happens during a deploy.
 //
 // These docs are aimed at users rather than danger developers, so please limit technical
@@ -9,6 +9,8 @@
 -->
 
 ## master
+
+* Use `CI_API_V4_URL` on GitLab 11.7+ installations [@glensc], #1089
 
 ## 5.14.0
 
@@ -1144,3 +1146,6 @@ I don't like breaking backwards comparability. Sorry, for as far as I can see at
 * Gets PR details from GitHub - orta
 * Gets Git details from local Git - orta
 * Fails when you say it's failed in  the  Dangerfile - orta
+
+
+[@glensc]: https://github.com/glensc

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -1,8 +1,7 @@
 # coding: utf-8
-
+require "uri"
 require "danger/helpers/comments_helper"
 require "danger/helpers/comment"
-
 require "danger/request_sources/support/get_ignored_violation"
 
 module Danger
@@ -56,12 +55,11 @@ module Danger
       end
 
       def endpoint
-        @endpoint ||= @environment["DANGER_GITLAB_API_BASE_URL"] ||
-                      "https://gitlab.com/api/v4"
+        @endpoint ||= @environment["DANGER_GITLAB_API_BASE_URL"] || @environment["CI_API_V4_URL"] || "https://gitlab.com/api/v4"
       end
 
       def host
-        @host ||= @environment["DANGER_GITLAB_HOST"] || "gitlab.com"
+        @host ||= @environment["DANGER_GITLAB_HOST"] || URI.parse(endpoint).host || "gitlab.com"
       end
 
       def base_commit


### PR DESCRIPTION
Fixes: #1088