### PR TITLE
Changed regex pattern for repo_url match

### DIFF
--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -25,7 +25,7 @@ module Danger
   # finding the project and repo slug in the GIT_REPOSITORY_URL variable. This GIT_REPOSITORY_URL variable 
   # comes from the App Settings tab for your Bitrsie App. If you are manually setting a repo URL in the 
   # Git Clone Repo step, you may need to set adjust this propery in the settings tab, maybe even fake it.
-  # The pattern used is `(%r{([\/:])(([^\/]+\/){1,2}[^\/]+?)(\.git$|$)}`.
+  # The pattern used is `(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)}`.
   #
   class Bitrise < CI
     def self.validates_as_ci?(env)
@@ -49,7 +49,7 @@ module Danger
       self.pull_request_id = env["BITRISE_PULL_REQUEST"]
       self.repo_url = env["GIT_REPOSITORY_URL"]
 
-      repo_matches = self.repo_url.match(%r{([\/:])(([^\/]+\/){1,2}[^\/]+?)(\.git$|$)})
+      repo_matches = self.repo_url.match(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)})
       self.repo_slug = repo_matches[2] unless repo_matches.nil?
     end
   end


### PR DESCRIPTION
Previous regex pattern was not suitable for GitLab Repo URL. Now it is suitable for both GitHub and GitLab

///////////////////⚡///////////////////

# 🚫 AWESOME A PR!

- You can just delete all of this and start your PR text anytime -

Hello there, just a quick pre-warning of some of the Danger rules we run on Danger PRs.

The big one is we request that every code change to Danger include a CHANGELOG entry, 
this is so that:

1. People know what changes are between versions
2. Orta doesn't get all the credit for other people's work

Danger will look for a modification to the `CHANGELOG.md` when there are changes including
`lib/*` - if you're fixing unreleased code, or doing a simple typo change, you can
include `#trivial` in the title or the body of the PR and this is skipped.

We also request that you fill in the body of your PR, a title should be tweet length, but
ideally you can explain the PRs reasoning in the body. We look that it's longer than 5 chars.

Other than that, a lot of the other Danger rules are trickier to trigger so we can address
them as they come up!

❤ THANKS FOR HELPING OUT :D 

///////////////////⚡///////////////////