### PR TITLE
Fix typo from environemnt -> environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix typo from environemnt -> environment
+
 ## 6.3.1
 
 * Remove ".git" at the end of project URL for bitrise projects. [@RonaldPrithiv](https://github.com/RonaldPrithiv)

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -21,7 +21,7 @@ module Danger
   #
   # ### bitbucket server and bitrsie
   #
-  # Danger will read the environemnt variable GIT_REPOSITORY_URL to construct the Bitbucket Server API URL 
+  # Danger will read the environment variable GIT_REPOSITORY_URL to construct the Bitbucket Server API URL 
   # finding the project and repo slug in the GIT_REPOSITORY_URL variable. This GIT_REPOSITORY_URL variable 
   # comes from the App Settings tab for your Bitrsie App. If you are manually setting a repo URL in the 
   # Git Clone Repo step, you may need to set adjust this propery in the settings tab, maybe even fake it.


### PR DESCRIPTION
**Fix typo from environemnt -> environment**

```
danger/lib/danger/ci_source/bitrise.rb:24:25: "environemnt" is a misspelling of "environment"
```