### PR TITLE
[Ruby 2.7] Fix warnings for Github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Improves messaging specific to GitLab
 * Updates GIT to 1.7 with Ruby 2.7 support without warnings
+* Fixes warnings for Github with Ruby 2.7
 
 ## 7.0.0
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -170,7 +170,7 @@ module Danger
         rest_inline_violations = submit_inline_comments!({
           danger_id: danger_id,
           previous_violations: previous_violations
-        }.merge(inline_violations))
+       }.merge(**inline_violations))
 
         main_violations = merge_violations(
           regular_violations, rest_inline_violations
@@ -189,7 +189,7 @@ module Danger
             template: "github",
             danger_id: danger_id,
             previous_violations: previous_violations
-          }.merge(main_violations))
+         }.merge(**main_violations))
 
           comment_result =
             if should_create_new_comment

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -170,7 +170,7 @@ module Danger
         rest_inline_violations = submit_inline_comments!({
           danger_id: danger_id,
           previous_violations: previous_violations
-       }.merge(**inline_violations))
+        }.merge(**inline_violations))
 
         main_violations = merge_violations(
           regular_violations, rest_inline_violations
@@ -189,7 +189,7 @@ module Danger
             template: "github",
             danger_id: danger_id,
             previous_violations: previous_violations
-         }.merge(**main_violations))
+          }.merge(**main_violations))
 
           comment_result =
             if should_create_new_comment


### PR DESCRIPTION
- fixes https://github.com/danger/danger/issues/1220
- more info: https://piechowski.io/post/last-arg-keyword-deprecated-ruby-2-7/