### PR TITLE
Fix Danger::RequestSources::GitLab#setup_danger_branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Fix RegEx pattern used to match URL.
+* Fix for GitLab Pipelines for Merge Results. [@rymai](https://github.com/rymai) [#1194](https://github.com/danger/danger/pull/1194)
 
 ## 6.2.2
 

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -122,11 +122,11 @@ module Danger
       end
 
       def setup_danger_branches
+        # we can use a GitLab specific feature here:
         base_branch = self.mr_json.source_branch
+        base_commit = self.mr_json.diff_refs.base_sha
         head_branch = self.mr_json.target_branch
-        head_commit = self.scm.head_commit
-
-        raise "Are you running `danger local/pr` against the correct repository? Also this can happen if you run danger on MR without changes" if base_commit == head_commit
+        head_commit = self.mr_json.diff_refs.head_sha
 
         # Next, we want to ensure that we have a version of the current branch at a known location
         scm.ensure_commitish_exists_on_branch! base_branch, base_commit
@@ -512,4 +512,3 @@ module Danger
     end
   end
 end
-

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -118,34 +118,22 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
       expect(subject.base_commit).to eq("0e4db308b6579f7cc733e5a354e026b272e1c076")
     end
 
-    it "raise error on empty MR" do
-      subject.fetch_details
-
-      expect(subject.scm).to receive(:head_commit).
-        and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
-      expect(subject).to receive(:base_commit).
-        and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
-
-      expect { subject.setup_danger_branches }.to raise_error("Are you running `danger local/pr` against the correct repository? Also this can happen if you run danger on MR without changes")
-    end
-
     it "setups the danger branches" do
       subject.fetch_details
 
-      expect(subject.scm).to receive(:head_commit).
-        and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
-      expect(subject).to receive(:base_commit).
-        and_return("0e4db308b6579f7cc733e5a354e026b272e1c076").thrice
-      expect(subject.scm).to receive(:exec)
-        .with("rev-parse --quiet --verify 345e74fabb2fecea93091e8925b1a7a208b48ba6^{commit}")
-        .and_return("345e74fabb2fecea93091e8925b1a7a208b48ba6")
-      expect(subject.scm).to receive(:exec)
-        .with("branch danger_head 345e74fabb2fecea93091e8925b1a7a208b48ba6")
       expect(subject.scm).to receive(:exec)
         .with("rev-parse --quiet --verify 0e4db308b6579f7cc733e5a354e026b272e1c076^{commit}")
         .and_return("0e4db308b6579f7cc733e5a354e026b272e1c076")
+
       expect(subject.scm).to receive(:exec)
         .with("branch danger_base 0e4db308b6579f7cc733e5a354e026b272e1c076")
+
+      expect(subject.scm).to receive(:exec)
+        .with("rev-parse --quiet --verify 04e58de1fa97502d7e28c1394d471bb8fb1fc4a8^{commit}")
+        .and_return("04e58de1fa97502d7e28c1394d471bb8fb1fc4a8")
+
+      expect(subject.scm).to receive(:exec)
+        .with("branch danger_head 04e58de1fa97502d7e28c1394d471bb8fb1fc4a8")
 
       subject.setup_danger_branches
     end
@@ -339,9 +327,9 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
 
           expect(subject.client).to receive(:create_merge_request_discussion)
           allow(subject.client).to receive(:delete_merge_request_comment)
-  
+
           subject.fetch_details
-  
+
           v = Danger::Violation.new("Sure thing", true, "a", 4)
           subject.update_pull_request!(warnings: [], errors: [], messages: [v])
         end
@@ -446,7 +434,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
           subject.fetch_details
           subject.update_pull_request!(warnings: [v], errors: [], messages: [])
         end
-  
+
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/danger/danger/issues/1193.

///////////////////⚡///////////////////

# 🚫 AWESOME A PR!

- You can just delete all of this and start your PR text anytime -

Hello there, just a quick pre-warning of some of the Danger rules we run on Danger PRs.

The big one is we request that every code change to Danger include a CHANGELOG entry, 
this is so that:

1. People know what changes are between versions
2. Orta doesn't get all the credit for other people's work

Danger will look for a modification to the `CHANGELOG.md` when there are changes including
`lib/*` - if you're fixing unreleased code, or doing a simple typo change, you can
include `#trivial` in the title or the body of the PR and this is skipped.

We also request that you fill in the body of your PR, a title should be tweet length, but
ideally you can explain the PRs reasoning in the body. We look that it's longer than 5 chars.

Other than that, a lot of the other Danger rules are trickier to trigger so we can address
them as they come up!

❤ THANKS FOR HELPING OUT :D 

///////////////////⚡///////////////////