### PR TITLE
Remove ".git" at the end of the project URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ## master
 
-* Update RegEx pattern used to match URL even if it contains ".git"
 * Fix RegEx pattern used to match URL.
 
 ## 6.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 
+* Update RegEx pattern used to match URL even if it contains ".git"
 * Fix RegEx pattern used to match URL.
 
 ## 6.2.2

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -25,8 +25,8 @@ module Danger
   # finding the project and repo slug in the GIT_REPOSITORY_URL variable. This GIT_REPOSITORY_URL variable 
   # comes from the App Settings tab for your Bitrsie App. If you are manually setting a repo URL in the 
   # Git Clone Repo step, you may need to set adjust this propery in the settings tab, maybe even fake it.
-  # The patterns used are `(%r{\.com/(.*)})` and `(%r{\.com:(.*)})` .
-  #
+  # The patterns used are `(%r{\.com/(.*)})` and `(%r{\.com:(.*)})` and .split(".git") to remove ".git" if the URL contains it.
+  # 
   class Bitrise < CI
     def self.validates_as_ci?(env)
       env.key? "BITRISE_IO"

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -50,9 +50,9 @@ module Danger
       self.repo_url = env["GIT_REPOSITORY_URL"]
   
       if repo_url.include? ".com/"
-        repo_matches = self.repo_url.match(%r{\.com/(.*)})[1]
+        repo_matches = self.repo_url.match(%r{\.com/(.*)})[1].split(".git")[0]
       elsif repo_url.include? ".com:"
-        repo_matches = self.repo_url.match(%r{\.com:(.*)})[1]
+        repo_matches = self.repo_url.match(%r{\.com:(.*)})[1].split(".git")[0]
       end
       
       self.repo_slug = repo_matches unless repo_matches.nil?

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -25,7 +25,7 @@ module Danger
   # finding the project and repo slug in the GIT_REPOSITORY_URL variable. This GIT_REPOSITORY_URL variable 
   # comes from the App Settings tab for your Bitrsie App. If you are manually setting a repo URL in the 
   # Git Clone Repo step, you may need to set adjust this propery in the settings tab, maybe even fake it.
-  # The patterns used are `(%r{\.com/(.*)})` and `(%r{\.com:(.*)})` and .split(".git") to remove ".git" if the URL contains it.
+  # The patterns used are `(%r{\.com/(.*)})` and `(%r{\.com:(.*)})` and .split(/\.git$|$/) to remove ".git" if the URL contains it.
   # 
   class Bitrise < CI
     def self.validates_as_ci?(env)
@@ -50,9 +50,9 @@ module Danger
       self.repo_url = env["GIT_REPOSITORY_URL"]
   
       if repo_url.include? ".com/"
-        repo_matches = self.repo_url.match(%r{\.com/(.*)})[1].split(".git")[0]
+        repo_matches = self.repo_url.match(%r{\.com/(.*)})[1].split(/\.git$|$/)[0]
       elsif repo_url.include? ".com:"
-        repo_matches = self.repo_url.match(%r{\.com:(.*)})[1].split(".git")[0]
+        repo_matches = self.repo_url.match(%r{\.com:(.*)})[1].split(/\.git$|$/)[0]
       end
       
       self.repo_slug = repo_matches unless repo_matches.nil?

--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe Danger::Bitrise do
 
     it "sets the repo_slug from a repo with two or more slashes in it", host: :github do
       valid_env["GIT_REPOSITORY_URL"] = "git@github.com:artsy/mobile/ios/artsy.github.io"
-      expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
+      expect(source.repo_slug).to eq("artsy/mobile/ios/artsy.github.io")
     end
     
     it "sets the repo_slug from a repo with .git in it", host: :github do
       valid_env["GIT_REPOSITORY_URL"] = "git@github.com:artsy/mobile/ios/artsy.github.io.git"
-      expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
+      expect(source.repo_slug).to eq("artsy/mobile/ios/artsy.github.io")
     end
 
     it "sets the repo_slug from a repo https url", host: :github do

--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -57,13 +57,23 @@ RSpec.describe Danger::Bitrise do
       expect(source.repo_slug).to eq("artsy/artsy.github.io")
     end
 
-    it "sets the repo_slug from a repo with two slashes in it", host: :github do
-      valid_env["GIT_REPOSITORY_URL"] = "git@github.com:artsy/ios/artsy.github.io"
+    it "sets the repo_slug from a repo with two or more slashes in it", host: :github do
+      valid_env["GIT_REPOSITORY_URL"] = "git@github.com:artsy/mobile/ios/artsy.github.io"
+      expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
+    end
+    
+    it "sets the repo_slug from a repo with .git in it", host: :github do
+      valid_env["GIT_REPOSITORY_URL"] = "git@github.com:artsy/mobile/ios/artsy.github.io.git"
       expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
     end
 
     it "sets the repo_slug from a repo https url", host: :github do
       valid_env["GIT_REPOSITORY_URL"] = "https://github.com/artsy/ios/artsy.github.io"
+      expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
+    end
+    
+    it "sets the repo_slug from a repo https url with .git in it", host: :github do
+      valid_env["GIT_REPOSITORY_URL"] = "https://github.com/artsy/ios/artsy.github.io.git"
       expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
     end
 


### PR DESCRIPTION
If the Git Repo URL contains ".git", we get the following error
 *Gitlab::Error::NotFound: Server responded with code 404, message: 404 Project Not Found.* 
As the URL should not contain ".git" at the end.

