### PR TITLE
Allow Danger to be run from a subfolder in a git repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 
+* Enable Danger to be run from a subfolder of a git repository [@scranen](https://github.com/scranen) [#1177](https://github.com/danger/danger/issues/1177)
 * Add github enterprise support to CodeBuild
 * Fix CodeBuild to allow repo url which not ended `.git`
 * Add an example for gitlab.api on [reference](https://danger.systems/reference.html)

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -257,7 +257,7 @@ module Danger
 
     def setup_for_running(base_branch, head_branch)
       env.ensure_danger_branches_are_setup
-      env.scm.diff_for_folder(".".freeze, from: base_branch, to: head_branch)
+      env.scm.diff_for_folder(".".freeze, from: base_branch, to: head_branch, lookup_top_level: true)
     end
 
     def run(base_branch, head_branch, dangerfile_path, danger_id, new_comment, remove_previous_comments)

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -6,9 +6,15 @@ module Danger
   class GitRepo
     attr_accessor :diff, :log, :folder
 
-    def diff_for_folder(folder, from: "master", to: "HEAD")
+    def diff_for_folder(folder, from: "master", to: "HEAD", lookup_top_level: false)
       self.folder = folder
-      repo = Git.open self.folder
+      git_top_level = folder
+      if lookup_top_level
+        Dir.chdir(folder) do
+          git_top_level = exec("rev-parse --show-toplevel")
+        end
+      end
+      repo = Git.open git_top_level
 
       ensure_commitish_exists!(from)
       ensure_commitish_exists!(to)

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm.env.scm.diff_for_folder(dir)
       end
     end
+
+    it "assumes the requested folder is the top level git folder by default" do
+      with_git_repo do |dir|
+        @dm = testing_dangerfile
+        expect do
+          @dm.env.scm.diff_for_folder(dir + '/subdir')
+        end.to raise_error(ArgumentError, /path does not exist/)
+      end
+    end
+
+    it "looks up the top level git folder when requested" do
+      with_git_repo do |dir|
+        @dm = testing_dangerfile
+        @dm.env.scm.diff_for_folder(dir + '/subdir', lookup_top_level: true)
+      end
+    end
   end
 
   describe "Return Types" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -122,6 +122,8 @@ def with_git_repo(origin: "git@github.com:artsy/eigen")
       `git commit -m "another"`
       `git remote add origin #{origin}`
 
+      Dir.mkdir(dir + "/subdir")
+
       yield dir
     end
   end


### PR DESCRIPTION
Addresses #1177. The idea is to enable Danger to be run from a subdirectory within a git repository without it complaining that the current path is not a git repository. Instead, it should do an educated guess about what we intended to do, and look up the top level git directory (by calling git).

To ensure backward compatibility, we only do this lookup in the special case that is currently causing Danger to fail (when doing the initial diff on `.`), but the functionality is exposed in `GitRepo` so is in principle reusable.

The two added tests serve to illustrate the new behaviour.