### PR TITLE
fix ruby 2.7 warning with correct double splat usage for gitlab.rb

### DIFF
--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -206,10 +206,10 @@ module Danger
           markdowns: markdowns
         )
 
-        rest_inline_violations = submit_inline_comments!({
+        rest_inline_violations = submit_inline_comments!(**{
           danger_id: danger_id,
           previous_violations: previous_violations
-        }.merge(**inline_violations))
+        }.merge(inline_violations))
 
         main_violations = merge_violations(
           regular_violations, rest_inline_violations
@@ -224,11 +224,11 @@ module Danger
 
         # If there are still violations to show
         if main_violations_sum.any?
-          body = generate_comment({
+          body = generate_comment(**{
             template: "gitlab",
             danger_id: danger_id,
             previous_violations: previous_violations
-          }.merge(**main_violations))
+          }.merge(main_violations))
 
           comment_result =
             if should_create_new_comment


### PR DESCRIPTION
Identical to #1264 but for `gitlab.rb`

Cf. https://github.com/danger/danger/issues/1250#issuecomment-686392009