### PR TITLE
[Ruby 2.7] Fix warnings for GitLab #1250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fixes warnings when using GitLab with Ruby 2.7 [@chwo](https://github.com/chwo) [#1250](https://github.com/danger/danger/issues/1250)
+
 ## 8.0.4
 
 - Minor docs update, might also update the dockerfile

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -208,7 +208,7 @@ module Danger
         rest_inline_violations = submit_inline_comments!({
           danger_id: danger_id,
           previous_violations: previous_violations
-        }.merge(inline_violations))
+        }.merge(**inline_violations))
 
         main_violations = merge_violations(
           regular_violations, rest_inline_violations
@@ -227,7 +227,7 @@ module Danger
             template: "gitlab",
             danger_id: danger_id,
             previous_violations: previous_violations
-          }.merge(main_violations))
+          }.merge(**main_violations))
 
           comment_result =
             if should_create_new_comment


### PR DESCRIPTION
- fixes #1250 
- implemented like https://github.com/danger/danger/pull/1222