### PR TITLE
Rescues from exceptions when submitting GitLab inline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 
+* Rescues from failures when submitting inline comments to GitLab [@pbendersky](https://github.com/pbendersky), #1097
 * Fixes issue with Github where some filenames have trailing tabs, preventing inline comments from being posted correctly. [@daniel-beard](https://github.com/daniel-beard)
 
 ## 5.16.1


### PR DESCRIPTION
This should fix #1097 

While I'm not clear on what cases it happens, the solution is similar to the one for GitHub: if we fail to submit an inline comment, the violation is kept and submitted as a regular one in the main comment.