### PR TITLE
Additional warning for CircleCI if danger doesn't get run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Add more helptext explaining what to do if Danger didn't run on a CircleCI build. [@ghiculescu](https://github.com/ghiculescu)
+
 ## 5.15.0
 
 * Fix `--new-comment` for GitLab to actually create the new comment instead of

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -62,7 +62,15 @@ module Danger
     def validate_pr!(cork, fail_if_no_pr)
       unless EnvironmentManager.pr?(system_env)
         ci_name = EnvironmentManager.local_ci_source(system_env).name.split("::").last
-        cork.puts "Not a #{ci_name} Pull Request - skipping `danger` run".yellow
+
+        msg = "Not a #{ci_name} Pull Request - skipping `danger` run. "
+        # circle won't run danger properly if the commit is pushed and build runs before the PR exists
+        # https://danger.systems/guides/troubleshooting.html#circle-ci-doesnt-run-my-build-consistently
+        # the best solution is to enable `fail_if_no_pr`, and then re-run the job once the PR is up
+        if ci_name == "CircleCI"
+          msg << "If you only created the PR recently, try re-running your workflow."
+        end
+        cork.puts msg.strip.yellow
 
         exit(fail_if_no_pr ? 1 : 0)
       end


### PR DESCRIPTION
Had a few "what does skipping danger run mean?" comments from the team since https://github.com/danger/danger/pull/1081 got merged. The good news is this means https://github.com/danger/danger/pull/1081 is working as expected. The bad news is it's confusing people. This PR hopefully will result in less confusion.
