### PR TITLE
Travis: move git commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,12 @@ before_install:
 after_install:
   - rake install
 
-script:
+before_script:
   # Tests use real git commands
   - git config --global user.email "danger@example.com"
   - git config --global user.name "Danger McShane"
+
+script:
   - echo "Running Tests"
   - bundle exec rake spec
   - echo "Linting the documentation for Danger's internal plugins"


### PR DESCRIPTION
This is so it doesn't clog up the main script logs.