### PR TITLE
Remove GitlabCI#project_url #trivial

### DIFF
--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -17,8 +17,6 @@ module Danger
   #
   # Add the `DANGER_GITLAB_API_TOKEN` to your pipeline env variables.
   class GitLabCI < CI
-    attr_reader :project_url
-
     def self.validates_as_ci?(env)
       env.key? "GITLAB_CI"
     end
@@ -55,7 +53,6 @@ module Danger
     def initialize(env)
       @env = env
       @repo_slug = env["CI_MERGE_REQUEST_PROJECT_PATH"] || env["CI_PROJECT_PATH"]
-      @project_url = env["CI_MERGE_REQUEST_PROJECT_URL"] || env["CI_PROJECT_URL"]
     end
 
     def supported_request_sources

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -77,19 +77,13 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
       end
     end
 
-    describe "#project_url" do
-      it "sets the project_url" do
-        expect(ci_source.project_url).to eq(env["CI_MERGE_REQUEST_PROJECT_URL"])
-      end
-    end
-
     describe "#pull_request_id" do
       it "sets the pull_request_id" do
         expect(ci_source.pull_request_id).to eq(env["CI_MERGE_REQUEST_IID"])
       end
     end
   end
-  
+
   context "valid environment on GitLab < 11.6" do
     let(:env) { stub_env_pre_11_6.merge("CI_MERGE_REQUEST_IID" => 28_493) }
 
@@ -102,12 +96,5 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
         expect(ci_source.repo_slug).to eq("k0nserv/danger-test")
       end
     end
-    
-    describe "#project_url" do
-      it "sets the project_url" do
-        expect(ci_source.project_url).to eq(env["CI_PROJECT_URL"])
-      end
-    end
-
   end
 end


### PR DESCRIPTION
`GitlabCI#project_url` is not being used anymore ever since #1157 was merged.
