### PR TITLE
Fix runtime errors in BitbucketCloud#delete_old_comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix incorrect method call in Bitbucket Cloud arising from my own changes in 6.2.1 [@telyn](https://github.com/telyn) [#1183](https://github.com/danger/danger/pull/1183)
+
 ## 6.2.1
 
 * Fix Bitbucket Pipelines documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 
-* Fix incorrect method call in Bitbucket Cloud arising from my own changes in 6.2.1 [@telyn](https://github.com/telyn) [#1183](https://github.com/danger/danger/pull/1183)
+* Fix incorrect method call in Bitbucket Cloud arising from my own changes in 6.2.1 [@telyn](https://github.com/telyn) [#1184](https://github.com/danger/danger/pull/1184)
 
 ## 6.2.1
 

--- a/lib/danger/request_sources/bitbucket_cloud.rb
+++ b/lib/danger/request_sources/bitbucket_cloud.rb
@@ -115,7 +115,7 @@ module Danger
       end
 
       def delete_old_comments(danger_id: "danger")
-        @api.fetch_last_comments.each do |c|
+        @api.fetch_comments.each do |c|
           next if c[:user][:uuid] != @api.my_uuid
           @api.delete_comment(c[:id]) if c[:content][:raw] =~ /generated_by_#{danger_id}/
         end

--- a/lib/danger/request_sources/bitbucket_cloud_api.rb
+++ b/lib/danger/request_sources/bitbucket_cloud_api.rb
@@ -48,12 +48,13 @@ module Danger
         values = []
         # TODO: use a url parts encoder to encode the query
         uri = "#{pr_api_endpoint}/comments?pagelen=100&q=deleted+%7E+false+AND+user.username+%7E+%22#{@username}%22"
-        while(uri)
+
+        while uri
           json = fetch_json(URI(uri))
           values += json[:values]
           uri = json[:next]
-          values
         end
+        values
       end
 
       def delete_comment(id)

--- a/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud
       expect(api.host).to eq("https://bitbucket.org/")
     end
   end
-  
+
   describe "#credentials_given" do
     it "#fetch_json raise error when missing credentials" do
       empty_env = {}


### PR DESCRIPTION
I had renamed BitbucketCloudAPI#fetch_last_comments, but neglected to refactor its use in BitbucketCloud. And I also broke the while loop I wrote, despite having had it working at some point. A touch embarrassing - sorry for the extra work! I should've waited until today to have a quick re-test and then submit my PR, rather than pushing ahead at 9PM