### PR TITLE
Improves messaging specific to GitLab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Improves messaging specific to GitLab
+
 ## 7.0.0
 
 **Breaking for BitBucket Cloud users only** - with changes in their API, see below, then Danger has a new env var

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -63,7 +63,7 @@ module Danger
       unless EnvironmentManager.pr?(system_env)
         ci_name = EnvironmentManager.local_ci_source(system_env).name.split("::").last
 
-        msg = "Not a #{ci_name} Pull Request - skipping `danger` run. "
+        msg = "Not a #{ci_name} #{commit_request(ci_name)} - skipping `danger` run. "
         # circle won't run danger properly if the commit is pushed and build runs before the PR exists
         # https://danger.systems/guides/troubleshooting.html#circle-ci-doesnt-run-my-build-consistently
         # the best solution is to enable `fail_if_no_pr`, and then re-run the job once the PR is up
@@ -82,6 +82,11 @@ module Danger
 
     def head_branch(user_specified_head_branch)
       user_specified_head_branch || EnvironmentManager.danger_head_branch
+    end
+
+    def commit_request(ci_name)
+      return "Merge Request" if ci_name == 'GitLabCI'
+      return "Pull Request"
     end
   end
 end

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
     end
 
     it "loads GitLab CI" do
-      with_gitlabci_setup_and_is_a_pull_request do |system_env|
+      with_gitlabci_setup_and_is_a_merge_request do |system_env|
         expect(described_class.local_ci_source(system_env)).to eq Danger::GitLabCI
       end
     end
@@ -45,13 +45,13 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
     end
 
     it "loads Jenkins (Gitlab)" do
-      with_jenkins_setup_gitlab_and_is_a_pull_request do |system_env|
+      with_jenkins_setup_gitlab_and_is_a_merge_request do |system_env|
         expect(described_class.local_ci_source(system_env)).to eq Danger::Jenkins
       end
     end
 
     it "loads Jenkins (Gitlab v3)" do
-      with_jenkins_setup_gitlab_v3_and_is_a_pull_request do |system_env|
+      with_jenkins_setup_gitlab_v3_and_is_a_merge_request do |system_env|
         expect(described_class.local_ci_source(system_env)).to eq Danger::Jenkins
       end
     end
@@ -137,7 +137,7 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
     end
 
     it "loads GitLab CI" do
-      with_gitlabci_setup_and_is_a_pull_request do |system_env|
+      with_gitlabci_setup_and_is_a_merge_request do |system_env|
         expect(described_class.pr?(system_env)).to eq(true)
       end
     end
@@ -149,13 +149,13 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
     end
 
     it "loads Jenkins (Gitlab)" do
-      with_jenkins_setup_gitlab_and_is_a_pull_request do |system_env|
+      with_jenkins_setup_gitlab_and_is_a_merge_request do |system_env|
         expect(described_class.pr?(system_env)).to eq(true)
       end
     end
 
     it "loads Jenkins (Gitlab v3)" do
-      with_jenkins_setup_gitlab_v3_and_is_a_pull_request do |system_env|
+      with_jenkins_setup_gitlab_v3_and_is_a_merge_request do |system_env|
         expect(described_class.pr?(system_env)).to eq(true)
       end
     end

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Danger::Executor, use: :ci_helper do
       end
 
       it "not raises error on GitLab CI" do
-        with_gitlabci_setup_and_is_a_pull_request do |system_env|
+        with_gitlabci_setup_and_is_a_merge_request do |system_env|
           expect { described_class.new(system_env).validate!(testing_ui) }.not_to raise_error
         end
       end
@@ -53,13 +53,13 @@ RSpec.describe Danger::Executor, use: :ci_helper do
       end
 
       it "not raises error on Jenkins (GitLab)" do
-        with_jenkins_setup_gitlab_and_is_a_pull_request do |system_env|
+        with_jenkins_setup_gitlab_and_is_a_merge_request do |system_env|
           expect { described_class.new(system_env).validate!(testing_ui) }.not_to raise_error
         end
       end
 
       it "not raises error on Jenkins (GitLab v3)" do
-        with_jenkins_setup_gitlab_v3_and_is_a_pull_request do |system_env|
+        with_jenkins_setup_gitlab_v3_and_is_a_merge_request do |system_env|
           expect { described_class.new(system_env).validate!(testing_ui) }.not_to raise_error
         end
       end
@@ -97,7 +97,7 @@ RSpec.describe Danger::Executor, use: :ci_helper do
       end
 
       it "not raises error on TeamCity (GitLab)" do
-        with_teamcity_setup_gitlab_and_is_a_pull_request do |system_env|
+        with_teamcity_setup_gitlab_and_is_a_merge_request do |system_env|
           expect { described_class.new(system_env) }.not_to raise_error
         end
       end
@@ -130,6 +130,14 @@ RSpec.describe Danger::Executor, use: :ci_helper do
           ui = testing_ui
           expect { described_class.new(system_env).validate!(ui) }.to raise_error(SystemExit)
           expect(ui.string).to include("Not a Travis Pull Request - skipping `danger` run")
+        end
+      end
+
+      it "raises error on GitLab CI" do
+        with_gitlabci_setup_and_is_not_a_merge_request do |system_env|
+          ui = testing_ui
+          expect { described_class.new(system_env).validate!(ui) }.to raise_error(SystemExit)
+          expect(ui.string).to include("Not a GitLabCI Merge Request - skipping `danger` run")
         end
       end
     end

--- a/spec/support/ci_helper.rb
+++ b/spec/support/ci_helper.rb
@@ -71,12 +71,21 @@ module Danger
         yield(system_env)
       end
 
-      def with_gitlabci_setup_and_is_a_pull_request
+      def with_gitlabci_setup_and_is_a_merge_request
         system_env = {
           "GITLAB_CI" => "true",
           "CI_PROJECT_PATH" => "danger/danger",
           "CI_MERGE_REQUEST_IID" => "42",
           "CI_MERGE_REQUEST_PROJECT_PATH" => "danger/danger"
+        }
+
+        yield(system_env)
+      end
+
+      def with_gitlabci_setup_and_is_not_a_merge_request
+        system_env = {
+          "GITLAB_CI" => "true",
+          "CI_PROJECT_PATH" => "danger/danger"
         }
 
         yield(system_env)
@@ -91,7 +100,7 @@ module Danger
         yield(system_env)
       end
 
-      def with_jenkins_setup_gitlab_and_is_a_pull_request
+      def with_jenkins_setup_gitlab_and_is_a_merge_request
         system_env = {
           "JENKINS_URL" => "https://ci.swift.org/job/oss-swift-incremental-RA-osx/lastBuild/",
           "gitlabMergeRequestIid" => "42"
@@ -100,7 +109,7 @@ module Danger
         yield(system_env)
       end
 
-      def with_jenkins_setup_gitlab_v3_and_is_a_pull_request
+      def with_jenkins_setup_gitlab_v3_and_is_a_merge_request
         system_env = {
           "JENKINS_URL" => "https://ci.swift.org/job/oss-swift-incremental-RA-osx/lastBuild/",
           "gitlabMergeRequestId" => "42"
@@ -157,7 +166,7 @@ module Danger
         yield(system_env)
       end
 
-      def with_teamcity_setup_gitlab_and_is_a_pull_request
+      def with_teamcity_setup_gitlab_and_is_a_merge_request
         system_env = {
           "TEAMCITY_VERSION" => "1.0.0",
           "GITLAB_REPO_SLUG" => "danger/danger",


### PR DESCRIPTION
* GitLab uses the terminology Merge Request as opposed to the commonly
known Pull Request utilized by GitHub
* This adds a method to check for GitLabCI and returns the desired
language
* Keeps Pull Request the default for the time being
* Modifies all method names that represent gitlab and ensures we utilize
the appropriate nomenclature
