### PR TITLE
Use COPY instead of ADD, ENTRYPOINT instead of RUN, and use relative path in Github actions docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
 ADD ./Gemfile $APP_HOME/Gemfile
-ADD Gemfile.lock $APP_HOME/Gemfile.lock
+ADD ./Gemfile.lock $APP_HOME/Gemfile.lock
 
 RUN bundle install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ENV APP_HOME /myapp
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
-ADD ./Gemfile $APP_HOME/Gemfile
-ADD ./Gemfile.lock $APP_HOME/Gemfile.lock
+COPY ./Gemfile $APP_HOME/Gemfile
+COPY ./Gemfile.lock $APP_HOME/Gemfile.lock
 
 RUN bundle install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN bundle install
 
 COPY . $APP_HOME
 
-CMD bundle exec danger pr
+ENTRYPOINT ["bundle", "exec", "danger"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN mkdir /myapp
 WORKDIR /myapp
 COPY . /myapp
 
+RUN gem install bundler
 RUN bundle install
 ENTRYPOINT ["bundle", "exec", "danger"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,20 @@
 FROM ruby:2.5
 
-LABEL "com.github.actions.name"="Danger" \
-      "com.github.actions.description"="Runs danger in a docker container such as GitHub Actions" \
-      "com.github.actions.icon"="mic" \
-      "com.github.actions.color"="purple" \
-      "repository"="https://github.com/danger/danger" \
-      "homepage"="https://github.com/danger/danger" \
-      "maintainer"="Rishabh Tayal <rtayal11@gmail.com>"
+MAINTAINER Orta Therox
+
+LABEL "com.github.actions.name"="Danger" 
+LABEL "com.github.actions.description"="Runs danger in a docker container such as GitHub Actions"
+LABEL "com.github.actions.icon"="mic"
+LABEL "com.github.actions.color"="purple"
+LABEL "repository"="https://github.com/danger/danger"
+LABEL "homepage"="https://github.com/danger/danger"
+LABEL "maintainer"="Rishabh Tayal <rtayal11@gmail.com>"
 
 RUN apt-get update -qq && apt-get install -y build-essential p7zip unzip
 
-ENV APP_HOME /myapp
-RUN mkdir $APP_HOME
-WORKDIR $APP_HOME
-
-COPY ./Gemfile $APP_HOME/Gemfile
-COPY ./Gemfile.lock $APP_HOME/Gemfile.lock
+RUN mkdir /myapp
+WORKDIR /myapp
+COPY . /myapp
 
 RUN bundle install
-
-COPY . $APP_HOME
-
 ENTRYPOINT ["bundle", "exec", "danger"]


### PR DESCRIPTION
This attempts to fix the issue:

https://github.com/danger/danger/issues/1148

Of the code:
```
ADD ./Gemfile $APP_HOME/Gemfile
ADD Gemfile.lock $APP_HOME/Gemfile.lock
```

The first line goes smooth, but the second fails, which seems to confirm this comment: https://github.com/danger/danger/issues/1148#issuecomment-518532561 

This adds a relative path to the ADD command in the dockerfile