### PR TITLE
Adds complex gitlab.api example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Add an example for gitlab.api on [reference](https://danger.systems/reference.html)
+
 ## 6.1.0
 
 * Fixes CircleCI integration for builds without associated Pull Request [@mvandervelden](https://github.com/mvandervelden) #1135

--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -53,6 +53,19 @@ module Danger
   #
   #         warn "#{gitlab.html_link("Package.json")} was edited." if git.modified_files.include? "Package.json"
   #
+  # @example Select a random group member as assignee if no assignee is selected
+  #
+  #         if gitlab.mr_json["assignee"].nil?
+  #           reviewer = gitlab.api.group_members(gitlab.api.merge_request_approvals(project_id, mr_id).to_hash["approver_groups"].first["group"]["id"]).sample
+  #           if gitlab.api.group_members(gitlab.api.merge_request_approvals(project_id, mr_id).to_hash["approver_groups"].first["group"]["id"]).length > 1
+  #             while reviewer.to_hash["id"] == gitlab.mr_json["author"]["id"] do
+  #               reviewer = gitlab.api.group_members(gitlab.api.merge_request_approvals(project_id, mr_id).to_hash["approver_groups"].first["group"]["id"]).sample
+  #             end
+  #           end
+  #           message "Reviewer roulete rolled for: #{reviewer.to_hash['name']} (@#{reviewer.to_hash['username']})"
+  #           gitlab.api.update_merge_request(project_id, mr_id, { assignee_id: reviewer.to_hash["id"] })
+  #         end
+  # 
   #
   # @see  danger/danger
   # @tags core, gitlab


### PR DESCRIPTION
This commit adds another example to [https://danger.systems/reference.html](https://danger.systems/reference.html).

Currently there is no example for the gitlab.api method. 
This is solved with this example.

