### PR TITLE
Added support to git.info_for_file for added and deleted files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 
+* Added support to git.info_for_file for added and deleted files. [@ethan-riback](https://github.com/ethan-riback) [#1216](https://github.com/danger/danger/pull/1216)
 * Allow danger to run with Faraday 1.0.0.
 * Allow github repository redirects to be followed. [@telyn] [#1209](https://github.com/danger/danger/pull/1209)
 

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -136,14 +136,14 @@ module Danger
     # @return [Hash] with keys `:insertions`, `:deletions` giving line counts, and `:before`, `:after` giving file contents, or nil if the file has no changes or does not exist
     #
     def info_for_file(file)
-      return nil unless modified_files.include?(file)
+      return nil unless modified_files.include?(file) || added_files.include?(file) || deleted_files.include?(file)
       stats = @git.diff.stats[:files][file]
       diff = @git.diff[file]
       {
         insertions: stats[:insertions],
         deletions: stats[:deletions],
-        before: diff.blob(:src).contents,
-        after: diff.blob(:dst).contents
+        before: added_files.include?(file) || deleted_files.include?(file) ? nil : diff.blob(:src).contents,
+        after: added_files.include?(file) || deleted_files.include?(file) ? nil : diff.blob(:dst).contents
       }
     end
 


### PR DESCRIPTION
Problem: As a developer I needed a way to check the link length of added and deleted files.

Solution: Update [`info_for_file`](https://github.com/danger/danger/blob/master/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb#L138) to check against `added_files` and `deleted_files`. If the file was added, insertions would be the file size and deletions would be 0. If the file was deleted, insertions would be 0 and deletions would be the file size.

This pull request addresses issue https://github.com/danger/danger/issues/1215. Strictly having been a mobile developer my professional life and having rarely touched Ruby, I had no idea if I could address this on my own. But when my issue was labeled "You Can Do This", I thought "you know what, I can"! So thanks for the motivation! I hope this PR covers what is needed.

Note: I was unsure if we should define a value for `before:` or `after:`. `diff.blob(:src).contents` and `diff.blob(:dst)` both error when using added or deleted files so for now these fields are made `nil` under the new circumstances.