### PR TITLE
Fix typos across danger repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Fixes CircleCI integration for builds without associated Pull Request [@mvandervelden](https://github.com/mvandervelden) #1135
+* Fix typos across danger repository [@kittenking](https://github.com/kittenking) #1144
 
 ## 6.0.11
 

--- a/lib/danger/ci_source/vsts.rb
+++ b/lib/danger/ci_source/vsts.rb
@@ -4,7 +4,7 @@ require "danger/request_sources/vsts"
 module Danger
   # ### CI Setup
   #
-  # You need to go to your project's build definiton. Then add a "Command Line" Task with the "Tool" field set to  "bundle"
+  # You need to go to your project's build definition. Then add a "Command Line" Task with the "Tool" field set to  "bundle"
   # and the "Arguments" field set to "exec danger".
   #
   # ### Token Setup

--- a/lib/danger/commands/dangerfile/init.rb
+++ b/lib/danger/commands/dangerfile/init.rb
@@ -1,6 +1,6 @@
 require "danger/danger_core/dangerfile_generator"
 
-# Mainly so we can have a nice strucutre for commands
+# Mainly so we can have a nice structure for commands
 
 module Danger
   class DangerfileCommand < Runner

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -21,7 +21,7 @@ module Danger
       # Run some validations
       validate!(cork, fail_if_no_pr: fail_if_no_pr)
 
-      # OK, we now know that Danger can run in this enviroment
+      # OK, we now know that Danger can run in this environment
       env ||= EnvironmentManager.new(system_env, cork, danger_id)
       dm ||= Dangerfile.new(env, cork)
 

--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -2,7 +2,7 @@ require "danger/plugin_support/plugin"
 
 module Danger
   # A way to interact with Danger herself. Offering APIs to import plugins,
-  # and Dangerfiles from muliple sources.
+  # and Dangerfiles from multiple sources.
   #
   # @example Import a plugin available over HTTP
   #

--- a/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb
@@ -34,7 +34,7 @@ module Danger
   # @example Failing a build
   #
   #          failure "This build didn't pass tests"
-  #          failure "Ooops!", "Something bad happend"
+  #          failure "Ooops!", "Something bad happened"
   #          failure ["This is example", "with array"]
   #
   # @example Failing a build, and note that on subsequent runs

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -34,7 +34,7 @@ module Danger
       # request_source implementations are invited to override this method.
       # This is mostly here to enable sources to detect when inlines change only in their
       # commit hash and not in content per-se. since the link is implementation dependant
-      # so should be the comparision.
+      # so should be the comparison.
       #
       # @param [Violation or Markdown] m1
       # @param [Violation or Markdown] m2

--- a/lib/danger/plugin_support/plugin_parser.rb
+++ b/lib/danger/plugin_support/plugin_parser.rb
@@ -56,7 +56,7 @@ module Danger
 
       # Add some of our custom tags
       YARD::Tags::Library.define_tag('tags', :tags)
-      YARD::Tags::Library.define_tag('availablity', :availablity)
+      YARD::Tags::Library.define_tag('availability', :availability)
     end
 
     def parse

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -276,7 +276,7 @@ module Danger
           else
             # We remove non-sticky violations that have no replies
             # Since there's no direct concept of a reply in GH, we simply consider
-            # the existance of non-danger comments in that line as replies
+            # the existence of non-danger comments in that line as replies
             replies = non_danger_comments.select do |potential|
               potential["path"] == comment["path"] &&
                 potential["position"] == comment["position"] &&

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -360,7 +360,7 @@ module Danger
           else
             # We remove non-sticky violations that have no replies
             # Since there's no direct concept of a reply in GH, we simply consider
-            # the existance of non-danger comments in that line as replies
+            # the existence of non-danger comments in that line as replies
             replies = non_danger_comments.select do |potential|
               potential["path"] == comment["path"] &&
                 potential["position"] == comment["position"] &&

--- a/spec/fixtures/github_api/inline_comments_pr_diff.diff
+++ b/spec/fixtures/github_api/inline_comments_pr_diff.diff
@@ -428,7 +428,7 @@ index 0f96cd6..b5fa1d1 100644
 +      # request_source implementations are invited to override this method.
 +      # This is mostly here to enable sources to detect when inlines change only in their
 +      # commit hash and not in content per-se. since the link is implementation dependant
-+      # so should be the comparision.
++      # so should be the comparison.
 +      #
 +      # @param [Violation or Markdown] m1
 +      # @param [Violation or Markdown] m2
@@ -685,7 +685,7 @@ index b122911..e0aff3d 100644
 +          else
 +            # We remove non-sticky violations that have no replies
 +            # Since there's no direct concept of a reply in GH, we simply consider
-+            # the existance of non-danger comments in that line as replies
++            # the existence of non-danger comments in that line as replies
 +            replies = non_danger_comments.select do |potential|
 +              potential[:path] == comment[:path] &&
 +                potential[:position] == comment[:position] &&

--- a/spec/lib/danger/ci_sources/circle_api_spec.rb
+++ b/spec/lib/danger/ci_sources/circle_api_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Danger::CircleAPI do
     end
   end
 
-  it "uses CIRCLE_PR_NUMBER if avaliable" do
+  it "uses CIRCLE_PR_NUMBER if available" do
     env = {
       "CIRCLE_BUILD_NUM" => "1500",
       "DANGER_CIRCLE_CI_API_TOKEN" => "token2",

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
   end
 
   describe "#run" do
-    context "when exception occured" do
+    context "when exception occurred" do
       before { allow(Danger).to receive(:danger_outdated?).and_return(false) }
 
       it "updates PR with an error" do

--- a/spec/lib/danger/request_sources/bitbucket_server_api_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_server_api_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Danger::RequestSources::BitbucketServerAPI, host: :bitbucket_serv
       expect(api.send(:use_ssl)).to eq(true)
     end
     
-    it "post build successfull" do
+    it "post build successful" do
         allow(ENV).to receive(:[]).with("ENVDANGER_BITBUCKETSERVER_PASSWORD") { "supertopsecret" }
          stub_request(:post, "https://stash.example.com/rest/build-status/1.0/commits/04dede05fb802bf1e6c69782ae98592d29c03b80").
          with(:body => "{\"state\":\"SUCCESSFUL\",\"key\":\"danger\",\"url\":\"build_job_link\",\"description\":\"description\"}",


### PR DESCRIPTION
Fix typos across **danger repository**

### Fixed files

```
danger/lib/danger/ci_source/vsts.rb:7:43: "definiton" is a misspelling of "definition"
danger/lib/danger/commands/dangerfile/init.rb:3:31: "strucutre" is a misspelling of "structure"
danger/lib/danger/danger_core/executor.rb:24:52: "enviroment" is a misspelling of "environment"
danger/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb:5:25: "muliple" is a misspelling of "multiple"
danger/lib/danger/danger_core/plugins/dangerfile_messaging_plugin.rb:37:46: "happend" is a misspelling of "happened"
danger/lib/danger/helpers/comments_helper.rb:37:25: "comparision" is a misspelling of "comparison"
danger/lib/danger/plugin_support/plugin_parser.rb:59:53: "availablity" is a misspelling of "availability"
danger/lib/danger/request_sources/github/github.rb:279:18: "existance" is a misspelling of "existence"
danger/lib/danger/request_sources/gitlab.rb:363:18: "existance" is a misspelling of "existence"
danger/spec/fixtures/github_api/inline_comments_pr_diff.diff:431:26: "comparision" is a misspelling of "comparison"
danger/spec/fixtures/github_api/inline_comments_pr_diff.diff:688:19: "existance" is a misspelling of "existence"
danger/spec/lib/danger/ci_sources/circle_api_spec.rb:37:31: "avaliable" is a misspelling of "available"
danger/spec/lib/danger/danger_core/dangerfile_spec.rb:305:28: "occured" is a misspelling of "occurred"
danger/spec/lib/danger/request_sources/bitbucket_server_api_spec.rb:35:19: "successfull" is a misspelling of "successful"
```