### PR TITLE
Remove trailing whitespace from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,3 @@ junit-results.xml
 
 # Mac OS
 .DS_Store
-


### PR DESCRIPTION
Fixes mixed line endings and removes trailing whitespace. 