### PR TITLE
Fix GitHub actions issue with pull_request_target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## master
 <!-- Your comment below here -->
 
-
+* Add support for `pull_request_target` in GitHub actions. - [@chesire](https://github.com/chesire)
 
 <!-- Your comment above here -->
 ## 8.1.0

--- a/lib/danger/ci_source/github_actions.rb
+++ b/lib/danger/ci_source/github_actions.rb
@@ -21,7 +21,8 @@ module Danger
     end
 
     def self.validates_as_pr?(env)
-      env["GITHUB_EVENT_NAME"] == "pull_request"
+      value = env["GITHUB_EVENT_NAME"]
+      value == "pull_request" || value == "pull_request_target"
     end
 
     def supported_request_sources

--- a/spec/lib/danger/ci_sources/github_actions_spec.rb
+++ b/spec/lib/danger/ci_sources/github_actions_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe Danger::GitHubActions do
         expect(described_class.validates_as_pr?(valid_env)).to be true
       end
 
+      it "validates if `GITHUB_EVENT_NAME` is 'pull_request_target" do
+        valid_env["GITHUB_EVENT_NAME"] = "pull_request_target"
+        expect(described_class.validates_as_pr?(valid_env)).to be true
+      end
+
       it "doesn't validate if `GITHUB_EVENT_NAME` is 'push'" do
         valid_env["GITHUB_EVENT_NAME"] = "push"
         expect(described_class.validates_as_pr?(valid_env)).to be false


### PR DESCRIPTION
Using GitHub actions if the event name is `pull_request_target` instead of `pull_request`, then Danger will not detect it as a valid PR and the error ```Not a GitHubActions Pull Request - skipping `danger` run.``` will be displayed when trying to run it.
Updated the check in the `github_actions` file to also check for this event name as well.

Based on https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/ this should be almost identical so hopefully the change will work as intended, I could not see anything related on how to test a GitHub action though.