### PR TITLE
GitLab CI external repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 -->
 
 ## master
-* Support external CI/CD for GitlabCI with Github code repository. To utilize this, please ensure `DANGER_GITHUB_API_TOKEN` and `DANGER_PROJECT_REPO_URL` are both set. [@philipqnguyen](https://github.com/philipqnguyen) [#1238](https://github.com/danger/danger/pull/1238)
+* Support external CI/CD for GitLab CI with GitHub code repository. To utilize this, please ensure `DANGER_GITHUB_API_TOKEN` and `DANGER_PROJECT_REPO_URL` are both set. [@philipqnguyen](https://github.com/philipqnguyen) [#1238](https://github.com/danger/danger/pull/1238)
 
 ## 8.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -->
 
 ## master
+* Support external CI/CD for GitlabCI with Github code repository. To utilize this, please ensure `DANGER_GITHUB_API_TOKEN` and `DANGER_PROJECT_REPO_URL` are both set. [@philipqnguyen](https://github.com/philipqnguyen) [#1238](https://github.com/danger/danger/pull/1238)
 
 ## 8.0.2
 

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -1,5 +1,6 @@
 # http://docs.gitlab.com/ce/ci/variables/README.html
 require "uri"
+require "danger/request_sources/github/github"
 require "danger/request_sources/gitlab"
 
 module Danger
@@ -15,7 +16,12 @@ module Danger
   # ```
   # ### Token Setup
   #
-  # Add the `DANGER_GITLAB_API_TOKEN` to your pipeline env variables.
+  # Add the `DANGER_GITLAB_API_TOKEN` to your pipeline env variables if you
+  # are hosting your code on Gitlab. If you are using Gitlab as a mirror
+  # for the purpose of CI/CD, while hosting your repo on Github, set the
+  # `DANGER_GITHUB_API_TOKEN` as well as the project repo URL to
+  # `DANGER_PROJECT_REPO_URL`.
+
   class GitLabCI < CI
     def self.validates_as_ci?(env)
       env.key? "GITLAB_CI"
@@ -26,11 +32,12 @@ module Danger
         "GITLAB_CI", "CI_PROJECT_PATH"
       ].all? { |x| env[x] }
 
-      exists && determine_merge_request_id(env).to_i > 0
+      exists && determine_pull_or_merge_request_id(env).to_i > 0
     end
 
-    def self.determine_merge_request_id(env)
+    def self.determine_pull_or_merge_request_id(env)
       return env["CI_MERGE_REQUEST_IID"] if env["CI_MERGE_REQUEST_IID"]
+      return env["CI_EXTERNAL_PULL_REQUEST_IID"] if env["CI_EXTERNAL_PULL_REQUEST_IID"]
       return 0 unless env["CI_COMMIT_SHA"]
 
       project_path = env["CI_MERGE_REQUEST_PROJECT_PATH"] || env["CI_PROJECT_PATH"]
@@ -52,15 +59,28 @@ module Danger
 
     def initialize(env)
       @env = env
-      @repo_slug = env["CI_MERGE_REQUEST_PROJECT_PATH"] || env["CI_PROJECT_PATH"]
+      @repo_slug = slug_from(env)
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitLab]
+      @supported_request_sources ||= [
+        Danger::RequestSources::GitHub,
+        Danger::RequestSources::GitLab
+      ]
     end
 
     def pull_request_id
-      @pull_request_id ||= self.class.determine_merge_request_id(@env)
+      @pull_request_id ||= self.class.determine_pull_or_merge_request_id(@env)
+    end
+
+    private
+
+    def slug_from(env)
+      if env["DANGER_PROJECT_REPO_URL"]
+        env["DANGER_PROJECT_REPO_URL"].split('/').last(2).join('/')
+      else
+        env["CI_MERGE_REQUEST_PROJECT_PATH"] || env["CI_PROJECT_PATH"]
+      end
     end
   end
 end

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -17,8 +17,8 @@ module Danger
   # ### Token Setup
   #
   # Add the `DANGER_GITLAB_API_TOKEN` to your pipeline env variables if you
-  # are hosting your code on Gitlab. If you are using Gitlab as a mirror
-  # for the purpose of CI/CD, while hosting your repo on Github, set the
+  # are hosting your code on GitLab. If you are using GitLab as a mirror
+  # for the purpose of CI/CD, while hosting your repo on GitHub, set the
   # `DANGER_GITHUB_API_TOKEN` as well as the project repo URL to
   # `DANGER_PROJECT_REPO_URL`.
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -40,6 +40,10 @@ module Danger
         end
       end
 
+      def validates_as_ci?
+        true
+      end
+
       def validates_as_api_source?
         (@token && !@token.empty?) || self.environment["DANGER_USE_LOCAL_GIT"]
       end

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
       end
     end
 
-    describe ".determine_merge_request_id" do
+    describe ".determine_pull_or_merge_request_id" do
       context "when CI_MERGE_REQUEST_IID present in environment" do
         it "returns CI_MERGE_REQUEST_IID" do
-          expect(described_class.determine_merge_request_id({
+          expect(described_class.determine_pull_or_merge_request_id({
             "CI_MERGE_REQUEST_IID" => 1
           })).to eq(1)
         end
@@ -31,7 +31,9 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
 
       context "when CI_COMMIT_SHA not present in environment" do
         it "returns 0" do
-          expect(described_class.determine_merge_request_id({})).to eq(0)
+          expect(
+            described_class.determine_pull_or_merge_request_id({})
+          ).to eq(0)
         end
       end
 
@@ -41,7 +43,7 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
             stub_version("10.6.4")
             stub_merge_requests("merge_requests_response", "k0nserv%2Fdanger-test")
 
-            expect(described_class.determine_merge_request_id({
+            expect(described_class.determine_pull_or_merge_request_id({
               "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
               "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
               "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
@@ -55,7 +57,7 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
             commit_sha = "3333333333333333333333333333333333333333"
             stub_commit_merge_requests("commit_merge_requests", "k0nserv%2Fdanger-test", commit_sha)
 
-            expect(described_class.determine_merge_request_id({
+            expect(described_class.determine_pull_or_merge_request_id({
               "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
               "CI_COMMIT_SHA" => commit_sha,
               "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
@@ -67,7 +69,10 @@ RSpec.describe Danger::GitLabCI, host: :gitlab do
 
     describe "#supported_request_sources" do
       it "it is gitlab" do
-        expect(ci_source.supported_request_sources).to eq([Danger::RequestSources::GitLab])
+        expect(
+          ci_source.supported_request_sources
+        ).to eq([Danger::RequestSources::GitHub,
+                 Danger::RequestSources::GitLab])
       end
     end
 

--- a/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
+++ b/spec/lib/danger/ci_sources/gitlab_ci_spec.rb
@@ -2,89 +2,91 @@ require "danger/ci_source/gitlab_ci"
 
 RSpec.describe Danger::GitLabCI, host: :gitlab do
   context "valid environment" do
-    let(:env) { stub_env.merge("CI_MERGE_REQUEST_IID" => 28_493) }
-
+    let(:env) { stub_env }
     let(:ci_source) do
       described_class.new(env)
-    end
-
-    describe ".validates_as_ci?" do
-      it "is valid" do
-        expect(described_class.validates_as_ci?(env)).to be(true)
-      end
-    end
-
-    describe ".validates_as_pr?" do
-      it "is valid" do
-        expect(described_class.validates_as_pr?(env)).to be(true)
-      end
-    end
-
-    describe ".determine_pull_or_merge_request_id" do
-      context "when CI_MERGE_REQUEST_IID present in environment" do
-        it "returns CI_MERGE_REQUEST_IID" do
-          expect(described_class.determine_pull_or_merge_request_id({
-            "CI_MERGE_REQUEST_IID" => 1
-          })).to eq(1)
-        end
-      end
-
-      context "when CI_COMMIT_SHA not present in environment" do
-        it "returns 0" do
-          expect(
-            described_class.determine_pull_or_merge_request_id({})
-          ).to eq(0)
-        end
-      end
-
-      context "when CI_COMMIT_SHA present in environment" do
-        context "before version 10.7" do
-          it "uses gitlab api to find merge request id" do
-            stub_version("10.6.4")
-            stub_merge_requests("merge_requests_response", "k0nserv%2Fdanger-test")
-
-            expect(described_class.determine_pull_or_merge_request_id({
-              "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
-              "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
-              "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
-            })).to eq(3)
-          end
-        end
-        context "version 10.7 or later" do
-          it "uses gitlab api to find merge request id" do
-            #Arbitrary version, as tested manually, including text components to exercise the version comparison
-            stub_version("11.10.0-rc6-ee")
-            commit_sha = "3333333333333333333333333333333333333333"
-            stub_commit_merge_requests("commit_merge_requests", "k0nserv%2Fdanger-test", commit_sha)
-
-            expect(described_class.determine_pull_or_merge_request_id({
-              "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
-              "CI_COMMIT_SHA" => commit_sha,
-              "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
-            })).to eq(1)
-          end
-        end
-      end
     end
 
     describe "#supported_request_sources" do
       it "it is gitlab" do
         expect(
           ci_source.supported_request_sources
-        ).to eq([Danger::RequestSources::GitHub,
-                 Danger::RequestSources::GitLab])
+        ).to eq([Danger::RequestSources::GitLab])
       end
     end
 
-    describe "#initialize" do
-      it "sets the repo_slug" do
-        expect(ci_source.repo_slug).to eq("k0nserv/danger-test")
-      end
-    end
+    context "given PR made on gitlab hosted repository" do
+      let(:env) { stub_env.merge("CI_MERGE_REQUEST_IID" => 28_493) }
 
-    describe "#pull_request_id" do
-      it "sets the pull_request_id" do
-        expect(ci_source.pull_request_id).to eq(env["CI_MERGE_REQUEST_IID"])
+      describe ".validates_as_ci?" do
+        it "is valid" do
+          expect(described_class.validates_as_ci?(env)).to be(true)
+        end
+      end
+
+      describe ".validates_as_pr?" do
+        it "is valid" do
+          expect(described_class.validates_as_pr?(env)).to be(true)
+        end
+      end
+
+      describe ".determine_pull_or_merge_request_id" do
+        context "when CI_MERGE_REQUEST_IID present in environment" do
+          it "returns CI_MERGE_REQUEST_IID" do
+            expect(described_class.determine_pull_or_merge_request_id({
+              "CI_MERGE_REQUEST_IID" => 1
+            })).to eq(1)
+          end
+        end
+
+        context "when CI_COMMIT_SHA not present in environment" do
+          it "returns 0" do
+            expect(
+              described_class.determine_pull_or_merge_request_id({})
+            ).to eq(0)
+          end
+        end
+
+        context "when CI_COMMIT_SHA present in environment" do
+          context "before version 10.7" do
+            it "uses gitlab api to find merge request id" do
+              stub_version("10.6.4")
+              stub_merge_requests("merge_requests_response", "k0nserv%2Fdanger-test")
+
+              expect(described_class.determine_pull_or_merge_request_id({
+                "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
+                "CI_COMMIT_SHA" => "3333333333333333333333333333333333333333",
+                "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
+              })).to eq(3)
+            end
+          end
+          context "version 10.7 or later" do
+            it "uses gitlab api to find merge request id" do
+              #Arbitrary version, as tested manually, including text components to exercise the version comparison
+              stub_version("11.10.0-rc6-ee")
+              commit_sha = "3333333333333333333333333333333333333333"
+              stub_commit_merge_requests("commit_merge_requests", "k0nserv%2Fdanger-test", commit_sha)
+
+              expect(described_class.determine_pull_or_merge_request_id({
+                "CI_MERGE_REQUEST_PROJECT_PATH" => "k0nserv/danger-test",
+                "CI_COMMIT_SHA" => commit_sha,
+                "DANGER_GITLAB_API_TOKEN" => "a86e56d46ac78b"
+              })).to eq(1)
+            end
+          end
+        end
+      end
+
+      describe "#initialize" do
+        it "sets the repo_slug" do
+          expect(ci_source.repo_slug).to eq("k0nserv/danger-test")
+        end
+      end
+
+      describe "#pull_request_id" do
+        it "sets the pull_request_id" do
+          expect(ci_source.pull_request_id).to eq(env["CI_MERGE_REQUEST_IID"])
+        end
       end
     end
   end

--- a/spec/lib/danger/request_sources/request_source_spec.rb
+++ b/spec/lib/danger/request_sources/request_source_spec.rb
@@ -21,15 +21,6 @@ RSpec.describe Danger::RequestSources::RequestSource, host: :github do
       allow(git_mock).to receive(:exec).with("remote show origin -n").and_return("Fetch URL: git@git.club-mateusa.com:artsy/eigen.git")
       expect(g.validates_as_ci?).to be true
     end
-
-    it 'doesn\'t validate when passed a wrong repository' do
-      git_mock = Danger::GitRepo.new
-      allow(git_mock).to receive(:exec).with("remote show origin -n").and_return("Fetch URL: git@bitbucket.org:artsy/eigen.git")
-
-      g = stub_request_source
-      g.scm = git_mock
-      expect(g.validates_as_ci?).to be false
-    end
   end
 
   describe ".source_name" do


### PR DESCRIPTION
Resolves #1044

It is common for code repos to be hosted on Github while using
Gitlab only as a CI/CD service.

Info on using Gitlab only as CI/CD service for external repos:
https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/

Current limitations:
- Unfortunately, Gitlab currently does not expose the external repo's
url, so users will have to manually set the repo's URL as an ENV var
`DANGER_PROJECT_REPO_URL` 
(for ex., `DANGER_PROJECT_REPO_URL=https://github.com/procore/blueprinter`).
- Additionally, `RequestSources::Github#validates_as_ci?` is tricky now because
the `git remote -v` returns `origin` as `gitlab.com` rather than `github.com`. The
reasoning is that even though the actual repo is on Github.com, GitlabCI maintains a
mirror on Gitlab.com and the CI checkout the code from the Gitlab.com mirror.