### PR TITLE
Code Insights support for Bitbucket Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Adds support for Code Insights for Bitbucket Server. [@qbeorama](https://github.com/Qbeorama)
+
 ## 8.0.6
 
 * Add ability to set dismiss_out_of_range_messages for gitlab. - [@fahmisdk6](https://github.com/fahmisdk6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 
-* Adds support for Code Insights for Bitbucket Server. [@qbeorama](https://github.com/Qbeorama)
+* Adds support for Code Insights for Bitbucket Server. To use Code Insights, please ensure `DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY`, `DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE` and `DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION` optional environment variabls are set. [@qbeorama](https://github.com/Qbeorama)
 
 ## 8.0.6
 

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -2,6 +2,8 @@
 
 require "danger/helpers/comments_helper"
 require "danger/request_sources/bitbucket_server_api"
+require "danger/request_sources/code_insights_api"
+require_relative "request_source"
 
 module Danger
   module RequestSources
@@ -17,12 +19,21 @@ module Danger
         ]
       end
 
+      def self.optional_env_vars
+        ["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY",
+         "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE",
+         "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION",
+         "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL"
+        ]
+      end
+
       def initialize(ci_source, environment)
         self.ci_source = ci_source
         self.environment = environment
 
         project, slug = ci_source.repo_slug.split("/")
         @api = BitbucketServerAPI.new(project, slug, ci_source.pull_request_id, environment)
+        @code_insights = CodeInsightsAPI.new(project, slug, environment)
       end
 
       def validates_as_ci?
@@ -73,15 +84,50 @@ module Danger
       def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
         delete_old_comments(danger_id: danger_id) if !new_comment || remove_previous_comments
 
-        comment = generate_description(warnings: warnings, errors: errors)
-        comment += "\n\n"
-        comment += generate_comment(warnings: warnings,
-                                     errors: errors,
-                                   messages: messages,
-                                  markdowns: markdowns,
-                        previous_violations: {},
-                                  danger_id: danger_id,
-                                   template: "bitbucket_server")
+        inline_violations = inline_violations_group(warnings: warnings, errors: errors, messages: messages)
+        inline_warnings = inline_violations[:warnings] || []
+        inline_errors = inline_violations[:errors] || []
+        inline_messages = inline_violations[:messages] || []
+
+        has_inline_comments = !(inline_warnings + inline_errors + inline_messages).empty?
+         if has_inline_comments
+
+          main_violations = main_violations_group(warnings: warnings, errors: errors, messages: messages)
+          main_warnings = main_violations[:warnings] || []
+          main_errors = main_violations[:errors] || []
+          main_messages = main_violations[:messages] || []
+          main_markdowns = main_violations[:markdowns] || []
+
+          comment = generate_description(warnings: main_warnings, errors: main_errors)
+          comment += "\n\n"
+          comment += generate_comment(warnings: main_warnings,
+                                      errors: main_errors,
+                                      messages: main_messages,
+                                      markdowns: main_markdowns,
+                                      previous_violations: {},
+                                      danger_id: danger_id,
+                                      template: "bitbucket_server")
+
+        else
+
+          comment = generate_description(warnings: warnings, errors: errors)
+          comment += "\n\n"
+          comment += generate_comment(warnings: warnings,
+                                      errors: errors,
+                                      messages: messages,
+                                      markdowns: markdowns,
+                                      previous_violations: {},
+                                      danger_id: danger_id,
+                                      template: "bitbucket_server")
+         end
+
+        if @code_insights.ready?
+          head_commit = self.pr_json[:fromRef][:latestCommit]
+          @code_insights.send_report(head_commit,
+                                     inline_warnings,
+                                     inline_errors,
+                                     inline_messages)
+        end
 
         @api.post_comment(comment)
       end
@@ -91,7 +137,34 @@ module Danger
           @api.delete_comment(c[:id], c[:version]) if c[:text] =~ /generated_by_#{danger_id}/
         end
       end
-        
+
+      def main_violations_group(warnings: [], errors: [], messages: [], markdowns: [])
+        {
+          warnings: warnings.reject(&:inline?),
+          errors: errors.reject(&:inline?),
+          messages: messages.reject(&:inline?),
+          markdowns: markdowns.reject(&:inline?)
+        }
+      end
+
+      def inline_violations_group(warnings: [], errors: [], messages: [], markdowns: [])
+        cmp = proc do |a, b|
+          next -1 unless a.file && a.line
+          next 1 unless b.file && b.line
+
+          next a.line <=> b.line if a.file == b.file
+          next a.file <=> b.file
+        end
+
+        # Sort to group inline comments by file
+        {
+          warnings: warnings.select(&:inline?).sort(&cmp),
+          errors: errors.select(&:inline?).sort(&cmp),
+          messages: messages.select(&:inline?).sort(&cmp),
+          markdowns: markdowns.select(&:inline?).sort(&cmp)
+        }
+      end
+
       def update_pr_build_status(status, build_job_link, description)
         changeset = self.pr_json[:fromRef][:latestCommit]
         # Support for older versions of Bitbucket Server

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -89,8 +89,9 @@ module Danger
         inline_errors = inline_violations[:errors] || []
         inline_messages = inline_violations[:messages] || []
 
+        # Separate main and inline comments only if Code Insights is ready to display the inline comments separately
         has_inline_comments = !(inline_warnings + inline_errors + inline_messages).empty?
-         if has_inline_comments
+        if has_inline_comments && @code_insights.ready?
 
           main_violations = main_violations_group(warnings: warnings, errors: errors, messages: messages)
           main_warnings = main_violations[:warnings] || []
@@ -108,8 +109,14 @@ module Danger
                                       danger_id: danger_id,
                                       template: "bitbucket_server")
 
-        else
+          head_commit = self.pr_json[:fromRef][:latestCommit]
+          @code_insights.send_report(head_commit,
+                                     inline_warnings,
+                                     inline_errors,
+                                     inline_messages)
 
+          # Otherwise, post both main body and inline comments as a single comment.
+        else
           comment = generate_description(warnings: warnings, errors: errors)
           comment += "\n\n"
           comment += generate_comment(warnings: warnings,
@@ -119,14 +126,6 @@ module Danger
                                       previous_violations: {},
                                       danger_id: danger_id,
                                       template: "bitbucket_server")
-         end
-
-        if @code_insights.ready?
-          head_commit = self.pr_json[:fromRef][:latestCommit]
-          @code_insights.send_report(head_commit,
-                                     inline_warnings,
-                                     inline_errors,
-                                     inline_messages)
         end
 
         @api.post_comment(comment)

--- a/lib/danger/request_sources/code_insights_api.rb
+++ b/lib/danger/request_sources/code_insights_api.rb
@@ -9,16 +9,16 @@ module Danger
     #
     # Currently this functionality is implemented only for Bitbucket Server request source.
     class CodeInsightsAPI
-      attr_accessor :report_title, :report_description, :report_key, :logo_url, :username, :password, :host
+      attr_accessor :username, :password, :host, :report_key, :report_title, :report_description, :logo_url
 
       def initialize(project, slug, environment)
-        @report_title = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE"] || ""
-        @report_key = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY"] || ""
-        @report_description = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION"] || ""
-        @logo_url = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL"] || ""
         @username = environment["DANGER_BITBUCKETSERVER_USERNAME"] || ""
         @password = environment["DANGER_BITBUCKETSERVER_PASSWORD"] || ""
         @host = environment["DANGER_BITBUCKETSERVER_HOST"] || ""
+        @report_key = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY"] || ""
+        @report_title = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE"] || ""
+        @report_description = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION"] || ""
+        @logo_url = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL"] || ""
         @project = project
         @slug = slug
       end
@@ -34,7 +34,7 @@ module Danger
       end
 
       def ready?
-        !(@report_title.empty? || @report_description.empty? || @username.empty? || @password.empty? || @host.empty? || report_key.empty?)
+        !(@report_key.empty? || @report_title.empty? || @report_description.empty? || @username.empty? || @password.empty? || @host.empty?)
       end
 
       def delete_report(commit)

--- a/lib/danger/request_sources/code_insights_api.rb
+++ b/lib/danger/request_sources/code_insights_api.rb
@@ -1,0 +1,131 @@
+# coding: utf-8
+
+module Danger
+  module RequestSources
+    class CodeInsightsAPI
+      attr_accessor :report_title, :report_description, :logo_url, :username, :password, :host
+
+      def initialize(project, slug, environment)
+        @report_title = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE"]
+        @report_key = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY"]
+        @report_description = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION"]
+        @logo_url = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL"]
+        @username = environment["DANGER_BITBUCKETSERVER_USERNAME"]
+        @password = environment["DANGER_BITBUCKETSERVER_PASSWORD"]
+        @host = environment["DANGER_BITBUCKETSERVER_HOST"]
+        @project = project
+        @slug = slug
+      end
+
+      def ready?
+        !(@report_title.empty? || @report_description.empty? || @username.empty? || @password.empty? || @host.empty?)
+      end
+
+      def delete_report(commit)
+        uri = URI(report_endpoint_at_commit(commit))
+        request = Net::HTTP::Delete.new(uri.request_uri, {"Content-Type" => "application/json"})
+        request.basic_auth @username, @password
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+          http.request(request)
+        end
+
+        # show failure when server returns an error
+        case response
+        when Net::HTTPClientError, Net::HTTPServerError
+          # HTTP 4xx - 5xx
+          abort "\nError deleting report from Code Insights API: #{response.code} (#{response.message}) - #{response.body}\n\n"
+        end
+
+      end
+
+      def send_report(commit, inline_warnings, inline_errors, inline_messages)
+        delete_report(commit)
+        put_report(commit, inline_errors.count)
+        should_post_annotations = !(inline_warnings + inline_errors + inline_messages).empty?
+        if should_post_annotations
+          post_annotations(commit, inline_warnings, inline_errors, inline_messages)
+        end
+      end
+
+      def put_report(commit, inline_errors_count)
+        uri = URI(report_endpoint_at_commit(commit))
+        request = Net::HTTP::Put.new(uri.request_uri, {"Content-Type" => "application/json"})
+        request.basic_auth @username, @password
+        request.body = {"title": @report_title,
+                        "details": @report_description,
+                        "result": (inline_errors_count > 0) ? "FAIL" : "PASS",
+                        "reporter": @username,
+                        "link": "https://github.com/danger/danger",
+                        "logoURL": @logo_url
+        }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+          http.request(request)
+        end
+
+        # show failure when server returns an error
+        case response
+        when Net::HTTPClientError, Net::HTTPServerError
+          # HTTP 4xx - 5xx
+          abort "\nError putting report to Code Insights API: #{response.code} (#{response.message}) - #{response.body}\n\n"
+        end
+      end
+
+      def post_annotations(commit, inline_warnings, inline_errors, inline_messages)
+        uri = URI(annotation_endpoint_at_commit(commit))
+
+        annotations = []
+
+        inline_messages.each do |violation|
+          annotations << violation_hash_with_severity(violation, "LOW")
+        end
+
+        inline_warnings.each do |violation|
+          annotations << violation_hash_with_severity(violation, "MEDIUM")
+        end
+
+        inline_errors.each do |violation|
+          annotations << violation_hash_with_severity(violation, "HIGH")
+        end
+
+        body = {annotations: annotations}.to_json
+        request = Net::HTTP::Post.new(uri.request_uri, {"Content-Type" => "application/json"})
+        request.basic_auth @username, @password
+        request.body = body
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+          http.request(request)
+        end
+
+        # show failure when server returns an error
+        case response
+        when Net::HTTPClientError, Net::HTTPServerError
+          # HTTP 4xx - 5xx
+          abort "\nError posting comment to Code Insights API: #{response.code} (#{response.message}) - #{response.body}\n\n"
+        end
+      end
+
+      def violation_hash_with_severity(violation, severity)
+        annotation = {}
+        annotation["message"] = violation.message
+        annotation["severity"] = severity
+        annotation["path"] = violation.file
+        annotation["line"] = violation.line.to_i
+        return annotation
+      end
+
+      def report_endpoint_at_commit(commit)
+        "#{@host}/rest/insights/1.0/projects/#{@project}/repos/#{@slug}/commits/#{commit}/reports/#{@report_key}"
+      end
+
+      def annotation_endpoint_at_commit(commit)
+        report_endpoint_at_commit(commit) + "/annotations"
+      end
+
+      def use_ssl
+        @host.include? "https://"
+      end
+
+    end
+  end
+end

--- a/lib/danger/request_sources/code_insights_api.rb
+++ b/lib/danger/request_sources/code_insights_api.rb
@@ -2,6 +2,12 @@
 
 module Danger
   module RequestSources
+    #
+    # Provides ability for Danger to interact with Atlassian's Code Insights API in order to provide code quality
+    # reports along with inline comments for specific lines in specific files.
+    #  See https://developer.atlassian.com/server/bitbucket/how-tos/code-insights/ for more details.
+    #
+    # Currently this functionality is implemented only for Bitbucket Server request source.
     class CodeInsightsAPI
       attr_accessor :report_title, :report_description, :report_key, :logo_url, :username, :password, :host
 

--- a/lib/danger/request_sources/code_insights_api.rb
+++ b/lib/danger/request_sources/code_insights_api.rb
@@ -3,22 +3,32 @@
 module Danger
   module RequestSources
     class CodeInsightsAPI
-      attr_accessor :report_title, :report_description, :logo_url, :username, :password, :host
+      attr_accessor :report_title, :report_description, :report_key, :logo_url, :username, :password, :host
 
       def initialize(project, slug, environment)
-        @report_title = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE"]
-        @report_key = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY"]
-        @report_description = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION"]
-        @logo_url = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL"]
-        @username = environment["DANGER_BITBUCKETSERVER_USERNAME"]
-        @password = environment["DANGER_BITBUCKETSERVER_PASSWORD"]
-        @host = environment["DANGER_BITBUCKETSERVER_HOST"]
+        @report_title = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE"] || ""
+        @report_key = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY"] || ""
+        @report_description = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION"] || ""
+        @logo_url = environment["DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL"] || ""
+        @username = environment["DANGER_BITBUCKETSERVER_USERNAME"] || ""
+        @password = environment["DANGER_BITBUCKETSERVER_PASSWORD"] || ""
+        @host = environment["DANGER_BITBUCKETSERVER_HOST"] || ""
         @project = project
         @slug = slug
       end
 
+      def inspect
+        inspected = super
+
+        if @password
+          inspected = inspected.sub! @password, "********".freeze
+        end
+
+        inspected
+      end
+
       def ready?
-        !(@report_title.empty? || @report_description.empty? || @username.empty? || @password.empty? || @host.empty?)
+        !(@report_title.empty? || @report_description.empty? || @username.empty? || @password.empty? || @host.empty? || report_key.empty?)
       end
 
       def delete_report(commit)

--- a/spec/lib/danger/request_sources/code_insights_api_spec.rb
+++ b/spec/lib/danger/request_sources/code_insights_api_spec.rb
@@ -3,7 +3,15 @@
 require "danger/request_sources/bitbucket_server"
 
 RSpec.describe Danger::RequestSources::CodeInsightsAPI, host: :bitbucket_server do
-  let(:code_insights) { Danger::RequestSources::CodeInsightsAPI.new("danger", "danger", stub_env_with_code_insights_fields)}
+  let(:code_insights) {
+    code_insights_fields = {
+      "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY" => "ReportKey",
+      "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE" => "Code Insights Report Title",
+      "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION" => "Report description",
+      "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL" => "https://stash.example.com/logo_url.png"
+    }
+    stub_env_with_code_insights_fields = stub_env.merge(code_insights_fields)
+    Danger::RequestSources::CodeInsightsAPI.new("danger", "danger", stub_env_with_code_insights_fields)}
 
   describe "initialization" do
     it "should properly parse corresponding environment variables" do

--- a/spec/lib/danger/request_sources/code_insights_api_spec.rb
+++ b/spec/lib/danger/request_sources/code_insights_api_spec.rb
@@ -1,0 +1,59 @@
+# coding: utf-8
+
+require "danger/request_sources/bitbucket_server"
+
+RSpec.describe Danger::RequestSources::CodeInsightsAPI, host: :bitbucket_server do
+  let(:code_insights) { Danger::RequestSources::CodeInsightsAPI.new("danger", "danger", stub_env_with_code_insights_fields)}
+
+  describe "initialization" do
+    it "should properly parse corresponding environment variables" do
+      expect(code_insights.username).to eq("a.name")
+      expect(code_insights.password).to eq("a_password")
+      expect(code_insights.host).to eq("stash.example.com")
+      expect(code_insights.report_key).to eq("ReportKey")
+      expect(code_insights.report_title).to eq("Code Insights Report Title")
+      expect(code_insights.report_description).to eq("Report description")
+      expect(code_insights.logo_url).to eq("https://stash.example.com/logo_url.png")
+    end
+  end
+
+  describe "#is_ready" do
+    it "should return true when all required fields are provided" do
+      expect(code_insights.ready?).to be true
+    end
+    it "should return false when username is empty" do
+      code_insights.username = ""
+      expect(code_insights.ready?).to be false
+    end
+    it "should return false when password is empty" do
+      code_insights.password = ""
+      expect(code_insights.ready?).to be false
+    end
+    it "should return false when host is empty" do
+      code_insights.host = ""
+      expect(code_insights.ready?).to be false
+    end
+    it "should return false when report title is empty" do
+      code_insights.report_title = ""
+      expect(code_insights.ready?).to be false
+    end
+    it "should return false when report description is empty" do
+      code_insights.report_description = ""
+      expect(code_insights.ready?).to be false
+    end
+    it "should return false when report key is empty" do
+      code_insights.report_key = ""
+      expect(code_insights.ready?).to be false
+    end
+  end
+
+  describe "#inspect" do
+    it "should mask password on inspect" do
+      allow(ENV).to receive(:[]).with("ENVDANGER_BITBUCKETSERVER_PASSWORD") { "supertopsecret" }
+      api = described_class.new("danger", "danger", stub_env)
+      inspected = api.inspect
+      expect(inspected).to include(%(@password="********"))
+    end
+  end
+
+end

--- a/spec/support/bitbucket_server_helper.rb
+++ b/spec/support/bitbucket_server_helper.rb
@@ -12,6 +12,21 @@ module Danger
         }
       end
 
+      def stub_env_with_code_insights_fields
+        {
+          "DANGER_BITBUCKETSERVER_HOST" => "stash.example.com",
+          "DANGER_BITBUCKETSERVER_USERNAME" => "a.name",
+          "DANGER_BITBUCKETSERVER_PASSWORD" => "a_password",
+          "JENKINS_URL" => "http://jenkins.example.com/job/ios-check-pullrequest/",
+          "GIT_URL" => "ssh://git@stash.example.com:7999/ios/fancyapp.git",
+          "ghprbPullId" => "2080",
+          "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY" => "ReportKey",
+          "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE" => "Code Insights Report Title",
+          "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION" => "Report description",
+          "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL" => "https://stash.example.com/logo_url.png"
+        }
+      end
+
       def stub_ci
         Danger::Jenkins.new(stub_env)
       end

--- a/spec/support/bitbucket_server_helper.rb
+++ b/spec/support/bitbucket_server_helper.rb
@@ -12,21 +12,6 @@ module Danger
         }
       end
 
-      def stub_env_with_code_insights_fields
-        {
-          "DANGER_BITBUCKETSERVER_HOST" => "stash.example.com",
-          "DANGER_BITBUCKETSERVER_USERNAME" => "a.name",
-          "DANGER_BITBUCKETSERVER_PASSWORD" => "a_password",
-          "JENKINS_URL" => "http://jenkins.example.com/job/ios-check-pullrequest/",
-          "GIT_URL" => "ssh://git@stash.example.com:7999/ios/fancyapp.git",
-          "ghprbPullId" => "2080",
-          "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_KEY" => "ReportKey",
-          "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_TITLE" => "Code Insights Report Title",
-          "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION" => "Report description",
-          "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL" => "https://stash.example.com/logo_url.png"
-        }
-      end
-
       def stub_ci
         Danger::Jenkins.new(stub_env)
       end


### PR DESCRIPTION

This PR adds possibility to pipeline inline comments generated by Danger and plugins to use directly in Atlassian's [Code Insights](https://support.atlassian.com/bitbucket-cloud/docs/code-insights/) report generating tools.

If inline comments are present and Code Insights are properly configured, they will be added on a per-file, per-line basis as [Annotations](Annotations). As in example below (_"WCAG 2.0: Use a more descriptive alternative text"_ is an example of a Low priority Annotation).

<img width="895" alt="hiding-annotations (1)" src="https://user-images.githubusercontent.com/4989023/96148213-5713c300-0f08-11eb-8857-58211458a31a.png">

Otherwise, default behaviour will be used (all inline comments inserted into single Danger pull request comment). 

As of this PR, Code Insights is only integrated with Bitbucket Server as this is the request source I had access to test against, however, it should be possible to adapt this code to work with Bitbucket Cloud, too.