### PR TITLE
Fixed error handling on GitLab inline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fixed error management with GitLab inline comments [@pbendersky](https://github.com/pbendersky), #1106
+
 ## 6.0.0
 
 * Support Kramdown 2.0+ (requires Ruby 2.3) [@davidstosik](https://github.com/davidstosik), #1100


### PR DESCRIPTION
Fix for #1106 
///////////////////⚡///////////////////

# 🚫 AWESOME A PR!

- You can just delete all of this and start your PR text anytime -

Hello there, just a quick pre-warning of some of the Danger rules we run on Danger PRs.

The big one is we request that every code change to Danger include a CHANGELOG entry, 
this is so that:

1. People know what changes are between versions
2. Orta doesn't get all the credit for other people's work

Danger will look for a modification to the `CHANGELOG.md` when there are changes including
`lib/*` - if you're fixing unreleased code, or doing a simple typo change, you can
include `#trivial` in the title or the body of the PR and this is skipped.

We also request that you fill in the body of your PR, a title should be tweet length, but
ideally you can explain the PRs reasoning in the body. We look that it's longer than 5 chars.

Other than that, a lot of the other Danger rules are trickier to trigger so we can address
them as they come up!

❤ THANKS FOR HELPING OUT :D 

///////////////////⚡///////////////////