### PR TITLE
Preserve single and double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 * Add ability to set dismiss_out_of_range_messages for gitlab. - [@fahmisdk6](https://github.com/fahmisdk6)
+* Preserve single and double quotes [@caalberts](https://github.com/caalberts)
 
 ## 8.0.5
 

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -11,7 +11,7 @@ module Danger
       include Danger::Helpers::CommentsParsingHelper
 
       def markdown_parser(text)
-        Kramdown::Document.new(text, input: "GFM")
+        Kramdown::Document.new(text, input: "GFM", smart_quotes: %w[apos apos quot quot])
       end
 
       # !@group Extension points

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -185,13 +185,14 @@ RSpec.describe Danger::Helpers::CommentsHelper do
     let(:violation_2) do
       violation_factory("A [link](https://example.com)", sticky: true)
     end
+    let(:violation_3) { violation_factory(%(with "double quote" and 'single quote')) }
 
     it "produces table data" do
-      table_data = dummy.table("2 Errors", "no_entry_sign", [violation_1, violation_2], {})
+      table_data = dummy.table("3 Errors", "no_entry_sign", [violation_1, violation_2, violation_3], {})
 
-      expect(table_data[:name]).to eq("2 Errors")
+      expect(table_data[:name]).to eq("3 Errors")
       expect(table_data[:emoji]).to eq("no_entry_sign")
-      expect(table_data[:content].size).to be(2)
+      expect(table_data[:content].size).to be(3)
       expect(table_data[:content][0].message).to eq("<strong>Violation 1</strong>")
       expect(table_data[:content][0].sticky).to eq(false)
 
@@ -199,8 +200,9 @@ RSpec.describe Danger::Helpers::CommentsHelper do
         "A <a href=\"https://example.com\">link</a>"
       )
       expect(table_data[:content][1].sticky).to eq(true)
+      expect(table_data[:content][2].message).to eq(%(with "double quote" and 'single quote'))
       expect(table_data[:resolved]).to be_empty
-      expect(table_data[:count]).to be(2)
+      expect(table_data[:count]).to be(3)
     end
 
     shared_examples "violation text as heredoc" do


### PR DESCRIPTION
The default behaviour of Kramdown replaces single quote `'`/`apos` with `lsquo` and `rsquo`, and double quote `"`/`quot` with `ldquo` and `rdquo`.

This creates unexpected result when a message contains quotes in '' or "".

Fixes #1263 

This was discovered in https://gitlab.com/gitlab-org/gitlab/-/merge_requests/44004#note_422102483