### PR TITLE
Fix Danger::Helpers::CommentsHelper#process_markdown so that it doesn't result in broken HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix Danger::Helpers::CommentsHelper#process_markdown so that it doesn't result in broken HTML. [@rymai](https://github.com/rymai) [#1236](https://github.com/danger/danger/pull/1236)
+
 ## 8.0.1
 
 * Fix request source detection for GitLab. [@rymai](https://github.com/rymai) [#1234](https://github.com/danger/danger/pull/1234)

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -49,8 +49,8 @@ module Danger
         message = "#{markdown_link_to_message(violation, hide_link)}#{message}" if violation.file && violation.line
 
         html = markdown_parser(message).to_html
-        # Remove the outer `<p>`, the -5 represents a newline + `</p>`
-        html = html[3...-5] if html.start_with? "<p>"
+        # Remove the outer `<p>` and `</p>`.
+        html = html.strip.sub(%r{\A<p>(.*)</p>\z}m, '\1')
         Violation.new(html, violation.sticky, violation.file, violation.line)
       end
 

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -202,6 +202,75 @@ RSpec.describe Danger::Helpers::CommentsHelper do
       expect(table_data[:resolved]).to be_empty
       expect(table_data[:count]).to be(2)
     end
+
+    shared_examples "violation text as heredoc" do
+      it "produces table data" do
+        table_data = dummy.table("1 Error", "no_entry_sign", [violation], {})
+
+        expect(table_data[:name]).to eq("1 Error")
+        expect(table_data[:emoji]).to eq("no_entry_sign")
+        expect(table_data[:content].size).to be(1)
+        expect(table_data[:content][0].message).to eq("#{heredoc_text.strip}")
+        expect(table_data[:content][0].sticky).to eq(false)
+
+        expect(table_data[:resolved]).to be_empty
+        expect(table_data[:count]).to be(1)
+      end
+
+    end
+
+    context "with a heredoc text with a newline at the end" do
+      let(:heredoc_text) { "You have made some app changes, but did not add any tests." }
+      let(:violation) { violation_factory(heredoc) }
+
+      context "with a heredoc text with a newline at the end" do
+        let(:heredoc) do
+          <<~MSG
+          #{heredoc_text}
+
+          MSG
+        end
+
+        it_behaves_like "violation text as heredoc"
+      end
+
+      context "with a heredoc text with two newlines at the end" do
+        let(:heredoc) do
+          <<~MSG
+          #{heredoc_text}
+
+
+          MSG
+        end
+
+        it_behaves_like "violation text as heredoc"
+      end
+
+      context "with a heredoc text with a newline at the start and end" do
+        let(:heredoc) do
+          <<~MSG
+
+          #{heredoc_text}
+
+          MSG
+        end
+
+        it_behaves_like "violation text as heredoc"
+      end
+
+      context "with a heredoc text with a newline at the start and two newlines at the end" do
+        let(:heredoc) do
+          <<~MSG
+
+          #{heredoc_text}
+
+
+          MSG
+        end
+
+        it_behaves_like "violation text as heredoc"
+      end
+    end
   end
 
   describe "#table_kind_from_title" do


### PR DESCRIPTION
This fixes https://github.com/danger/danger/issues/1235.