### PR TITLE
Descriptive error message on shallow clone/fetch #trivial

### DIFF
--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -135,7 +135,7 @@ module Danger
       git_in_depth_fetch
       possible_merge_base = possible_merge_base(repo, from, to)
 
-      raise "Cannot find a merge base between #{from} and #{to}." unless possible_merge_base
+      raise "Cannot find a merge base between #{from} and #{to}. If you are using shallow clone/fetch, try increasing the --depth" unless possible_merge_base
 
       possible_merge_base
     end


### PR DESCRIPTION
If shallow clone/fetch is lower than the number of commits in a PR,
it will not be able to find the base.

For example, if the depth of clone/fetch is set to 10, and the PR has
11 commits, it will not be able to find the base. The error should
provide that hint as that could be the reason.

Related issues #913 #768 