### PR TITLE
Updated RegEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix RegEx pattern used to match URL.
+
 ## 6.2.2
 
 * Fix incorrect method call in Bitbucket Cloud arising from my own changes in 6.2.1 [@telyn](https://github.com/telyn) [#1184](https://github.com/danger/danger/pull/1184)

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -48,9 +48,15 @@ module Danger
     def initialize(env)
       self.pull_request_id = env["BITRISE_PULL_REQUEST"]
       self.repo_url = env["GIT_REPOSITORY_URL"]
-
-      repo_matches = self.repo_url.match(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)})
-      self.repo_slug = repo_matches[2] unless repo_matches.nil?
+  
+      if repo_url.include? ".com/"
+        repo_matches = self.repo_url.match(%r{\.com/(.*)})[1]
+      elsif repo_url.include? ".com:"
+        repo_matches = self.repo_url.match(%r{\.com:(.*)})[1]
+      end
+      
+      self.repo_slug = repo_matches unless repo_matches.nil?
+      
     end
   end
 end

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -25,7 +25,7 @@ module Danger
   # finding the project and repo slug in the GIT_REPOSITORY_URL variable. This GIT_REPOSITORY_URL variable 
   # comes from the App Settings tab for your Bitrsie App. If you are manually setting a repo URL in the 
   # Git Clone Repo step, you may need to set adjust this propery in the settings tab, maybe even fake it.
-  # The pattern used is `(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)}`.
+  # The patterns used are `(%r{\.com/(.*)})` and `(%r{\.com:(.*)})` .
   #
   class Bitrise < CI
     def self.validates_as_ci?(env)

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -25,7 +25,7 @@ module Danger
   # finding the project and repo slug in the GIT_REPOSITORY_URL variable. This GIT_REPOSITORY_URL variable 
   # comes from the App Settings tab for your Bitrsie App. If you are manually setting a repo URL in the 
   # Git Clone Repo step, you may need to set adjust this propery in the settings tab, maybe even fake it.
-  # The pattern used is `(%r{([\/:])(([^\/]+\/){1,2}[^\/]+?)(\.git$|$)}`.
+  # The pattern used is `(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)}`.
   #
   class Bitrise < CI
     def self.validates_as_ci?(env)
@@ -49,7 +49,7 @@ module Danger
       self.pull_request_id = env["BITRISE_PULL_REQUEST"]
       self.repo_url = env["GIT_REPOSITORY_URL"]
 
-      repo_matches = self.repo_url.match(%r{([\/:])(([^\/]+\/){1,2}[^\/]+?)(\.git$|$)})
+      repo_matches = self.repo_url.match(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)})
       self.repo_slug = repo_matches[2] unless repo_matches.nil?
     end
   end


### PR DESCRIPTION
Previous regex pattern does not work if the URL consists of more than 2 subgroups. 

For example : git@git.com:xxxxx/xxxxx/project works fine.

However, if it is more than 2 subgroups then the url becomes
git@git.com:xxxxx/xxxxx/xxxxx/project in this case it fails. 

For the URL match there are 2 cases:

1. ':' after '.com' 
2. '/' after '.com'

I have added 2 if conditions that will use the appropriate RegEx pattern for each of the cases.
