### PR TITLE
Use GitLabCI.validates_as_ci? to validate GitLab CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ## master
 
-<!-- Your logs here -->
+* Fixed GitLab CI detection when Git remote host is different than GitLab.com.
+  If you're using GitLab.com with shared runner, you'll need this.
+  [#1231](https://github.com/danger/danger/issues/1231)
 
 ## 8.0.0
 

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -50,7 +50,7 @@ module Danger
         includes_port = self.host.include? ":"
         raise "Port number included in `DANGER_GITLAB_HOST`, this will fail with GitLab CI Runners" if includes_port
 
-        super
+        GitLabCI.validates_as_ci?(environment)
       end
 
       def validates_as_api_source?

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -77,8 +77,9 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
       expect { stub_request_source(env).validates_as_ci? }.to raise_error("Port number included in `DANGER_GITLAB_HOST`, this will fail with GitLab CI Runners")
     end
 
-    it "does validate as CI when there is no port number included in host" do
+    it "does validate with GitLabCI.validates_as_ci? when there is no port number included in host" do
       env["DANGER_GITLAB_HOST"] = "gitlab.example.com"
+      expect(Danger::GitLabCI).to receive(:validates_as_ci?).and_call_original
 
       git_mock = Danger::GitRepo.new
       g = stub_request_source(env)
@@ -86,9 +87,7 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
 
       allow(git_mock).to receive(:exec).with("remote show origin -n").and_return("Fetch URL: git@gitlab.example.com:artsy/eigen.git")
 
-      result = g.validates_as_ci?
-
-      expect(result).to be_truthy
+      g.validates_as_ci?
     end
   end
 


### PR DESCRIPTION
This is attempting to fix https://github.com/danger/danger/issues/1231

I have one question. Why do we need to validate it with:

``` ruby
# @return [Boolean] whether scm.origins is a valid git repository or not
def validates_as_ci?
  !!self.scm.origins.match(%r{#{Regexp.escape self.host}(:|/)(.+/.+?)(?:\.git)?$})
end
```

I don't want to break anything, but it seems a bit odd to me that we use two different ways to validate if we're on GitLab CI or not.

Does this change make sense?