### PR TITLE
Lets import dangerfiles on gitlab via its name again (instead of forcing a project_id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix regression introduced in 6.0.6 using import_dangerfile() for GitLab [@jk](https://github.com/jk) #1128 #1130
+
 ## 6.0.7
 
 * Update `faraday-http-cache` dependency from 1.0 to 2.0

--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -78,8 +78,8 @@ module Danger
       elsif opts.kind_of?(Hash)
         if opts.key?(:github)
           import_dangerfile_from_github(opts[:github], opts[:branch], opts[:path])
-        elsif opts.key?(:gitlab_project_id)
-          import_dangerfile_from_gitlab(opts[:gitlab_project_id], opts[:branch], opts[:path])
+        elsif opts.key?(:gitlab)
+          import_dangerfile_from_gitlab(opts[:gitlab], opts[:branch], opts[:path])
         elsif opts.key?(:path)
           import_dangerfile_from_path(opts[:path])
         elsif opts.key?(:gem)
@@ -166,17 +166,16 @@ module Danger
     # @!group Danger
     # Download and execute a remote Dangerfile.
     #
-    # @param    [Int] project_id
-    #           The id of the repo where the Dangerfile is.
+    # @param    [Int] slug_or_project_id
+    #           The slug or id of the repo where the Dangerfile is.
     # @param    [String] branch
     #           A branch from repo where the Dangerfile is.
     # @param    [String] path
     #           The path at the repo where Dangerfile is.
     # @return   [void]
     #
-    def import_dangerfile_from_gitlab(project_id, branch = nil, path = nil)
-      raise "`import_dangerfile_from_gitlab` requires a integer" unless project_id.kind_of?(Integer)
-      download_url = env.request_source.file_url(repository: project_id, branch: branch, path: path || "Dangerfile")
+    def import_dangerfile_from_gitlab(slug_or_project_id, branch = nil, path = nil)
+      download_url = env.request_source.file_url(repository: slug_or_project_id, branch: branch, path: path || "Dangerfile")
       local_path = download(download_url)
       @dangerfile.parse(Pathname.new(local_path))
     end

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -103,14 +103,14 @@ RSpec.describe Danger::Dangerfile::DSL, host: :github do
       end
 
       it "gitlab: 'repo/name'" do
-        outer_dangerfile = "danger.import_dangerfile(gitlab_project_id: 1)"
+        outer_dangerfile = "danger.import_dangerfile(gitlab: 1)"
 
         dm.parse(Pathname.new("."), outer_dangerfile)
         expect(dm.status_report[:messages]).to eq(["OK"])
       end
 
       it "gitlab: 'repo/name', branch: 'custom-branch', path: 'path/to/Dangerfile'" do
-        outer_dangerfile = "danger.import_dangerfile(gitlab_project_id: 1, branch: 'custom-branch', path: 'path/to/Dangerfile')"
+        outer_dangerfile = "danger.import_dangerfile(gitlab: 1, branch: 'custom-branch', path: 'path/to/Dangerfile')"
 
         dm.parse(Pathname.new("."), outer_dangerfile)
         expect(dm.status_report[:messages]).to eq(["OK"])


### PR DESCRIPTION
This PR fixes a regression introduced in #1128, reported in #1130.

It also reverts from using
```
danger.import_dangerfile(gitlab_project_id: 42)
```
back to 
```
danger.import_dangerfile(gitlab: 42)
danger.import_dangerfile(gitlab: "org/repo")
```

So now old Dangerfiles using `danger.import_dangerfile(gitlab: "")` will work again.