### PR TITLE
For GitLab >= 10.7, use a faster API to find the MR for a commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* For GitLab >= 10.7, use a newer faster API to find the MR for the commit
+
 ## 6.0.3
 
 * Support Bitbucket cloud OAuth [@susan335](https://github.com/susan335) #1115

--- a/spec/fixtures/gitlab_api/commit_merge_requests.json
+++ b/spec/fixtures/gitlab_api/commit_merge_requests.json
@@ -1,0 +1,74 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Sun, 14 Apr 2019 22:58:42 GMT
+Content-Type: application/json
+Content-Length: 1794
+Cache-Control: max-age=0, private, must-revalidate
+Etag: W/"ac5231c0151c62f2c6f3058b8b166f54"
+Link: <https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/repository/commits/04e58de1fa97502d7e28c1394d471bb8fb1fc4a8/merge_requests?id=k0nserv%2Fdanger-test&page=1&per_page=20&sha=04e58de1fa97502d7e28c1394d471bb8fb1fc4a8&state=opened>; rel="first", <https://gitlab.com/api/v4/projects/k0nserv%2Fdanger-test/repository/commits/04e58de1fa97502d7e28c1394d471bb8fb1fc4a8/merge_requests?id=k0nserv%2Fdanger-test&page=1&per_page=20&sha=04e58de1fa97502d7e28c1394d471bb8fb1fc4a8&state=opened>; rel="last"
+Vary: Origin
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Next-Page: 
+X-Page: 1
+X-Per-Page: 20
+X-Prev-Page: 
+X-Request-Id: J139ByVCLPa
+X-Runtime: 0.092095
+X-Total: 1
+X-Total-Pages: 1
+
+[
+   {
+      "should_remove_source_branch" : null,
+      "source_branch" : "mr-test",
+      "source_project_id" : 1342007,
+      "target_project_id" : 1342007,
+      "approvals_before_merge" : null,
+      "discussion_locked" : null,
+      "closed_at" : null,
+      "target_branch" : "master",
+      "user_notes_count" : 5,
+      "merged_by" : null,
+      "updated_at" : "2019-02-14T20:12:34.236Z",
+      "sha" : "3333333333333333333333333333333333333333",
+      "author" : {
+         "id" : 483414,
+         "username" : "k0nserv",
+         "web_url" : "https://gitlab.com/k0nserv",
+         "name" : "Hugo Tunius",
+         "state" : "active",
+         "avatar_url" : "https://secure.gravatar.com/avatar/7300342f996dcc9d4e22418cc9a70b14?s=80&d=identicon"
+      },
+      "upvotes" : 0,
+      "time_stats" : {
+         "human_time_estimate" : null,
+         "time_estimate" : 0,
+         "total_time_spent" : 0,
+         "human_total_time_spent" : null
+      },
+      "state" : "opened",
+      "merge_commit_sha" : null,
+      "reference" : "!1",
+      "merged_at" : null,
+      "merge_when_pipeline_succeeds" : false,
+      "force_remove_source_branch" : null,
+      "iid" : 1,
+      "web_url" : "https://gitlab.com/k0nserv/danger-test/merge_requests/1",
+      "description" : "The descriptions is here\r\n\r\n> Danger: ignore \"Developer specific files shouldn't be changed\"\r\n\r\n> Danger: ignore \"Testing\"",
+      "id" : 593728,
+      "created_at" : "2016-06-27T11:04:02.114Z",
+      "title" : "Add a",
+      "assignee" : null,
+      "squash" : false,
+      "closed_by" : null,
+      "project_id" : 1342007,
+      "downvotes" : 0,
+      "labels" : [
+         "test-label"
+      ],
+      "milestone" : null,
+      "merge_status" : "can_be_merged",
+      "work_in_progress" : false
+   }
+]

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -36,14 +36,31 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
       end
 
       context "when CI_COMMIT_SHA present in environment" do
-        it "uses gitlab api to find merge request id" do
-          stub_merge_requests("merge_requests_response", "k0nserv%2Fdanger-test")
+        context "before version 10.7" do
+          it "uses gitlab api to find merge request id" do
+            stub_version("10.6.4")
+            stub_merge_requests("merge_requests_response", "k0nserv%2Fdanger-test")
 
-          expect(described_class.determine_merge_request_id({
-            "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
-            "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
-            "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
-          })).to eq(3)
+            expect(described_class.determine_merge_request_id({
+              "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
+              "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
+              "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
+            })).to eq(3)
+          end
+        end
+        context "version 10.7 or later" do
+          it "uses gitlab api to find merge request id" do
+            #Arbitrary version, as tested manually, including text components to exercise the version comparison
+            stub_version("11.10.0-rc6-ee")
+            commit_sha = "3333333333333333333333333333333333333333"
+            stub_commit_merge_requests("commit_merge_requests", "k0nserv%2Fdanger-test", commit_sha)
+
+            expect(described_class.determine_merge_request_id({
+              "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
+              "CI_COMMIT_SHA" => commit_sha,
+              "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
+            })).to eq(1)
+          end
         end
       end
     end

--- a/spec/support/gitlab_helper.rb
+++ b/spec/support/gitlab_helper.rb
@@ -74,6 +74,13 @@ module Danger
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
       end
 
+      def stub_commit_merge_requests(fixture, slug, commit_sha)
+        raw_file = File.new("spec/fixtures/gitlab_api/#{fixture}.json")
+
+        url = "https://gitlab.com/api/v4/projects/#{slug}/repository/commits/#{commit_sha}/merge_requests?state=opened"
+        WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)
+      end
+
       def stub_version(version)
         url = "https://gitlab.com/api/v4/version"
         WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(


### PR DESCRIPTION
Original code queries all open PRs for the project, iterating over them looking for the one that has the commit SHA.  This can take quite some time if there are a lot of MRs open.  For example https://gitlab.com/gitlab-org/gitlab-ce/merge_requests has ~800 open MRs, which causes (@ 20 per page) 40 API requests to fetch, each doing an HTTPS connection setup, plus run-time, which really adds up.

Since GitLab 10.7 there is an API which will directly find/return any MRs for a given commit; this takes one API call, and is speedy.  This PR uses this new API, if GitLab is new enough.  