### PR TITLE
Add support for Concourse-CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## master
 <!-- Your comment below here -->
 
-
+* Add support for Concourse-CI [@matthewellis](https://github.com/matthewellis)
 
 <!-- Your comment above here -->
 ## 8.1.0

--- a/lib/danger/ci_source/concourse.rb
+++ b/lib/danger/ci_source/concourse.rb
@@ -1,0 +1,61 @@
+require "git"
+require "danger/request_sources/local_only"
+
+module Danger
+# Concourse CI Integration
+#
+# https://concourse-ci.org/
+#
+  # ### CI Setup
+  #
+  # With Concourse, you run the docker images yourself, so you will want to add `yarn danger ci` within one of your build jobs.
+  #
+  #   ``` shell
+  #    build:
+  #      image: golang
+  #        commands:
+  #          - ...
+  #          - yarn danger ci
+  #   ```
+  #
+  # ### Environment Variable Setup
+  #
+  # As this is self-hosted, you will need to add the `CONCOURSE` environment variable `export CONCOURSE=true` to your build environment,
+  # as well as setting environment variables for `PULL_REQUEST_ID` and `REPO_SLUG`. Assuming you are using the github pull request resource
+  # https://github.com/jtarchie/github-pullrequest-resource the id of the PR can be accessed from `git config --get pullrequest.id`.
+  #
+  # ### Token Setup
+  #
+  # Once again as this is self-hosted, you will need to add `DANGER_GITHUB_API_TOKEN` environment variable to the build environment.
+  # The suggested method of storing the token is within the vault - https://concourse-ci.org/creds.html
+
+  class Concourse < CI
+    def self.validates_as_ci?(env)
+      env.key? "CONCOURSE"
+    end
+
+    def self.validates_as_pr?(env)
+      exists = ["PULL_REQUEST_ID", "REPO_SLUG"].all? { |x| env[x] && !env[x].empty? }
+      exists && env["PULL_REQUEST_ID"].to_i > 0
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= [
+        Danger::RequestSources::GitHub,
+        Danger::RequestSources::GitLab,
+        Danger::RequestSources::BitbucketServer,
+        Danger::RequestSources::BitbucketCloud
+      ]
+    end
+
+    def initialize(env)
+      self.repo_slug = env["REPO_SLUG"]
+
+      if env["PULL_REQUEST_ID"].to_i > 0
+        self.pull_request_id = env["PULL_REQUEST_ID"]
+      end
+      self.repo_url = GitRepo.new.origins
+    end
+
+  end
+end

--- a/spec/lib/danger/ci_sources/ci_source_spec.rb
+++ b/spec/lib/danger/ci_sources/ci_source_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Danger::CI do
           "Danger::CodeBuild",
           "Danger::Codefresh",
           "Danger::Codeship",
+          "Danger::Concourse",
           "Danger::DotCi",
           "Danger::Drone",
           "Danger::GitLabCI",

--- a/spec/lib/danger/ci_sources/concourse_spec.rb
+++ b/spec/lib/danger/ci_sources/concourse_spec.rb
@@ -1,0 +1,86 @@
+require "danger/ci_source/concourse"
+
+RSpec.describe Danger::Concourse do
+  let(:valid_env) do
+    {
+      "CONCOURSE" => "true",
+      "PULL_REQUEST_ID" => "800",
+      "REPO_SLUG" => "artsy/eigen"
+    }
+  end
+
+  let(:source) { described_class.new(valid_env) }
+
+  describe ".validates_as_ci?" do
+    it "validates when all Concourse environment vars are set" do
+      expect(described_class.validates_as_ci?(valid_env)).to be true
+    end
+
+    ["PULL_REQUEST_ID", "REPO_SLUG"].each do |var|
+      it "validates when `#{var}` is missing" do
+        valid_env[var] = nil
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+
+      it "validates when `#{var}` is empty" do
+        valid_env[var] = ""
+        expect(described_class.validates_as_ci?(valid_env)).to be true
+      end
+    end
+  end
+
+  describe ".validates_as_pr?" do
+    it "validates when all Concourse PR environment vars are set" do
+      expect(described_class.validates_as_pr?(valid_env)).to be true
+    end
+
+    ["PULL_REQUEST_ID", "REPO_SLUG"].each do |var|
+      it "does not validate when `#{var}` is missing" do
+        valid_env[var] = nil
+        expect(described_class.validates_as_pr?(valid_env)).to be false
+      end
+
+      it "does not validate when `#{var}` is empty" do
+        valid_env[var] = ""
+        expect(described_class.validates_as_pr?(valid_env)).to be false
+      end
+    end
+
+    it "dost not validate when `PULL_REQUEST_ID` is `false`" do
+      valid_env["PULL_REQUEST_ID"] = "false"
+      expect(described_class.validates_as_pr?(valid_env)).to be false
+    end
+
+    it "does not validate if `PULL_REQUEST_ID` is empty" do
+      valid_env["PULL_REQUEST_ID"] = ""
+      expect(described_class.validates_as_pr?(valid_env)).to be false
+    end
+
+    it "does not validate if `PULL_REQUEST_ID` is not a int" do
+      valid_env["PULL_REQUEST_ID"] = "pulls"
+      expect(described_class.validates_as_pr?(valid_env)).to be false
+    end
+  end
+
+  describe "#new" do
+    it "sets the pull_request_id" do
+      expect(source.pull_request_id).to eq("800")
+    end
+
+    it "sets the repo_slug" do
+      expect(source.repo_slug).to eq("artsy/eigen")
+    end
+
+    it "sets the repo_url", host: :github do
+      with_git_repo do
+        expect(source.repo_url).to eq("git@github.com:artsy/eigen")
+      end
+    end
+  end
+
+  describe "#supported_request_sources" do
+    it "supports GitHub" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::GitHub)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for Concourse-CI to danger as a supported CI system

This PR uses the same ENV's as found in danger-js in this PR https://github.com/danger/danger-js/pull/658, This has been done to keep things consistent between the two for Concourse.