### PR TITLE
[Ruby 2.7] Bump git subspec to new 1.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Improves messaging specific to GitLab
+* Updates GIT to 1.7 with Ruby 2.7 support without warnings
 
 ## 7.0.0
 

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "claide", "~> 1.0"
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
-  spec.add_runtime_dependency "git", "~> 1.6"
+  spec.add_runtime_dependency "git", "~> 1.7"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "faraday", ">= 0.9.0", "< 2.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"


### PR DESCRIPTION
- Git has released new version 1.7 with Ruby 2.7 support and warning fixes - https://github.com/ruby-git/ruby-git/releases

I know semantically this is not required but at least there will be some change for new (minor?) release for us - Ruby 2.7 users.

Could we release new version @orta please? :)