### PR TITLE
Update to Ruby-Git 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Fix Bitbucket Pipelines documentation
+* Update Ruby-Git to 1.6.0 to fix output encoding
 
 ## 6.2.0
 

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "claide", "~> 1.0"
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
-  spec.add_runtime_dependency "git", "~> 1.5"
+  spec.add_runtime_dependency "git", "~> 1.6"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"


### PR DESCRIPTION
Ruby-Git released a new version 1.6.0 after more than year and half. There is important change in output encoding that should be included in Danger sooner than later.

Update to Ruby-Git 1.6.0 (https://github.com/ruby-git/ruby-git/releases) that fixes output encoding https://github.com/ruby-git/ruby-git/pull/405

After merging this, it would be nice to release patch version 6.2.1 and also update releases page (currently missing not only 6.2.0) - https://github.com/danger/danger/releases. :)