### PR TITLE
Update faraday-http-cache dependency from 1.0 to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Update `faraday-http-cache` dependency from 1.0 to 2.0
+
 ## 6.0.6
 
 * Fixed missing Unified diff headers for `gitlab.mr_diff` due to a Gitlab API bug (See https://gitlab.com/gitlab-org/gitlab-ce/issues/53229).

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "git", "~> 1.5"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "faraday", "~> 0.9"
-  spec.add_runtime_dependency "faraday-http-cache", "~> 1.0"
+  spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
   spec.add_runtime_dependency "kramdown", "~> 2.0"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "octokit", "~> 4.7"


### PR DESCRIPTION
The version `2.0` of `faraday-http-cache` was released 3 years ago. Pinning Danger to the version `~> 1.0` of that gem makes it incompatible with other recent gems.