### PR TITLE
Typo fixed in CI configuration #trivial

### DIFF
--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -6,7 +6,7 @@ module Danger
   # ### CI Setup
   #
   # Install dependencies and add a danger step to your .gitlab-ci.yml:
-  # ``` yml
+  # ```yml
   # before_script:
   #  - bundle install
   # danger:


### PR DESCRIPTION
Otherwise content is rendered poorly:
<img width="1176" alt="Снимок экрана 2019-03-29 в 9 41 04" src="https://user-images.githubusercontent.com/4660275/55214185-e95d5480-5206-11e9-9d84-b06b6abc6bce.png">
