### PR TITLE
Fix branch_for_head api of Bitbucket cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## master
 
+## 6.0.9
+
+* Fixed branch_for_head API of Bitbucket cloud [@susan335](https://github.com/susan335) #1133
+
 ## 6.0.8
 
 * Fix regression introduced in 6.0.6 using import_dangerfile() for GitLab [@jk](https://github.com/jk) #1128 #1130

--- a/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_bitbucket_cloud_plugin.rb
@@ -121,7 +121,7 @@ module Danger
     # @return [String]
     #
     def branch_for_head
-      @bs.pr_json[:destination][:branch][:name]
+      @bs.pr_json[:source][:branch][:name]
     end
 
     # @!group PR Commit Metadata

--- a/spec/lib/danger/plugins/dangerfile_bitbucket_cloud_plugin_spec.rb
+++ b/spec/lib/danger/plugins/dangerfile_bitbucket_cloud_plugin_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Danger::DangerfileBitbucketCloudPlugin, host: :bitbucket_cloud do
 
     describe "#branch_for_head" do
       it "has a fetched branch for head" do
-        expect(plugin.branch_for_head).to eq("develop")
+        expect(plugin.branch_for_head).to eq("feature/test_danger")
       end
     end
 


### PR DESCRIPTION
`branch_for_head` and `branch_for_base` return a same value on Bitbucket cloud.

It is simple.
get the value from the same key in Json.