### PR TITLE
Fix strike-out comments on Github for Danger 7+, drop Ruby 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/danger
     docker:
-      - image: ruby:2.3
+      - image: ruby:2.4
         environment:
         - RAILS_ENV=test
         - RACK_ENV=test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # Defaults can be found here: https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - 'spec/fixtures/**/*'
     - 'lib/danger/plugin_support/plugin_parser.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - 2.6.0
   - 2.5.3
   - 2.4.5
-  - 2.3.8
 
 bundler_args: "--without documentation --path bundle"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 
+**Breaking** - Drop support for Ruby 2.3, support Ruby 2.4+ [@Kaspik] [#1225](https://github.com/danger/danger/pull/1225)
 * Fix github inline-comments always being struck-through. This was caused by a regression in PR [#1182](https://github.com/danger/danger/pull/1182), fixed in PR [#1208](https://github.com/danger/danger/pull/1208/) for 6.3.2 but didn't make it to 7.0.0 [@Kaspik] [#1225](https://github.com/danger/danger/pull/1225)
 
 ## 7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix github inline-comments always being struck-through. This was caused by a regression in PR [#1182](https://github.com/danger/danger/pull/1182), fixed in PR [#1208](https://github.com/danger/danger/pull/1208/) for 6.3.2 but didn't make it to 7.0.0 [@Kaspik] [#1225](https://github.com/danger/danger/pull/1225)
+
 ## 7.0.1
 
 * Fixed import Dangerfile in directory from GitLab

--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,7 @@ gem "guard", "~> 2.14"
 gem "guard-rspec", "~> 4.7"
 gem "guard-rubocop", "~> 1.2"
 gem "listen", "3.0.7"
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.4.0")
-  gem "pry", "~> 0.10", "< 0.13"
-else
-  gem "pry", "~> 0.10"
-end
+gem "pry", "~> 0.10"
 gem "pry-byebug"
 gem "rake", "~> 10.0"
 gem "rspec", "~> 3.4"
@@ -25,7 +21,3 @@ gem "rubocop", "~> 0.49.0"
 gem "simplecov", "~> 0.12.0"
 gem "webmock", "~> 2.1"
 gem "yard", "~> 0.9.11"
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.4.0")
-  gem "byebug", "< 11.1.0"
-  gem "gitlab", "< 4.14.0"
-end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - set PATH=C:\Ruby23\bin;%PATH%
+  - set PATH=C:\Ruby24\bin;%PATH%
   - gem uninstall bundler --executables
   - gem install bundler -v '2.0.1'
   - bundle install

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_runtime_dependency "claide", "~> 1.0"
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -108,7 +108,7 @@ module Danger
       # have some nice generic resolved-thing going :)
       def generate_message_group_comment(message_group:,
                                          danger_id: "danger",
-                                         resolved: false,
+                                         resolved: [],
                                          template: "github")
         # cheating a bit - I don't want to alter the apply_template API
         # so just sneak around behind its back setting some instance variables
@@ -128,7 +128,7 @@ module Danger
       def generate_inline_comment_body(emoji,
                                        message,
                                        danger_id: "danger",
-                                       resolved: [],
+                                       resolved: false,
                                        template: "github")
         apply_template(
           tables: [{ content: [message], resolved: resolved, emoji: emoji }],

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -108,7 +108,7 @@ module Danger
       # have some nice generic resolved-thing going :)
       def generate_message_group_comment(message_group:,
                                          danger_id: "danger",
-                                         resolved: [],
+                                         resolved: false,
                                          template: "github")
         # cheating a bit - I don't want to alter the apply_template API
         # so just sneak around behind its back setting some instance variables


### PR DESCRIPTION
- Fixes: https://github.com/danger/danger/issues/1189
- How: Re apply change from https://github.com/danger/danger/pull/1208 as Danger 7.0.0 doesn't have it anymore somehow
- Drops Ruby 2.3 - Circle CI dropped this version support last week and tests are not working anymore - it's dangerous to guarantee support for version that we don't have tests for, so I believe we should drop it. It's in EOL state for years anyways.

If you check the file history, the PR is not even there and the commit never made it to Danger 7.0 even tho other parts of the PR are correctly on master. This should fix the issue again for Danger 7+.

@orta I have no idea how this happened, Git history doesn't show anything. No idea how Danger 7 was released either... but the only way how to fix this is downgrade to Danger 6.3.2. Could we release 7.0.2 with this? Or do you want 7.1 as this also drops Ruby to keep tests green?