### PR TITLE
fix ruby 2.7 warning with correct double splat usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -->
 
 ## master
+* correct the usage of double splat to fix Ruby 2.7 warning
 
 ## 8.0.6
 

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -171,10 +171,10 @@ module Danger
           markdowns: markdowns
         )
 
-        rest_inline_violations = submit_inline_comments!({
+        rest_inline_violations = submit_inline_comments!(**{
           danger_id: danger_id,
           previous_violations: previous_violations
-        }.merge(**inline_violations))
+        }.merge(inline_violations))
 
         main_violations = merge_violations(
           regular_violations, rest_inline_violations
@@ -189,11 +189,11 @@ module Danger
 
         # If there are still violations to show
         if main_violations_sum.any?
-          body = generate_comment({
+          body = generate_comment(**{
             template: "github",
             danger_id: danger_id,
             previous_violations: previous_violations
-          }.merge(**main_violations))
+          }.merge(main_violations))
 
           comment_result =
             if should_create_new_comment


### PR DESCRIPTION
This corrects the fix made for Ruby 2.7 warning in this PR https://github.com/danger/danger/pull/1222.