### PR TITLE
feat(bitbucket_server_api): allow specifying the ca certificate path to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Add ability to specify ca file path for bitbucket server resource [@ryancurrah] [#1248](https://github.com/danger/danger/pull/1248)
+
 ## 8.0.3 - 8.0.4
 
 - Minor docs update, might also update the dockerfile

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -5,7 +5,7 @@ require "danger/helpers/comments_helper"
 module Danger
   module RequestSources
     class BitbucketServerAPI
-      attr_accessor :host, :pr_api_endpoint, :key, :project
+      attr_accessor :host, :ca_file, :pr_api_endpoint, :key, :project
 
       def initialize(project, slug, pull_request_id, environment)
         @username = environment["DANGER_BITBUCKETSERVER_USERNAME"]
@@ -14,6 +14,7 @@ module Danger
         if self.host && !(self.host.include? "http://") && !(self.host.include? "https://")
           self.host = "https://" + self.host
         end
+        self.ca_file = environment["DANGER_BITBUCKETSERVER_CA_FILE"]
         self.key = slug
         self.project = project
         self.pr_api_endpoint = "#{host}/rest/api/1.0/projects/#{project}/repos/#{slug}/pull-requests/#{pull_request_id}"
@@ -73,7 +74,7 @@ module Danger
       def fetch_json(uri)
         req = Net::HTTP::Get.new(uri.request_uri, { "Content-Type" => "application/json" })
         req.basic_auth @username, @password
-        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl, ca_file: self.ca_file) do |http|
           http.request(req)
         end
         JSON.parse(res.body, symbolize_names: true)
@@ -84,7 +85,7 @@ module Danger
         req.basic_auth @username, @password
         req.body = body
 
-        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl, ca_file: self.ca_file) do |http|
           http.request(req)
         end
 
@@ -99,7 +100,7 @@ module Danger
       def delete(uri)
         req = Net::HTTP::Delete.new(uri.request_uri, { "Content-Type" => "application/json" })
         req.basic_auth @username, @password
-        Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+        Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl, ca_file: self.ca_file) do |http|
           http.request(req)
         end
       end


### PR DESCRIPTION
For the bitbucket server request resource allow specifying the ca certificate path to use.

In environments where they are using self signed ca certificates we need to be able to specify a path to a CA cert for HTTP module so we do not get errors like below.

```
╰─ danger
Traceback (most recent call last):
        16: from /Users/rcurrah/.rbenv/versions/2.6.5/bin/danger:23:in `<main>'
        15: from /Users/rcurrah/.rbenv/versions/2.6.5/bin/danger:23:in `load'
        14: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/danger-8.0.4/bin/danger:5:in `<top (required)>'
        13: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
        12: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/danger-8.0.4/lib/danger/commands/runner.rb:73:in `run'
        11: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/danger-8.0.4/lib/danger/danger_core/executor.rb:29:in `run'
        10: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/danger-8.0.4/lib/danger/danger_core/dangerfile.rb:276:in `run'
         9: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/danger-8.0.4/lib/danger/danger_core/environment_manager.rb:52:in `fill_environment_vars'
         8: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/danger-8.0.4/lib/danger/request_sources/bitbucket_server.rb:46:in `fetch_details'
         7: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/danger-8.0.4/lib/danger/request_sources/bitbucket_server_api.rb:43:in `fetch_pr_json'
         6: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/danger-8.0.4/lib/danger/request_sources/bitbucket_server_api.rb:77:in `fetch_json'
         5: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/2.6.0/net/http.rb:605:in `start'
         4: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/2.6.0/net/http.rb:919:in `start'
         3: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/2.6.0/net/http.rb:930:in `do_start'
         2: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/2.6.0/net/http.rb:996:in `connect'
         1: from /Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/2.6.0/net/protocol.rb:44:in `ssl_socket_connect'
/Users/rcurrah/.rbenv/versions/2.6.5/lib/ruby/2.6.0/net/protocol.rb:44:in `connect_nonblock': SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain) (OpenSSL::SSL::SSLError)
```