### PR TITLE
Support Kramdown 2.0+ (requires Ruby 2.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ rvm:
   - 2.5.3
   - 2.4.5
   - 2.3.8
-  - 2.2.10
-  - 2.1.10
-  - 2.0
 
 bundler_args: "--without documentation --path bundle"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 
 ## master
 
+## 6.0.0
+
+* Support Kramdown 2.0+ (requires Ruby 2.3) [@davidstosik](https://github.com/davidstosik), #1100
+
+### Breaking changes
+
+* Danger requires Kramdown 2.0 or more recent and will not work with lower versions.
+* Danger requires Ruby 2.3 or more recent and will not work with lower versions.
+
 ## 5.16.1
 
 * Fixes GitLab inline comments when violations happened in files outside of the MR diff [@pbendersky](https://github.com/pbendersky), #1092

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_runtime_dependency "claide", "~> 1.0"
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
@@ -26,12 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday-http-cache", "~> 1.0"
-  if RUBY_VERSION >= "2.3.0"
-    spec.add_runtime_dependency "kramdown", "~> 2.0"
-    spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
-  else
-    spec.add_runtime_dependency "kramdown", "~> 1.5"
-  end
+  spec.add_runtime_dependency "kramdown", "~> 2.0"
+  spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "octokit", "~> 4.7"
   spec.add_runtime_dependency "terminal-table", "~> 1"
   spec.add_runtime_dependency "cork", "~> 0.1"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -26,9 +26,13 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday-http-cache", "~> 1.0"
+  if RUBY_VERSION >= "2.3.0"
+    spec.add_runtime_dependency "kramdown", "~> 2.0"
+    spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
+  else
+    spec.add_runtime_dependency "kramdown", "~> 1.5"
+  end
   spec.add_runtime_dependency "octokit", "~> 4.7"
-  spec.add_runtime_dependency "kramdown", ">= 1.5"
-  spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "terminal-table", "~> 1"
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "no_proxy_fix"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday-http-cache", "~> 1.0"
   spec.add_runtime_dependency "octokit", "~> 4.7"
-  spec.add_runtime_dependency "kramdown", "~> 1.5"
+  spec.add_runtime_dependency "kramdown", ">= 1.5"
   spec.add_runtime_dependency "terminal-table", "~> 1"
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "no_proxy_fix"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday-http-cache", "~> 1.0"
   spec.add_runtime_dependency "octokit", "~> 4.7"
   spec.add_runtime_dependency "kramdown", ">= 1.5"
+  spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "terminal-table", "~> 1"
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "no_proxy_fix"

--- a/lib/danger/version.rb
+++ b/lib/danger/version.rb
@@ -1,4 +1,4 @@
 module Danger
-  VERSION = "5.16.1".freeze
+  VERSION = "6.0.0".freeze
   DESCRIPTION = "Like Unit Tests, but for your Team Culture.".freeze
 end


### PR DESCRIPTION
Kramdown released [2.0.0](https://kramdown.gettalong.org/news.html#kramdown-200-released) on 2019/01/20, followed by [2.1.0](https://kramdown.gettalong.org/news.html#kramdown-210-released) on 2019/01/31.
For projects staying on the edge, it is important that Danger's dependency on Kramdown `~> 1.5` does not become a blocker.

As it is not possible to write a gemspec with conditions on the Ruby version, this is my final proposition:

## Suggest drastic update of Danger that will require Ruby 2.3

This is a drastic change triggered by Kramdown 2.x requiring Ruby 2.3 and `kramdown-parser-gfm`. Danger 6.0+ will require:
- Ruby 2.3+
- kramdown gem 2.0+
- kramdown-parser-gfm gem

To keep using Ruby 2.0\~2.3 and kramdown gem 1.5\~2.0, you'll have to stick to Danger 5.x.

I'd like to suggest creating a `v5.x` branch on this repository, right before this PR gets merged. If there is a desire to keep maintaining Danger 5.x for a while, patches would need to be applied to both `master` and `v5.x`.