### PR TITLE
Fix wrong GitHub Pull Request identifier being used for Azure Pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix `html_links` of `dangerfile_gitlab_plugin` for non `gitlab`/`jenkins` ci [@mfiebig](https://github.com/mfiebig) [#1157](https://github.com/danger/danger/pull/1157)
 * Updated Semaphore to also work with Semaphore 2.0. [@gabrielrinaldi](https://github.com/gabrielrinaldi) [#1165](https://github.com/danger/danger/pull/1165)
 * adding documentation in bitrise.rb with respect to [#1164](https://github.com/danger/danger/issues/1164)
+* Fix GitHub Pull Request identifier in Azure Pipelines [@Dahlgren](https://github.com/Dahlgren)
 
 ## 6.1.0
 

--- a/lib/danger/ci_source/azure_pipelines.rb
+++ b/lib/danger/ci_source/azure_pipelines.rb
@@ -36,7 +36,7 @@ module Danger
     end
 
     def initialize(env)
-      self.pull_request_id = env["SYSTEM_PULLREQUEST_PULLREQUESTID"]
+      self.pull_request_id = env["SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"] || env["SYSTEM_PULLREQUEST_PULLREQUESTID"]
       self.repo_url = env["BUILD_REPOSITORY_URI"]
       self.repo_slug = env["BUILD_REPOSITORY_NAME"]
     end


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables

System.PullRequest.PullRequestNumber must be used for GitHub as System.PullRequest.PullRequestId contains a different identifier

Variables are uppercased and . are replaced with _ on Unix environments