### PR TITLE
Handle repository URLs with shh and port in Bitrise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+- Handle ssh URLs with port in Bitrise
+
 ## 8.0.4
 
 - Minor docs update, might also update the dockerfile

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -57,7 +57,8 @@ module Danger
       begin
         # Try to pars the URL as a valid URI. This should cover the cases of http/https/ssh URLs.
         uri = URI.parse(url)
-        return uri.path.delete_prefix("/").delete_suffix(".git")
+        # return uri.path.delete_prefix("/").delete_suffix(".git")
+        return uri.path.sub(/^(\/)/,'').sub(/(.git)$/,'')
       rescue URI::InvalidURIError
         # In case of invalid URI try the parse as a git URL. git@github.com:organization/repo.git
         matcher_url = url

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -50,16 +50,20 @@ module Danger
       self.repo_url = env["GIT_REPOSITORY_URL"]
       
       matcher_url = self.repo_url
+      self.repo_slug = repo_slug_from(self.repo_url)
+    end
 
-      #If the URL contains https:// as :// leads to inaccurate matching. So we remove it and proceed to match.
-      if repo_url.include? "https://"
-        matcher_url["https://"] = ''
+    def repo_slug_from(url)
+      begin
+        # Try to pars the URL as a valid URI. This should cover the cases of http/https/ssh URLs.
+        uri = URI.parse(url)
+        return uri.path.delete_prefix("/").delete_suffix(".git")
+      rescue URI::InvalidURIError
+        # In case of invalid URI try the parse as a git URL. git@github.com:organization/repo.git
+        matcher_url = url
+        repo_matches = matcher_url.match(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)})[2]
+        return repo_matches unless repo_matches.nil?
       end
-
-      repo_matches = matcher_url.match(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)})[2]
-
-      self.repo_slug = repo_matches unless repo_matches.nil?
-      
     end
   end
 end

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -54,16 +54,25 @@ module Danger
     end
 
     def repo_slug_from(url)
-      begin
+      if url =~ URI::regexp
         # Try to parse the URL as a valid URI. This should cover the cases of http/https/ssh URLs.
-        uri = URI.parse(url)
-        return uri.path.sub(/^(\/)/,'').sub(/(.git)$/,'')
-      rescue URI::InvalidURIError
-        # In case of invalid URI try the parse as a git URL. git@github.com:organization/repo.git
-        matcher_url = url
-        repo_matches = matcher_url.match(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)})[2]
-        return repo_matches unless repo_matches.nil?
+        begin
+          uri = URI.parse(url)
+          return uri.path.sub(/^(\/)/,'').sub(/(.git)$/,'')
+        rescue URI::InvalidURIError
+          # In case URL could not be parsed fallback to git URL parsing.
+          repo_slug_asgiturl(url)
+        end
+      else
+        # In case URL could not be parsed fallback to git URL parsing. git@github.com:organization/repo.git
+        repo_slug_asgiturl(url)
       end
+    end
+
+    def repo_slug_asgiturl(url)
+      matcher_url = url
+      repo_matches = matcher_url.match(%r{([\/:])(([^\/]+\/)+[^\/]+?)(\.git$|$)})[2]
+      return repo_matches unless repo_matches.nil?
     end
   end
 end

--- a/lib/danger/ci_source/bitrise.rb
+++ b/lib/danger/ci_source/bitrise.rb
@@ -55,9 +55,8 @@ module Danger
 
     def repo_slug_from(url)
       begin
-        # Try to pars the URL as a valid URI. This should cover the cases of http/https/ssh URLs.
+        # Try to parse the URL as a valid URI. This should cover the cases of http/https/ssh URLs.
         uri = URI.parse(url)
-        # return uri.path.delete_prefix("/").delete_suffix(".git")
         return uri.path.sub(/^(\/)/,'').sub(/(.git)$/,'')
       rescue URI::InvalidURIError
         # In case of invalid URI try the parse as a git URL. git@github.com:organization/repo.git

--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -76,6 +76,11 @@ RSpec.describe Danger::Bitrise do
       valid_env["GIT_REPOSITORY_URL"] = "https://github.com/artsy/ios/artsy.github.io.git"
       expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
     end
+
+    it "sets the repo_slug from a repo without scheme", host: :github do
+      valid_env["GIT_REPOSITORY_URL"] = "github.com/artsy/ios/artsy.github.io.git"
+      expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
+    end
     
     it "sets the repo_slug from a repo with .io instead of .com", host: :github do
       valid_env["GIT_REPOSITORY_URL"] = "git@github.company.io:artsy/ios/artsy.github.io.git"

--- a/spec/lib/danger/ci_sources/bitrise_spec.rb
+++ b/spec/lib/danger/ci_sources/bitrise_spec.rb
@@ -78,7 +78,17 @@ RSpec.describe Danger::Bitrise do
     end
     
     it "sets the repo_slug from a repo with .io instead of .com", host: :github do
-      valid_env["GIT_REPOSITORY_URL"] = "git@github.company.io/artsy/ios/artsy.github.io.git"
+      valid_env["GIT_REPOSITORY_URL"] = "git@github.company.io:artsy/ios/artsy.github.io.git"
+      expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
+    end
+
+    it "sets the repo_slug from an url that has an ssh scheme", host: :github do
+      valid_env["GIT_REPOSITORY_URL"] = "ssh://git@github.company.io/artsy/ios/artsy.github.io.git"
+      expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
+    end
+
+    it "sets the repo_slug from an url that has a port in it and has ssh as a scheme", host: :github do
+      valid_env["GIT_REPOSITORY_URL"] = "ssh://git@github.company.io:22/artsy/ios/artsy.github.io.git"
       expect(source.repo_slug).to eq("artsy/ios/artsy.github.io")
     end
 


### PR DESCRIPTION
This PR is fixing a bug that caused the corresponding Bitrise step to fail if a repository URL was provided with an SSH scheme and port.