### PR TITLE
Update way to import Dangerfile from Gitlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Update `faraday-http-cache` dependency from 1.0 to 2.0
+* Fixed importing Dangerfile from Gitlab (uses Gitlab API now)
 
 ## 6.0.6
 

--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -76,8 +76,10 @@ module Danger
         warn "Use `import_dangerfile(github: '#{opts}')` instead of `import_dangerfile '#{opts}'`."
         import_dangerfile_from_github(opts)
       elsif opts.kind_of?(Hash)
-        if opts.key?(:github) || opts.key?(:gitlab)
-          import_dangerfile_from_github(opts[:github] || opts[:gitlab], opts[:branch], opts[:path])
+        if opts.key?(:github)
+          import_dangerfile_from_github(opts[:github], opts[:branch], opts[:path])
+        elsif opts.key?(:gitlab_project_id)
+          import_dangerfile_from_gitlab(opts[:gitlab_project_id], opts[:branch], opts[:path])
         elsif opts.key?(:path)
           import_dangerfile_from_path(opts[:path])
         elsif opts.key?(:gem)
@@ -157,6 +159,24 @@ module Danger
       raise "`import_dangerfile_from_github` requires a string" unless slug.kind_of?(String)
       org, repo = slug.split("/")
       download_url = env.request_source.file_url(organisation: org, repository: repo, branch: branch, path: path || "Dangerfile")
+      local_path = download(download_url)
+      @dangerfile.parse(Pathname.new(local_path))
+    end
+
+    # @!group Danger
+    # Download and execute a remote Dangerfile.
+    #
+    # @param    [Int] project_id
+    #           The id of the repo where the Dangerfile is.
+    # @param    [String] branch
+    #           A branch from repo where the Dangerfile is.
+    # @param    [String] path
+    #           The path at the repo where Dangerfile is.
+    # @return   [void]
+    #
+    def import_dangerfile_from_gitlab(project_id, branch = nil, path = nil)
+      raise "`import_dangerfile_from_gitlab` requires a integer" unless project_id.kind_of?(Integer)
+      download_url = env.request_source.file_url(repository: project_id, branch: branch, path: path || "Dangerfile")
       local_path = download(download_url)
       @dangerfile.parse(Pathname.new(local_path))
     end

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -297,8 +297,8 @@ module Danger
       # @return [String] A URL to the specific file, ready to be downloaded
       def file_url(organisation: nil, repository: nil, branch: nil, path: nil)
         branch ||= 'master'
-
-        "https://#{host}/#{organisation}/#{repository}/raw/#{branch}/#{path}"
+        token = @environment["DANGER_GITLAB_API_TOKEN"]
+        "#{endpoint}/projects/#{repository}/repository/files/#{path}/raw?ref=#{branch}&private_token=#{token}"
       end
 
       def regular_violations_group(warnings: [], errors: [], messages: [], markdowns: [])

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -90,18 +90,31 @@ RSpec.describe Danger::Dangerfile::DSL, host: :github do
       expect(dm.status_report[:messages]).to eq(["OK"])
     end
 
-    it "gitlab: 'repo/name'" do
-      outer_dangerfile = "danger.import_dangerfile(gitlab: 'example/example')"
+    context "Gitlab", host: :gitlab do
+      before do
+        allow_any_instance_of(Danger::GitRepo).to receive(:origins).and_return("https://gitlab.com/author/repo.github.io.git")
 
-      dm.parse(Pathname.new("."), outer_dangerfile)
-      expect(dm.status_report[:messages]).to eq(["OK"])
-    end
+        download_url = "https://gitlab.com/api/v4/projects/1/repository/files/Dangerfile/raw?private_token=a86e56d46ac78b&ref=master"
+        download_url_custom = "https://gitlab.com/api/v4/projects/1/repository/files/path/to/Dangerfile/raw?private_token=a86e56d46ac78b&ref=custom-branch"
+        mock_dangerfile = "message('OK')"
 
-    it "gitlab: 'repo/name', branch: 'custom-branch', path: 'path/to/Dangerfile'" do
-      outer_dangerfile = "danger.import_dangerfile(gitlab: 'example/example', branch: 'custom-branch', path: 'path/to/Dangerfile')"
+        stub_request(:get, download_url).to_return(status: 200, body: mock_dangerfile)
+        stub_request(:get, download_url_custom).to_return(status: 200, body: mock_dangerfile)
+      end
 
-      dm.parse(Pathname.new("."), outer_dangerfile)
-      expect(dm.status_report[:messages]).to eq(["OK"])
+      it "gitlab: 'repo/name'" do
+        outer_dangerfile = "danger.import_dangerfile(gitlab_project_id: 1)"
+
+        dm.parse(Pathname.new("."), outer_dangerfile)
+        expect(dm.status_report[:messages]).to eq(["OK"])
+      end
+
+      it "gitlab: 'repo/name', branch: 'custom-branch', path: 'path/to/Dangerfile'" do
+        outer_dangerfile = "danger.import_dangerfile(gitlab_project_id: 1, branch: 'custom-branch', path: 'path/to/Dangerfile')"
+
+        dm.parse(Pathname.new("."), outer_dangerfile)
+        expect(dm.status_report[:messages]).to eq(["OK"])
+      end
     end
 
     it "path: 'path'" do

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -452,18 +452,18 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
 
     describe "#file_url" do
       it "returns a valid URL with the minimum parameters" do
-        url = subject.file_url(organisation: "artsy", repository: "danger", path: "Dangerfile")
-        expect(url).to eq("https://gitlab.com/artsy/danger/raw/master/Dangerfile")
+        url = subject.file_url(repository: 1, path: "Dangerfile")
+        expect(url).to eq("https://gitlab.com/api/v4/projects/1/repository/files/Dangerfile/raw?ref=master&private_token=a86e56d46ac78b")
       end
 
       it "returns a valid URL with more parameters" do
-        url = subject.file_url(repository: "danger", organisation: "artsy", branch: "master", path: "path/Dangerfile")
-        expect(url).to eq("https://gitlab.com/artsy/danger/raw/master/path/Dangerfile")
+        url = subject.file_url(repository: 1, organisation: "artsy", branch: "develop", path: "path/Dangerfile")
+        expect(url).to eq("https://gitlab.com/api/v4/projects/1/repository/files/path/Dangerfile/raw?ref=develop&private_token=a86e56d46ac78b")
       end
 
       it "returns a valid fallback URL" do
-        url = subject.file_url(repository: "danger", organisation: "teapot", path: "Dangerfile")
-        expect(url).to eq("https://gitlab.com/teapot/danger/raw/master/Dangerfile")
+        url = subject.file_url(repository: 1, organisation: "teapot", path: "Dangerfile")
+        expect(url).to eq("https://gitlab.com/api/v4/projects/1/repository/files/Dangerfile/raw?ref=master&private_token=a86e56d46ac78b")
       end
     end
 


### PR DESCRIPTION
Gitlab added restrictions for security reasons, and you can no longer download a raw file without going through their API (Cf: https://gitlab.com/gitlab-org/gitlab-ce/issues/54572#note_120858359)
Therefore, using `danger.import_dangerfile(gitlab: "repo", path: 'Dangerfile')` would fail.
To fix this, in this PR, I updated the `file_url` for Gitlab request source, and updated the tests