### PR TITLE
Fixed missing Unified diff headers for `gitlab.mr_diff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fixed missing Unified diff headers for `gitlab.mr_diff` due to a Gitlab API bug (See https://gitlab.com/gitlab-org/gitlab-ce/issues/53229).
+
 ## 6.0.5
 
 * Fixed error of GitLab inline comments @oboenikui, #1111

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -94,8 +94,15 @@ module Danger
 
       def mr_diff
         @mr_diff ||= begin
-          mr_changes
-            .changes.map { |change| change["diff"] }.join("\n")
+          diffs = mr_changes.changes.map do |change|
+            diff = change["diff"]
+            if diff.start_with?('--- a/')
+              diff
+            else
+              "--- a/#{change["old_path"]}\n+++ b/#{change["new_path"]}\n#{diff}"
+            end
+          end
+          diffs.join("\n")
         end
       end
 


### PR DESCRIPTION
Fixed missing Unified diff headers for `gitlab.mr_diff` due to a Gitlab API bug (See https://gitlab.com/gitlab-org/gitlab-ce/issues/53229).