### PR TITLE
Replace URI.escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 <!-- Your comment below here -->
 * Silence the ObjectifiedHash warnings when iterating over GitLab notes. - [@dstull](https://github.com/dstull)
+* Replace `URI.escape` which is obsolete in Ruby 3. - [@mataku](https://github.com/mataku)
 
 <!-- Your comment above here -->
 

--- a/lib/danger/request_sources/bitbucket_cloud_api.rb
+++ b/lib/danger/request_sources/bitbucket_cloud_api.rb
@@ -95,12 +95,13 @@ module Danger
         "#{base_url(2)}/#{pull_request_id}"
       end
 
-      def prs_api_endpoint(branch_name)
-        "#{base_url(2)}?q=source.branch.name=\"#{branch_name}\""
+      def prs_api_url(branch_name)
+        encoded_branch_name = URI.encode_www_form_component(branch_name)
+        "#{base_url(2)}?q=source.branch.name=\"#{encoded_branch_name}\""
       end
 
       def fetch_pr_from_branch(branch_name)
-        uri = URI(URI.escape(prs_api_endpoint(branch_name)))
+        uri = URI(prs_api_url(branch_name))
         fetch_json(uri)[:values][0][:id]
       end
 


### PR DESCRIPTION
Since Ruby 3.0, `URI.escape` is obsolete. See: https://github.com/ruby/uri/pull/9

So i treated `prs_api_endpoint` method as that encodes parameters and returns a url so that Ruby 2.7 and below will behave the same behavior.

This is how i tested.

```shell
rbenv local 3.0.0
bundle exec rspec
```

- - - 

You will see that some tests about Danger::Violation class will not pass in Ruby 3.0, but the issue was already created. https://github.com/danger/danger/issues/1282

