### PR TITLE
Bump kramdown to ~> 2.3

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "faraday", ">= 0.9.0", "< 2.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
-  spec.add_runtime_dependency "kramdown", "~> 2.0"
+  spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "octokit", "~> 4.7"
   spec.add_runtime_dependency "terminal-table", "~> 1"


### PR DESCRIPTION
See [CVE-2020-14001](https://github.com/advisories/GHSA-mqm2-cgpr-p4m6). This came up as a GitHub _dependabot_ alert in our repo so I guess others have this issue as well.