### PR TITLE
Add github enterprise support to CodeBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 
+* Fix CodeBuild to allow repo url which not ended `.git`
 * Add an example for gitlab.api on [reference](https://danger.systems/reference.html)
 * Fix `html_links` of `dangerfile_gitlab_plugin` for non `gitlab`/`jenkins` ci [@mfiebig](https://github.com/mfiebig) [#1157](https://github.com/danger/danger/pull/1157)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 
+* Add github enterprise support to CodeBuild
 * Fix CodeBuild to allow repo url which not ended `.git`
 * Add an example for gitlab.api on [reference](https://danger.systems/reference.html)
 * Fix `html_links` of `dangerfile_gitlab_plugin` for non `gitlab`/`jenkins` ci [@mfiebig](https://github.com/mfiebig) [#1157](https://github.com/danger/danger/pull/1157)

--- a/lib/danger/ci_source/code_build.rb
+++ b/lib/danger/ci_source/code_build.rb
@@ -30,28 +30,27 @@ module Danger
       self.repo_url = self.class.extract_repo_url(env)
     end
 
-    private
-      def self.extract_repo_slug(env)
-        return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
+    def self.extract_repo_slug(env)
+      return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
 
-        env["CODEBUILD_SOURCE_REPO_URL"].gsub(/^.*?github\.com\/(.*?)\.git$/, '\1')
-      end
+      env["CODEBUILD_SOURCE_REPO_URL"].gsub(%r{^.*?github\.com\/(.*?)\.git$}, '\1')
+    end
 
-      def self.extract_repo_url(env)
-        return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
+    def self.extract_repo_url(env)
+      return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
 
-        env["CODEBUILD_SOURCE_REPO_URL"].gsub(/\.git$/, "")
-      end
+      env["CODEBUILD_SOURCE_REPO_URL"].gsub(/\.git$/, "")
+    end
 
-      def self.extract_pr_url(env)
-        return nil unless env.key? "CODEBUILD_SOURCE_VERSION"
-        return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
-        return nil unless env["CODEBUILD_SOURCE_VERSION"].split("/").length == 2
+    def self.extract_pr_url(env)
+      return nil unless env.key? "CODEBUILD_SOURCE_VERSION"
+      return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
+      return nil unless env["CODEBUILD_SOURCE_VERSION"].split("/").length == 2
 
-        source_origin, pr_number = env["CODEBUILD_SOURCE_VERSION"].split("/")
-        github_repo_url = env["CODEBUILD_SOURCE_REPO_URL"].gsub(/\.git$/, "")
+      _source_origin, pr_number = env["CODEBUILD_SOURCE_VERSION"].split("/")
+      github_repo_url = env["CODEBUILD_SOURCE_REPO_URL"].gsub(/\.git$/, "")
 
-        "#{github_repo_url}/pull/#{pr_number}"
-      end
+      "#{github_repo_url}/pull/#{pr_number}"
+    end
   end
 end

--- a/lib/danger/ci_source/code_build.rb
+++ b/lib/danger/ci_source/code_build.rb
@@ -32,7 +32,7 @@ module Danger
     def self.extract_repo_slug(env)
       return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
 
-      env["CODEBUILD_SOURCE_REPO_URL"].gsub(%r{^.*?github\.com\/(.*?)\.git$}, '\1')
+      env["CODEBUILD_SOURCE_REPO_URL"].gsub(%r{^.*?github\.com\/(.*?)(\.git)?$}, '\1')
     end
 
     def self.extract_repo_url(env)

--- a/lib/danger/ci_source/code_build.rb
+++ b/lib/danger/ci_source/code_build.rb
@@ -32,7 +32,9 @@ module Danger
     def self.extract_repo_slug(env)
       return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
 
-      env["CODEBUILD_SOURCE_REPO_URL"].gsub(%r{^.*?github\.com\/(.*?)(\.git)?$}, '\1')
+      gh_host = env["DANGER_GITHUB_HOST"] || "github.com"
+
+      env["CODEBUILD_SOURCE_REPO_URL"].gsub(%r{^.*?#{Regexp.escape(gh_host)}\/(.*?)(\.git)?$}, '\1')
     end
 
     def self.extract_repo_url(env)

--- a/lib/danger/ci_source/code_build.rb
+++ b/lib/danger/ci_source/code_build.rb
@@ -16,8 +16,7 @@ module Danger
     end
 
     def self.validates_as_pr?(env)
-      return false unless url = self.extract_pr_url(env)
-      url
+      !!self.extract_pr_url(env)
     end
 
     def supported_request_sources
@@ -26,7 +25,7 @@ module Danger
 
     def initialize(env)
       self.repo_slug = self.class.extract_repo_slug(env)
-      self.pull_request_id = env["CODEBUILD_SOURCE_VERSION"].split("/")[1]
+      self.pull_request_id = env["CODEBUILD_SOURCE_VERSION"].split("/")[1].to_i
       self.repo_url = self.class.extract_repo_url(env)
     end
 

--- a/spec/lib/danger/ci_sources/code_build_spec.rb
+++ b/spec/lib/danger/ci_sources/code_build_spec.rb
@@ -1,0 +1,90 @@
+require "danger/ci_source/github_actions"
+
+RSpec.describe Danger::CodeBuild do
+  # CODEBUILD_SOURCE_VERSION=pr/2512 CODEBUILD_SOURCE_REPO_URL=https://github.o-in.dwango.co.jp/zane/zane-Soroban-web CODEBUILD_BUILD_ID=zane-soroban:cf613895-4a78-4456-8568-a53784fa75c5
+  let(:valid_env) do
+    {
+      "CODEBUILD_BUILD_ID" => "codebuild:cf613895-4a78-4456-8568-a53784fa75c5",
+      "CODEBUILD_SOURCE_VERSION" => "pr/1234",
+      "CODEBUILD_SOURCE_REPO_URL" => "https://github.com/danger/danger.git"
+    }
+  end
+
+  let(:source) { described_class.new(valid_env) }
+
+  context "with GitHub" do
+    describe ".validates_as_ci?" do
+      subject { described_class.validates_as_ci?(env) }
+      context "when required env variables are set" do
+        let(:env) { valid_env }
+
+        it "validates" do
+          is_expected.to be true
+        end
+      end
+
+      context "when required env variables are not set" do
+        let(:env) { {} }
+
+        it "doesn't validates" do
+          is_expected.to be false
+        end
+      end
+    end
+
+    describe ".validates_as_pr?" do
+      subject { described_class.validates_as_pr?(env) }
+      let(:env) { valid_env }
+
+      context "when `CODEBUILD_SOURCE_VERSION` like a 'pr/1234" do
+        let(:env) { valid_env.merge({ "CODEBUILD_SOURCE_VERSION" => "pr/1234" }) }
+
+        it "validates" do
+          is_expected.to be true
+        end
+      end
+
+      context "when `CODEBUILD_SOURCE_VERSION` is commit hash" do
+        let(:env) { valid_env.merge({ "CODEBUILD_SOURCE_VERSION" => "6548dbc49fe57e1fe7507a7a4b815639a62e9f90" }) }
+
+        it "doesn't validates" do
+          is_expected.to be false
+        end
+      end
+
+      context "when `CODEBUILD_SOURCE_VERSION` is missing" do
+        let(:env) { valid_env.tap { |e| e.delete("CODEBUILD_SOURCE_VERSION") } }
+
+        it "doesn't validates" do
+          is_expected.to be false
+        end
+      end
+    end
+  end
+
+  describe "#new" do
+    describe "repo slug" do
+      it "gets out a repo slug" do
+        expect(source.repo_slug).to eq("danger/danger")
+      end
+    end
+
+    describe "pull request id" do
+      it "get out a pull request id" do
+        expect(source.pull_request_id).to eq 1234
+      end
+    end
+
+    describe "repo url" do
+      it "get out a repo url" do
+        expect(source.repo_url).to eq "https://github.com/danger/danger"
+      end
+    end
+  end
+
+  describe "#supported_request_sources" do
+    it "supports GitHub" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::GitHub)
+    end
+  end
+end

--- a/spec/lib/danger/ci_sources/code_build_spec.rb
+++ b/spec/lib/danger/ci_sources/code_build_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe Danger::CodeBuild do
     {
       "CODEBUILD_BUILD_ID" => "codebuild:cf613895-4a78-4456-8568-a53784fa75c5",
       "CODEBUILD_SOURCE_VERSION" => "pr/1234",
-      "CODEBUILD_SOURCE_REPO_URL" => "https://github.com/danger/danger.git"
+      "CODEBUILD_SOURCE_REPO_URL" => source_repo_url
     }
   end
+
+  let(:source_repo_url) { "https://github.com/danger/danger.git" }
 
   let(:source) { described_class.new(valid_env) }
 
@@ -66,6 +68,14 @@ RSpec.describe Danger::CodeBuild do
     describe "repo slug" do
       it "gets out a repo slug" do
         expect(source.repo_slug).to eq("danger/danger")
+      end
+
+      context "when `CODEBUILD_SOURCE_REPO_URL` is not ended with '.git'" do
+        let(:source_repo_url) { "https://github.com/danger/danger" }
+
+        it "also gets out a repo slug" do
+          expect(source.repo_slug).to eq("danger/danger")
+        end
       end
     end
 

--- a/spec/lib/danger/ci_sources/code_build_spec.rb
+++ b/spec/lib/danger/ci_sources/code_build_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Danger::CodeBuild do
 
   let(:source_repo_url) { "https://github.com/danger/danger.git" }
 
-  let(:source) { described_class.new(valid_env) }
+  let(:env) { valid_env }
+  let(:source) { described_class.new(env) }
 
   context "with GitHub" do
     describe ".validates_as_ci?" do
@@ -72,6 +73,15 @@ RSpec.describe Danger::CodeBuild do
 
       context "when `CODEBUILD_SOURCE_REPO_URL` is not ended with '.git'" do
         let(:source_repo_url) { "https://github.com/danger/danger" }
+
+        it "also gets out a repo slug" do
+          expect(source.repo_slug).to eq("danger/danger")
+        end
+      end
+
+      context "when `CODEBUILD_SOURCE_REPO_URL` is hosted on github enterprise" do
+        let(:env) { valid_env.merge({ "DANGER_GITHUB_HOST" => "github.example.com" }) }
+        let(:source_repo_url) { "https://github.example.com/danger/danger" }
 
         it "also gets out a repo slug" do
           expect(source.repo_slug).to eq("danger/danger")


### PR DESCRIPTION
- Add spec test
- Change to allow source repo url which not ended with '.git'
  - it is valiable on code build
- Change to be able to handle host which likes github enterprise 
