### PR TITLE
Fix Danger::DangerfileGitLabPlugin spec

### DIFF
--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
         expect(plugin).to receive("mr_json").
           and_return({:source_project_id => "15"})
 
+        require "gitlab"
         project = Gitlab::ObjectifiedHash.new({:web_url => "https://gitlab.com/k0nserv/danger-test"})
 
         expect(plugin.api).to receive("project").


### PR DESCRIPTION
```
Failures:

  1) Danger::DangerfileGitLabPlugin repository_web_url should request the project
     Failure/Error: project = Gitlab::ObjectifiedHash.new({:web_url => "https://gitlab.com/k0nserv/danger-test"})

     NameError:
       uninitialized constant Gitlab
     # ./spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb:104:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:125:in `block (2 levels) in with_git_repo'
     # ./spec/spec_helper.rb:113:in `chdir'
     # ./spec/spec_helper.rb:113:in `block in with_git_repo'
     # ./spec/spec_helper.rb:112:in `with_git_repo'
     # ./spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb:99:in `block (3 levels) in <top (required)>'
```

not executed `require "gitlab"`

`require "gitlab"` is only here ↓

https://github.com/danger/danger/blob/597529b42e99eea06730a87137e6f3e3f009508a/lib/danger/request_sources/gitlab.rb#L31

and actually executed `require 'gitlab'` when calling `Danger::RequestSources::GitLab#client` for the first time.

If you look at the spec, you can see that it may not be executed `require "gitlab"` depending on the execution order.

https://github.com/danger/danger/blob/597529b42e99eea06730a87137e6f3e3f009508a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb#L98-L105

_sorry my poor English_