### PR TITLE
Fix incorrect command in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 <!-- Your comment below here -->
 
+* Fix incorrect command in error message [@revolter](https://github.com/revolter)
 
 <!-- Your comment above here -->
 

--- a/lib/danger/commands/dry_run.rb
+++ b/lib/danger/commands/dry_run.rb
@@ -22,7 +22,7 @@ module Danger
       super
 
       if argv.flag?("pry", false)
-        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path)
+        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path, DryRun.command)
       end
     end
 

--- a/lib/danger/commands/local.rb
+++ b/lib/danger/commands/local.rb
@@ -32,7 +32,7 @@ module Danger
       super
 
       if argv.flag?("pry", false)
-        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path)
+        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path, Local.command)
       end
     end
 

--- a/lib/danger/commands/local_helpers/pry_setup.rb
+++ b/lib/danger/commands/local_helpers/pry_setup.rb
@@ -4,9 +4,9 @@ module Danger
       @cork = cork
     end
 
-    def setup_pry(dangerfile_path)
+    def setup_pry(dangerfile_path, command)
       return dangerfile_path if dangerfile_path.empty?
-      validate_pry_available
+      validate_pry_available(command)
       FileUtils.cp dangerfile_path, DANGERFILE_COPY
       File.open(DANGERFILE_COPY, "a") do |f|
         f.write("\nbinding.pry; File.delete(\"#{DANGERFILE_COPY}\")")
@@ -20,10 +20,10 @@ module Danger
 
     DANGERFILE_COPY = "_Dangerfile.tmp".freeze
 
-    def validate_pry_available
+    def validate_pry_available(command)
       Kernel.require "pry"
     rescue LoadError
-      cork.warn "Pry was not found, and is required for 'danger pr --pry'."
+      cork.warn "Pry was not found, and is required for 'danger #{command} --pry'."
       cork.print_warnings
       abort
     end

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -37,7 +37,7 @@ module Danger
       @dangerfile_path = dangerfile if File.exist?(dangerfile)
 
       if argv.flag?("pry", false)
-        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path)
+        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path, PR.command)
       end
     end
 

--- a/lib/danger/commands/staging.rb
+++ b/lib/danger/commands/staging.rb
@@ -23,7 +23,7 @@ module Danger
       super
 
       if argv.flag?("pry", false)
-        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path)
+        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path, Staging.command)
       end
     end
 

--- a/spec/lib/danger/commands/local_helpers/pry_setup_spec.rb
+++ b/spec/lib/danger/commands/local_helpers/pry_setup_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Danger::PrySetup do
 
         dangerfile_copy = described_class
           .new(testing_ui)
-          .setup_pry(dangerfile_path)
+          .setup_pry(dangerfile_path, "pr")
 
         expect(File).to exist(dangerfile_copy)
         expect(File.read(dangerfile_copy)).to include("binding.pry; File.delete(\"_Dangerfile.tmp\")")
@@ -20,7 +20,7 @@ RSpec.describe Danger::PrySetup do
     end
 
     it "doesn't copy a nonexistant Dangerfile" do
-      described_class.new(testing_ui).setup_pry("")
+      described_class.new(testing_ui).setup_pry("", "pr")
 
       expect(File).not_to exist("_Dangerfile.tmp")
     end
@@ -30,7 +30,7 @@ RSpec.describe Danger::PrySetup do
       expect(Kernel).to receive(:require).with("pry").and_raise(LoadError)
 
       expect do
-        described_class.new(ui).setup_pry("Dangerfile")
+        described_class.new(ui).setup_pry("Dangerfile", "pr")
       end.to raise_error(SystemExit)
       expect(ui.err_string).to include("Pry was not found")
     end


### PR DESCRIPTION
Running `danger local --pry` was printing out

```
[!] Pry was not found, and is required for 'danger pr --pry'.
```

instead of

```
[!] Pry was not found, and is required for 'danger local --pry'.
```

which was confusing.