### PR TITLE
Show correct error when GitLab Gem can't be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 ## master
 
 * Fix RegEx pattern used to match URL.
+* Show correct error when GitLab Gem can't be loaded [@glensc], [#1191], [#1192]
+
+[#1192]: https://github.com/danger/danger/pull/1192
+[#1191]: https://github.com/danger/danger/issues/1191
 
 ## 6.2.2
 
@@ -1253,6 +1257,5 @@ I don't like breaking backwards comparability. Sorry, for as far as I can see at
 * Gets PR details from GitHub - orta
 * Gets Git details from local Git - orta
 * Fails when you say it's failed in  the  Dangerfile - orta
-
 
 [@glensc]: https://github.com/glensc

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -36,9 +36,13 @@ module Danger
         require "gitlab"
 
         @client ||= Gitlab.client(endpoint: endpoint, private_token: token)
-      rescue LoadError
-        puts "The GitLab gem was not installed, you will need to change your Gem from `danger` to `danger-gitlab`.".red
-        puts "\n - See https://github.com/danger/danger/blob/master/CHANGELOG.md#400"
+      rescue LoadError => e
+        if e.path == "gitlab"
+          puts "The GitLab gem was not installed, you will need to change your Gem from `danger` to `danger-gitlab`.".red
+          puts "\n - See https://github.com/danger/danger/blob/master/CHANGELOG.md#400"
+        else
+          puts "Error: #{e}".red
+        end
         abort
       end
 


### PR DESCRIPTION
Fixes https://github.com/danger/danger/issues/1191:

The previous logic did hide actual load error based on bad assumptions:

New error shows what (other) modules could have failed to load:
```
/app # danger
Error: cannot load such file -- bigdecimal
/app #
```