### PR TITLE
Change dangerfile_gitlab_plugin to rely on gitlab instead of the ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Add an example for gitlab.api on [reference](https://danger.systems/reference.html)
+* Fix `html_links` of `dangerfile_gitlab_plugin` for non `gitlab`/`jenkins` ci [@mfiebig](https://github.com/mfiebig) [#1157](https://github.com/danger/danger/pull/1157)
 
 ## 6.1.0
 

--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -193,6 +193,17 @@ module Danger
     end
 
     # @!group GitLab Misc
+    # Returns the web_url of the source project.
+    # @return [String]
+    #
+    def repository_web_url
+      @repository_web_url ||= begin
+        project = api.project(mr_json["source_project_id"])
+        project.web_url
+      end
+    end
+
+    # @!group GitLab Misc
     # Returns a list of HTML anchors for a file, or files in the head repository. An example would be:
     # `<a href='https://gitlab.com/artsy/eigen/blob/561827e46167077b5e53515b4b7349b8ae04610b/file.txt'>file.txt</a>`. It returns a string of multiple anchors if passed an array.
     # @param    [String or Array<String>] paths
@@ -209,7 +220,7 @@ module Danger
       paths = paths.map do |path|
         url_path = path.start_with?("/") ? path : "/#{path}"
         text = full_path ? path : File.basename(path)
-        create_link("#{env.ci_source.project_url}/blob/#{commit}#{url_path}", text)
+        create_link("#{repository_web_url}/blob/#{commit}#{url_path}", text)
       end
 
       return paths.first if paths.count < 2

--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -79,13 +79,34 @@ RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
   describe "#html_link" do
     it "should render a html link to the given file" do
       with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
+
         head_commit = "04e58de1fa97502d7e28c1394d471bb8fb1fc4a8";
         dangerfile.env.request_source.fetch_details
+
+        expect(plugin).to receive(:repository_web_url).
+          and_return("https://gitlab.com/k0nserv/danger-test")
 
         expect(plugin).to receive(:head_commit).
           and_return(head_commit)
 
         expect(plugin.html_link("CHANGELOG.md")).to eq("<a href='https://gitlab.com/k0nserv/danger-test/blob/#{head_commit}/CHANGELOG.md'>CHANGELOG.md</a>")
+      end
+    end
+  end
+
+  describe "repository_web_url" do
+    it "should request the project" do
+      with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
+
+        expect(plugin).to receive("mr_json").
+          and_return({:source_project_id => "15"})
+
+        project = Gitlab::ObjectifiedHash.new({:web_url => "https://gitlab.com/k0nserv/danger-test"})
+
+        expect(plugin.api).to receive("project").
+          and_return(project)
+
+        expect(plugin.repository_web_url).to eq("https://gitlab.com/k0nserv/danger-test")
       end
     end
   end


### PR DESCRIPTION
for creating links.

We use Teamcity in combination with a self hosted gitlab. While using the`danger-xcode_summary` gem we discovered that the `html_links` method of `dangerfile_gitlab_plugin.rb` would throw, due to `env.ci_source.project_url` not being defined for `Danger::TeamCity`

In this merge request I altered the method to use the Gitlab API to retrieve the correct `web_url` instead of relying on the underlying CI that triggered the build.

I tried to write tests, please let me know if they are appropriate, I had some trouble mocking the Gitlab API.

<details>
<summary>original errors stack trace</summary>
<pre>
Exit status of command 'bundle exec danger --dangerfile=Dangerfile --fail-on-errors=true' was 1 instead of 0.
/Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb:199:in `block in html_link': [31m (Danger::DSLError)
[!] Invalid `Dangerfile` file: undefined method `project_url' for #<Danger::TeamCity:0x00007fe0224832d0>[0m
 #  from Dangerfile:119
 #  -------------------------------------------
 #  #
 >  xcode_summary.report "./fastlane/test_output/xcpretty-json-formatter-results.json"
 #  warnings_and_errors_json = xcode_summary.warning_error_count "./fastlane/test_output/xcpretty-json-formatter-results.json"
 #  -------------------------------------------
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb:196:in `map'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb:196:in `html_link'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-xcode_summary-0.5.1/lib/xcode_summary/plugin.rb:221:in `format_path'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-xcode_summary-0.5.1/lib/xcode_summary/plugin.rb:253:in `format_compile_warning'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-xcode_summary-0.5.1/lib/xcode_summary/plugin.rb:171:in `block in warnings'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-xcode_summary-0.5.1/lib/xcode_summary/plugin.rb:170:in `map'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-xcode_summary-0.5.1/lib/xcode_summary/plugin.rb:170:in `warnings'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-xcode_summary-0.5.1/lib/xcode_summary/plugin.rb:136:in `format_summary'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-xcode_summary-0.5.1/lib/xcode_summary/plugin.rb:110:in `report'
 from Dangerfile:119:in `eval_file'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:297:in `eval'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:297:in `eval_file'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:200:in `block in parse'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:197:in `instance_eval'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:197:in `parse'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/dangerfile.rb:273:in `run'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/danger_core/executor.rb:29:in `run'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/lib/danger/commands/runner.rb:72:in `run'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/claide-1.0.2/lib/claide/command.rb:334:in `run'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/gems/danger-6.0.9/bin/danger:5:in `<top (required)>'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/bin/danger:23:in `load'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/bin/danger:23:in `<main>'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/bin/ruby_executable_hooks:24:in `eval'
 from /Users/teamcity/.rvm/gems/ruby-2.6.2/bin/ruby_executable_hooks:24:in `<main>'
</pre>
</details>