### PR TITLE
Fix Danger crash in Filelist include.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Fixes CircleCI integration for builds without associated Pull Request [@mvandervelden](https://github.com/mvandervelden) #1135
+* Fixes a crash in FileList include [@chemouna](https://github.com/chemouna)
 
 ## 6.0.11
 

--- a/lib/danger/core_ext/file_list.rb
+++ b/lib/danger/core_ext/file_list.rb
@@ -8,7 +8,9 @@ module Danger
     # e.g. "**/something.*" for any file called something with any extension
     def include?(pattern)
       self.each do |current|
-        return true if File.fnmatch(pattern, current) || pattern == current
+        unless current.nil?
+          return true if File.fnmatch(pattern, current) || pattern == current
+        end
       end
       return false
     end

--- a/spec/lib/danger/core_ext/file_list_spec.rb
+++ b/spec/lib/danger/core_ext/file_list_spec.rb
@@ -24,5 +24,9 @@ RSpec.describe Danger::FileList do
     it "returns false if nothing was found" do
       expect(@filelist.include?("notFound")).to eq(false)
     end
+    it "returns false if file path is nil" do
+      @filelist = Danger::FileList.new([nil])
+      expect(@filelist.include?("pattern")).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
We were getting this crash when using danger with danger-jacoco on an Android project.

doing the check for `current.nil?` fixes it, couldn't find if there's a specific input in our project that was triggering the crash but adding this check fixes it.

```
Traceback (most recent call last):
	28: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `<main>'
	27: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `eval'
	26: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/bin/danger:23:in `<main>'
	25: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/bin/danger:23:in `load'
	24: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/bin/danger:5:in `<top (required)>'
	23: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/claide-1.0.2/lib/claide/command.rb:334:in `run'
	22: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/commands/pr.rb:63:in `run'
	21: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/commands/local_helpers/local_setup.rb:43:in `setup'
	20: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/commands/pr.rb:64:in `block in run'
	19: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:273:in `run'
	18: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:197:in `parse'
	17: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:197:in `instance_eval'
	16: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:200:in `block in parse'
	15: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:297:in `eval_file'
	14: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:297:in `eval'
	13: from Dangerfile:23:in `eval_file'
	12: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-jacoco-0.1.4/lib/jacoco/plugin.rb:52:in `report'
	11: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/nokogiri-1.10.3/lib/nokogiri/xml/sax/parser.rb:81:in `parse'
	10: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/nokogiri-1.10.3/lib/nokogiri/xml/sax/parser.rb:93:in `parse_io'
	 9: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/nokogiri-1.10.3/lib/nokogiri/xml/sax/parser.rb:93:in `parse_with'
	 8: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/nokogiri-1.10.3/lib/nokogiri/xml/sax/document.rb:116:in `start_element_namespace'
	 7: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-jacoco-0.1.4/lib/jacoco/sax_parser.rb:19:in `start_element'
	 6: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-jacoco-0.1.4/lib/jacoco/sax_parser.rb:41:in `start_class'
	 5: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/core_ext/file_list.rb:10:in `include?'
	 4: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/helpers/array_subclass.rb:19:in `method_missing'
	 3: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/helpers/array_subclass.rb:49:in `respond_to_method'
	 2: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/helpers/array_subclass.rb:49:in `each'
	 1: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/core_ext/file_list.rb:11:in `block in include?'
/Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/core_ext/file_list.rb:11:in `fnmatch': no implicit conversion of nil into String (TypeError)
	28: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `<main>'
	27: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `eval'
	26: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/bin/danger:23:in `<main>'
	25: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/bin/danger:23:in `load'
	24: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/bin/danger:5:in `<top (required)>'
	23: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/claide-1.0.2/lib/claide/command.rb:334:in `run'
	22: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/commands/pr.rb:63:in `run'
	21: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/commands/local_helpers/local_setup.rb:43:in `setup'
	20: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/commands/pr.rb:64:in `block in run'
	19: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:273:in `run'
	18: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:197:in `parse'
	17: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:197:in `instance_eval'
	16: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:200:in `block in parse'
	15: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:297:in `eval_file'
	14: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:297:in `eval'
	13: from Dangerfile:23:in `eval_file'
	12: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-jacoco-0.1.4/lib/jacoco/plugin.rb:52:in `report'
	11: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/nokogiri-1.10.3/lib/nokogiri/xml/sax/parser.rb:81:in `parse'
	10: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/nokogiri-1.10.3/lib/nokogiri/xml/sax/parser.rb:93:in `parse_io'
	 9: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/nokogiri-1.10.3/lib/nokogiri/xml/sax/parser.rb:93:in `parse_with'
	 8: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/nokogiri-1.10.3/lib/nokogiri/xml/sax/document.rb:116:in `start_element_namespace'
	 7: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-jacoco-0.1.4/lib/jacoco/sax_parser.rb:19:in `start_element'
	 6: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-jacoco-0.1.4/lib/jacoco/sax_parser.rb:41:in `start_class'
	 5: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/core_ext/file_list.rb:10:in `include?'
	 4: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/helpers/array_subclass.rb:19:in `method_missing'
	 3: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/helpers/array_subclass.rb:49:in `respond_to_method'
	 2: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/helpers/array_subclass.rb:49:in `each'
	 1: from /Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/core_ext/file_list.rb:11:in `block in include?'
/Users/[redacted]/.rvm/gems/ruby-2.6.3/gems/danger-6.0.9/lib/danger/core_ext/file_list.rb:11:in `fnmatch':  (Danger::DSLError)
```