### PR TITLE
Fix inline github comments when diff has trailing tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fixes issue with Github where some filenames have trailing tabs, preventing inline comments from being posted correctly. [@daniel-beard](https://github.com/daniel-beard)
+
 ## 5.16.1
 
 * Fixes GitLab inline comments when violations happened in files outside of the MR diff [@pbendersky](https://github.com/pbendersky), #1092

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -375,6 +375,12 @@ module Danger
         pattern = "+++ b/" + message.file + "\n"
         file_start = diff_lines.index(pattern)
 
+        # Files containing spaces sometimes have a trailing tab
+        if file_start.nil?
+          pattern = "+++ b/" + message.file + "\t\n"
+          file_start = diff_lines.index(pattern)
+        end
+
         return nil if file_start.nil?
 
         position = -1

--- a/spec/fixtures/github_api/inline_comments_pr_diff.diff
+++ b/spec/fixtures/github_api/inline_comments_pr_diff.diff
@@ -77,6 +77,17 @@ index 5817675..30499d7 100644
  * Show appropriate error message when GitHub repo was moved - KrauseFx
  * `danger plugins json [gem]` will now give gem metadata too - orta
  
+diff --git a/ios/Example/App Delegates/README.md b/ios/Example/App Delegates/README.md
+index 5817675..30499d7 100644
+--- a/ios/Example/App Delegates/README.md	
++++ b/ios/Example/App Delegates/README.md	
+@@ -1,5 +1,6 @@
+ ## Master
+ 
++* add `file` and `line` optional parameters to methods on the messaging plugin
+ * Show appropriate error message when GitHub repo was moved - KrauseFx
+ * `danger plugins json [gem]` will now give gem metadata too - orta
+ 
 diff --git a/Dangerfile b/Dangerfile
 index 16e75d7..50e35a9 100644
 --- a/Dangerfile

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -397,6 +397,19 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
         @g.update_pull_request!(warnings: [], errors: [], messages: [v])
       end
 
+      it "correctly handles trailing tabs in diff" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
+        expect(@g.client).to receive(:create_pull_request_comment).with("artsy/eigen", "800", anything, "561827e46167077b5e53515b4b7349b8ae04610b", "ios/Example/App Delegates/README.md", 4)
+
+        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_1).and_return({})
+        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_2).and_return({})
+        expect(@g.client).to receive(:delete_comment).with("artsy/eigen", main_issue_id).and_return({})
+
+        v = Danger::Violation.new("Sure thing", true, "ios/Example/App Delegates/README.md", 4)
+        @g.update_pull_request!(warnings: [], errors: [], messages: [v])
+      end
+
       it "adds main comment when inline out of range" do
         allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return([])


### PR DESCRIPTION
- Fixes an issue where if a filename in the `+++` or `---` lines contains a space, an additional tab is appended to the end of the line before the newline character [reference to source](https://github.com/git/git/blob/6e0cc6776106079ed4efa0cc9abace4107657abf/diff.c#L1491)
- I believe this fixes #1010 #1042 and potentially https://github.com/ashfurrow/danger-ruby-swiftlint/issues/115