### PR TITLE
Fix #1213 - username-related 404 on Bitbucket Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 * Allow danger to run with Faraday 1.0.0.
 * Allow github repository redirects to be followed. [@telyn] [#1209](https://github.com/danger/danger/pull/1209)
+* Fix 404 on Bitbucket Cloud fetching `/users/$DANGER_BITBUCKETCLOUD_USERNAME`.
+  This fix requires that everyone using Bitbucket Cloud now provides the
+  `DANGER_BITBUCKETCLOUD_UUID` environment variable containing the UUID of
+   danger's user on bitbucket (with or without the `{}` braces). See
+   [this blog post from Atlassian](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#removal-of-usernames-from-user-referencing-apis)
+   for details on the change Atlassian made which broke Danger. [@telyn] [#1217](https://github.com/danger/danger/pull/1217)
 
 ## 6.3.2
 

--- a/lib/danger/request_sources/bitbucket_cloud.rb
+++ b/lib/danger/request_sources/bitbucket_cloud.rb
@@ -12,6 +12,7 @@ module Danger
       def self.env_vars
         [
           "DANGER_BITBUCKETCLOUD_USERNAME",
+          "DANGER_BITBUCKETCLOUD_UUID",
           "DANGER_BITBUCKETCLOUD_PASSWORD"
         ]
       end

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
         danger_em.raise_error_for_no_request_source(req_src_env, ui)
       end.to raise_error(SystemExit)
 
-      expect(ui.string).to include("For your BitbucketCloud repo, you need to expose: DANGER_BITBUCKETCLOUD_USERNAME, DANGER_BITBUCKETCLOUD_PASSWORD")
+      expect(ui.string).to include("For your BitbucketCloud repo, you need to expose: DANGER_BITBUCKETCLOUD_USERNAME, DANGER_BITBUCKETCLOUD_UUID, DANGER_BITBUCKETCLOUD_PASSWORD")
     end
 
     it "handles throwing out all kinds of info when the repo url isnt recognised" do
@@ -410,7 +410,7 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
         " - GitHub: DANGER_GITHUB_API_TOKEN",
         " - GitLab: DANGER_GITLAB_API_TOKEN",
         " - BitbucketServer: DANGER_BITBUCKETSERVER_USERNAME, DANGER_BITBUCKETSERVER_PASSWORD, DANGER_BITBUCKETSERVER_HOST",
-        " - BitbucketCloud: DANGER_BITBUCKETCLOUD_USERNAME, DANGER_BITBUCKETCLOUD_PASSWORD"
+        " - BitbucketCloud: DANGER_BITBUCKETCLOUD_USERNAME, DANGER_BITBUCKETCLOUD_UUID, DANGER_BITBUCKETCLOUD_PASSWORD"
       ]
       messages.each do |m|
         expect(ui.string).to include(m)

--- a/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
@@ -1,11 +1,15 @@
 require "danger/request_sources/bitbucket_cloud_api"
 
 RSpec.describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud do
+  subject(:api) { described_class.new(repo, pr_id, branch, env) }
+  let(:repo) { "ios/fancyapp" }
+  let(:pr_id) { 1 }
+  let(:branch) { "feature_branch" }
+  let(:env) { stub_env }
+
   describe "#inspect" do
     it "masks password on inspect" do
       allow(ENV).to receive(:[]).with("ENVDANGER_BITBUCKETCLOUD_PASSWORD") { "supertopsecret" }
-      api = described_class.new("danger/danger", 1, nil, stub_env)
-
       inspected = api.inspect
 
       expect(inspected).to include(%(@password="********"))
@@ -13,90 +17,115 @@ RSpec.describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud
   end
 
   describe "#project" do
-    it "gets set from repo_slug" do
-      api = described_class.new("org/repo", 1, nil, stub_env)
+    let(:repo) { "org/repo" }
 
+    it "gets set from repo_slug" do
       expect(api.project).to eq("org")
     end
   end
 
   describe "#slug" do
-    it "gets set from repo_slug" do
-      api = described_class.new("org/repo", 1, nil, stub_env)
+    let(:repo) { "org/repo" }
 
+    it "gets set from repo_slug" do
       expect(api.slug).to eq("repo")
     end
   end
 
   describe "#pull_request_id" do
-    it "gets set from pull_request_id" do
-      api = described_class.new("org/repo", 1, nil, stub_env)
 
+    it "gets set from pull_request_id" do
       expect(api.pull_request_id).to eq(1)
+    end
+
+    context "when pr_id is nil" do
+      let(:pr_id) { nil }
+
+      it "fetches the id from bitbucket" do
+        stub_pull_requests
+        expect(api.pull_request_id).to eq(2080)
+      end
     end
   end
 
   describe "#host" do
     it "gets set from host" do
-      api = described_class.new("org/repo", 1, nil, stub_env)
-
       expect(api.host).to eq("https://bitbucket.org/")
+    end
+  end
+
+  describe "#my_uuid" do
+    subject { api.my_uuid }
+    let(:env) { stub_env.merge("DANGER_BITBUCKETCLOUD_UUID" => uuid) }
+
+    context "when DANGER_BITBUCKETCLOUD_UUID is empty string" do
+      let(:uuid) { nil }
+
+      it { is_expected.to be nil }
+    end
+
+    context "when DANGER_BITBUCKETCLOUD_UUID is empty string" do
+      let(:uuid) { "" }
+
+      it { is_expected.to eq "" }
+    end
+
+    context "when DANGER_BITBUCKETCLOUD_UUID is uuid without braces" do
+      let(:uuid) { "c91be865-efc6-49a6-93c5-24e1267c479b" }
+
+      it { is_expected.to eq "{c91be865-efc6-49a6-93c5-24e1267c479b}" }
+    end
+
+    context "when DANGER_BITBUCKETCLOUD_UUID is uuid with braces" do
+      let(:uuid) { "{c91be865-efc6-49a6-93c5-24e1267c479b}" }
+
+      it { is_expected.to eq "{c91be865-efc6-49a6-93c5-24e1267c479b}" }
     end
   end
 
   describe "#credentials_given" do
     it "#fetch_json raise error when missing credentials" do
       empty_env = {}
-      api = described_class.new("ios/fancyapp", "123", nil, empty_env)
       expect { api.pull_request }.to raise_error
     end
 
     it "#post raise error when missing credentials" do
       empty_env = {}
-      api = described_class.new("ios/fancyapp", "123", nil, empty_env)
       expect { api.post("http://post-url.org", {}) }.to raise_error
     end
 
     it "#delete raise error when missing credentials" do
       empty_env = {}
-      api = described_class.new("ios/fancyapp", "123", nil, empty_env)
       expect { api.delete("http://delete-url.org") }.to raise_error
     end
   end
 
-  describe "#fetch_pr_id" do
-    it "gets called if pull_request_id is nil" do
-      stub_pull_requests
-      api = described_class.new("ios/fancyapp", nil, "feature_branch", stub_env)
-
-      expect(api.pull_request_id).to eq(2080)
-    end
-  end
-
   describe "#fetch_access_token" do
-    it "gets called if auth environment variables is not nil" do
-      stub_access_token
-      env = stub_env
-      env["DANGER_BITBUCKETCLOUD_OAUTH_KEY"] = "XXX"
-      env["DANGER_BITBUCKETCLOUD_OAUTH_SECRET"] = "YYY"
-      api = described_class.new("ios/fancyapp", "123", "feature_branch", env)
+    let(:pr_id) { "123" }
+    let(:branch) { "feature_branch" }
+    subject { api.access_token }
 
-      expect(api.access_token).to eq("a_token")
+    context "when DANGER_BITBUCKET_CLOUD_OAUTH_KEY and _SECRET are set" do
+      let(:env) do
+        stub_env.merge(
+          "DANGER_BITBUCKETCLOUD_OAUTH_KEY" => "XXX",
+          "DANGER_BITBUCKETCLOUD_OAUTH_SECRET" => "YYY"
+        )
+      end
+      before { stub_access_token }
+
+      it { is_expected.to eq("a_token") }
     end
 
-    it "gets called if auth environment variables is insufficiency" do
-      stub_access_token
-      env = stub_env
-      env["DANGER_BITBUCKETCLOUD_OAUTH_KEY"] = "XXX"
-      api = described_class.new("ios/fancyapp", "123", "feature_branch", env)
+    context "when only DANGER_BITBUCKETCLOUD_OAUTH_KEY is set" do
+      let(:env) { stub_env.merge("DANGER_BITBUCKETCLOUD_OAUTH_KEY" => "XXX") }
+      before { stub_access_token }
 
-      expect(api.access_token).to be nil
+      it { is_expected.to be nil }
     end
 
-    it "gets called if auth environment variables is insufficiency" do
-      api = described_class.new("ios/fancyapp", "123", "feature_branch", stub_env)
-
-      expect(api.access_token).to be nil
+    context "when neither DANGER_BITBUCKETCLOUD_OAUTH_KEY and _SECRET are set" do
+      it { is_expected.to be nil }
     end
   end
 end

--- a/spec/lib/danger/request_sources/bitbucket_cloud_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_cloud_spec.rb
@@ -13,8 +13,41 @@ RSpec.describe Danger::RequestSources::BitbucketCloud, host: :bitbucket_cloud do
   end
 
   describe "#validates_as_api_source" do
-    it "validates_as_api_source for non empty `DANGER_BITBUCKETCLOUD_USERNAME` and `DANGER_BITBUCKETCLOUD_PASSWORD`" do
-      expect(bs.validates_as_api_source?).to be true
+    subject { bs.validates_as_api_source? }
+
+    context "when DANGER_BITBUKETCLOUD_USERNAME, _UUID, and _PASSWORD are set" do
+      it { is_expected.to be_truthy }
+    end
+
+    context "when DANGER_BITBUCKETCLOUD_USERNAME is unset" do
+      let(:env) { stub_env.reject { |k, _| k == "DANGER_BITBUCKETCLOUD_USERNAME" } }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when DANGER_BITBUCKETCLOUD_USERNAME is empty" do
+      let(:env) { stub_env.merge("DANGER_BITBUCKETCLOUD_USERNAME" => "") }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when DANGER_BITBUCKETCLOUD_UUID is unset" do
+      let(:env) { stub_env.reject { |k, _| k == "DANGER_BITBUCKETCLOUD_UUID" } }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when DANGER_BITBUCKETCLOUD_UUID is empty" do
+      let(:env) { stub_env.merge("DANGER_BITBUCKETCLOUD_UUID" => "") }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when DANGER_BITBUCKETCLOUD_PASSWORD is unset" do
+      let(:env) { stub_env.reject { |k, _| k == "DANGER_BITBUCKETCLOUD_PASSWORD" } }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when DANGER_BITBUCKETCLOUD_PASSWORD is empty" do
+      let(:env) { stub_env.merge("DANGER_BITBUCKETCLOUD_PASSWORD" => "") }
+      it { is_expected.to be_falsey }
     end
   end
 

--- a/spec/support/bitbucket_cloud_helper.rb
+++ b/spec/support/bitbucket_cloud_helper.rb
@@ -4,6 +4,7 @@ module Danger
       def stub_env
         {
           "DANGER_BITBUCKETCLOUD_USERNAME" => "a.name",
+          "DANGER_BITBUCKETCLOUD_UUID" => "c91be865-efc6-49a6-93c5-24e1267c479b",
           "DANGER_BITBUCKETCLOUD_PASSWORD" => "a_password",
           "JENKINS_URL" => "http://jenkins.example.com/job/ios-check-pullrequest/",
           "GIT_URL" => "ssh://git@stash.example.com:7999/ios/fancyapp.git",


### PR DESCRIPTION
Bitbucket changed its API, and now accessing `/users/<username>` returns a
404 ([here's some detail](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#removal-of-usernames-from-user-referencing-apis) on the privacy aspect of that.

Though I think to be honest what we were doing at least where I work was a bit of a security hole in Bitbucket - we'd set up an access token with only pull_requests scope, but it used to be be able to access `/users/<username>` for its own user anyway. I think that's why this has changed before the 29th, as the above link says it's going to.

Anyway, we were only using that endpoint to find the UUID for identifying whether the user that wrote a comment was danger (to decide whether to attempt to delete it), so now we just require the UUID and don't fetch danger's user details.

After this commit everyone using bitbucketcloud will have to provide the DANGER_BITBUCKETCLOUD_UUID env var. It seems neater than having a feature that presumably a lot of people are using (danger deleting its old comments) not work unless you set that variable. But I am opening to reworking this, if there's protest.

Fixes #1213
Also I made the specs for BitbucketCloud and BitbucketCloudAPI more
RSpec-idiomatic. I can't help myself.

This has been tested where I work (albeit merged into my message-aggregation branch†) and been shown to be working, so, hooray.

† sorry for dragging my heels on that PR