### PR TITLE
Support matching multiple patterns `{a,b}` in FileList#include?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Add ability to set dismiss_out_of_range_messages for gitlab. - [@fahmisdk6](https://github.com/fahmisdk6)
+* Add support for multiple patterns `{a,b}` in FileList#include? - [@l15](https://github.com/l15n) [#1258](https://github.com/danger/danger/pull/1258)
 
 ## 8.0.5
 

--- a/lib/danger/core_ext/file_list.rb
+++ b/lib/danger/core_ext/file_list.rb
@@ -9,7 +9,7 @@ module Danger
     def include?(pattern)
       self.each do |current|
         unless current.nil?
-          return true if File.fnmatch(pattern, current) || pattern == current
+          return true if File.fnmatch(pattern, current, File::FNM_EXTGLOB) || pattern == current
         end
       end
       return false

--- a/spec/lib/danger/core_ext/file_list_spec.rb
+++ b/spec/lib/danger/core_ext/file_list_spec.rb
@@ -24,9 +24,16 @@ RSpec.describe Danger::FileList do
     it "returns false if nothing was found" do
       expect(@filelist.include?("notFound")).to eq(false)
     end
+
     it "returns false if file path is nil" do
       @filelist = Danger::FileList.new([nil])
       expect(@filelist.include?("pattern")).to eq(false)
+    end
+
+    it "supports {a,b} as union of multiple patterns" do
+      expect(@filelist.include?("{path1/file_name.txt,path3/file_name.rb}")).to eq(true)
+      expect(@filelist.include?("{path1/file_name.rb,path1/file_name.js}")).to eq(false)
+      expect(@filelist.include?("{path1/file_name.rb,path1/file_name.js,path2/*}")).to eq(true)
     end
   end
 end


### PR DESCRIPTION
# Use case

I'd like to be able to trigger a rule when files requiring different patterns match. Currently, this can be achieved by calling `FileList#include?` multiple times.

i.e. 

```ruby
# Dangerfile
if git.modified_files.include?("pattern1") || git.modified_files.include?("pattern2")
  warn("some shared warning")
end
```

## Proposal

`FileList#include?` is based on [`File.fnmatch`](https://rubyapi.org/2.7/o/file#method-c-fnmatch). `File.fnmatch` supports an optional syntax `{a,b}`which can match multiple patterns.

From the `File.fnmatch` documentation:

> `{a,b}`  |      Matches pattern a and pattern b if `File::FNM_EXTGLOB` flag is enabled. Behaves like a Regexp union `((?:a|b))`.

I'm initially proposing to enable this flag by default, allowing usage such as

```ruby
if git.modified_files.include?("{pattern1,pattern2}")
  warn("some shared warning")
end
```

This is much more compact, and supports > 2 patterns to be checked in a single pass. 

Note that this syntax also works within a pattern, and can be used multiple times e.g. `app/models/{controllers,helpers}/{order,deliver,item}*`, much like shell globbing.

## Tradeoffs and alternatives

In this implementation, I've enabled this option by default. This means that a literal `{a,b}` in a pattern will no longer work correctly. My understanding is that this pattern is exceedingly rare for filenames, but I may be mistaken.

Alternative interfaces include:

* Adding an option to `include?` that accepts the same options as `File.fnmatch`, allowing the user to explicitly specify `File::FNM_EXTGLOB`. This requires additional knowledge, and unfortunately exposes internal implementation details. On the other hand, it gives further flexibility, such as `File::FNM_CASEFOLD` (case insensitive), `File::FNM_DOTMATCH` (match `.` files with `*`), etc.
* Accept an `options` hash in `include?` that exposes `File.fnmatch` options with friendlier names, e.g. `include?(pattern, glob: true, case_insensitive: true, dot_match: true)` etc. This is a more complex implementation, and still requires the user to read up on the documentation anyway.



