### PR TITLE
fixed GitLab Discussions API request params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ## master
 
-## Release number TBD
-
 * Fixed error of GitLab inline comments @oboenikui, #1111
 
 ## 6.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## master
 
+## 6.0.3
+
+* Fixed error of GitLab inline comments @oboenikui, #1111
+
 ## 6.0.2
 
 * Add project URL to Jenkins if available, [@qyhongfan](https://github.com/qyhongfan) #1109

--- a/lib/danger/helpers/comment.rb
+++ b/lib/danger/helpers/comment.rb
@@ -14,7 +14,7 @@ module Danger
 
     def self.from_gitlab(comment)
       if comment.respond_to?(:id) && comment.respond_to?(:body)
-        type = comment.respond_to?(:type) ? comment.type : comment["type"]
+        type = comment.respond_to?(:type) ? comment.type : nil
         self.new(comment.id, comment.body, type == "DiffNote")
       else
         self.new(comment["id"], comment["body"], comment["type"] == "DiffNote")

--- a/lib/danger/helpers/comment.rb
+++ b/lib/danger/helpers/comment.rb
@@ -2,9 +2,10 @@ module Danger
   class Comment
     attr_reader :id, :body
 
-    def initialize(id, body)
+    def initialize(id, body, inline = nil)
       @id = id
       @body = body
+      @inline = inline
     end
 
     def self.from_github(comment)
@@ -13,9 +14,10 @@ module Danger
 
     def self.from_gitlab(comment)
       if comment.respond_to?(:id) && comment.respond_to?(:body)
-        self.new(comment.id, comment.body)
+        type = comment.respond_to?(:type) ? comment.type : comment["type"]
+        self.new(comment.id, comment.body, type == "DiffNote")
       else
-        self.new(comment["id"], comment["body"])
+        self.new(comment["id"], comment["body"], comment["type"] == "DiffNote")
       end
     end
 
@@ -24,7 +26,7 @@ module Danger
     end
 
     def inline?
-      body.include?("")
+      @inline.nil? ? body.include?("") : @inline
     end
   end
 end

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -464,6 +464,7 @@ module Danger
           line: nil
         }
 
+        # If the file is new one, old line number must be nil.
         return modified_position if change["new_file"]
 
         current_old_line = 0
@@ -473,7 +474,10 @@ module Danger
           match = line.match range_header_regexp
 
           if match
+            # If the message line is at before next diffs, break from loop.
             break if message.line.to_i < match[:new].to_i
+
+            # The match [:old] line does not appear yet at the header position, so reduce line number.
             current_old_line = match[:old].to_i - 1
             current_new_line = match[:new].to_i - 1
             next
@@ -483,10 +487,12 @@ module Danger
             current_old_line += 1
           elsif line.start_with?("+")
             current_new_line += 1
+            # If the message line starts with '+', old line number must be nil.
             return modified_position if current_new_line == message.line.to_i
           elsif !line.eql?("\\ No newline at end of file\n")
             current_old_line += 1
             current_new_line += 1
+            # If the message line doesn't start with '+', old line number must be specified.
             break if current_new_line == message.line.to_i
           end
         end

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -406,6 +406,8 @@ module Danger
                 position_type: 'text',
                 new_path: m.file,
                 new_line: m.line,
+                old_path: m.file,
+                old_line: m.line,
                 base_sha: self.mr_json.diff_refs.base_sha,
                 start_sha: self.mr_json.diff_refs.start_sha,
                 head_sha: self.mr_json.diff_refs.head_sha

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -162,8 +162,9 @@ module Danger
       end
 
       def update_pull_request_with_inline_comments!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
-        editable_regular_comments = mr_comments.select {|comment| comment.generated_by_danger?(danger_id)}
-                                      .reject(&:inline?)
+        editable_regular_comments = mr_comments
+          .select { |comment| comment.generated_by_danger?(danger_id) }
+          .reject(&:inline?)
 
         last_comment = editable_regular_comments.last
         should_create_new_comment = new_comment || last_comment.nil? || remove_previous_comments
@@ -220,7 +221,6 @@ module Danger
               client.edit_merge_request_note(ci_source.repo_slug, ci_source.pull_request_id, last_comment.id, body)
             end
         end
-        
       end
 
       def update_pull_request_without_inline_comments!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
@@ -331,6 +331,7 @@ module Danger
         comments = mr_discussions
           .auto_paginate
           .flat_map { |discussion| discussion.notes.map { |note| note.merge({"discussion_id" => discussion.id}) } }
+          .select { |comment| Comment.from_gitlab(comment).inline? }
 
         danger_comments = comments.select { |comment| Comment.from_gitlab(comment).generated_by_danger?(danger_id) }
         non_danger_comments = comments - danger_comments


### PR DESCRIPTION
fixed https://github.com/danger/danger/issues/1111

Fixed GitLab Discussions POST API params.

Although not in the GitLab API documentation, `old_line` and` old_path` seem to be required parameters when `new_path` and `new_line` were used.