### PR TITLE
Delegate keyword arguments for Ruby 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 <!-- Your comment below here -->
 * Silence the ObjectifiedHash warnings when iterating over GitLab notes. - [@dstull](https://github.com/dstull)
 * Replace `URI.escape` which is obsolete in Ruby 3. - [@mataku](https://github.com/mataku)
+* Delegate explicitly keyword arguments for Ruby 3. - [@mataku](https://github.com/mataku)
 
 <!-- Your comment above here -->
 

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -49,22 +49,26 @@ module Danger
     # However, as we're using using them in the DSL, they won't
     # get method_missing called correctly without overriding them.
 
-    def warn(*args, &blk)
-      method_missing(:warn, *args, &blk)
+    def warn(*args, **kargs, &blk)
+      method_missing(:warn, *args, **kargs, &blk)
     end
 
-    def fail(*args, &blk)
-      method_missing(:fail, *args, &blk)
+    def fail(*args, **kargs, &blk)
+      method_missing(:fail, *args, **kargs, &blk)
     end
 
     # When an undefined method is called, we check to see if it's something
     # that the core DSLs have, then starts looking at plugins support.
 
     # rubocop:disable Style/MethodMissing
-    def method_missing(method_sym, *arguments, &_block)
+    def method_missing(method_sym, *arguments, **keyword_arguments, &_block)
       @core_plugins.each do |plugin|
         if plugin.public_methods(false).include?(method_sym)
-          return plugin.send(method_sym, *arguments)
+          if keyword_arguments.empty?
+            return plugin.send(method_sym, *arguments)
+          else
+            return plugin.send(method_sym, *arguments, **keyword_arguments)
+          end
         end
       end
       super

--- a/lib/danger/plugin_support/plugin.rb
+++ b/lib/danger/plugin_support/plugin.rb
@@ -19,8 +19,8 @@ module Danger
     # We need to redirect the self calls to the Dangerfile
 
     # rubocop:disable Style/MethodMissing
-    def method_missing(method_sym, *arguments, &block)
-      @dangerfile.send(method_sym, *arguments, &block)
+    def method_missing(method_sym, *arguments, **keyword_arguments, &block)
+      @dangerfile.send(method_sym, *arguments, **keyword_arguments, &block)
     end
 
     def self.all_plugins

--- a/lib/danger/plugin_support/plugin.rb
+++ b/lib/danger/plugin_support/plugin.rb
@@ -20,7 +20,11 @@ module Danger
 
     # rubocop:disable Style/MethodMissing
     def method_missing(method_sym, *arguments, **keyword_arguments, &block)
-      @dangerfile.send(method_sym, *arguments, **keyword_arguments, &block)
+      if keyword_arguments.empty?
+        @dangerfile.send(method_sym, *arguments, &block)
+      else
+        @dangerfile.send(method_sym, *arguments, **keyword_arguments, &block)
+      end
     end
 
     def self.all_plugins

--- a/spec/lib/danger/plugin_support/plugin_spec.rb
+++ b/spec/lib/danger/plugin_support/plugin_spec.rb
@@ -6,11 +6,19 @@ RSpec.describe Danger::Plugin do
 
   it "should forward unknown method calls to the dangerfile" do
     class DangerTestForwardPlugin < Danger::Plugin; end
-    class DangerFileMock; attr_accessor :pants; end
+    class DangerFileMock
+      attr_accessor :pants
+
+      def check(*args, **kargs); end
+    end
 
     plugin = DangerTestForwardPlugin.new(DangerFileMock.new)
     expect do
       plugin.pants
+    end.to_not raise_error
+
+    expect do
+      plugin.check('a', 'b', verbose: true)
     end.to_not raise_error
   end
 end


### PR DESCRIPTION
Ruby 3.0 has separated positional arguments and keyword arguments which are already deprecated in Ruby 2.7. 

At least, I've confirmed that at least the current combination of master branch and Ruby 3 does not pass some tests due to this effect.

So specified keyword arguments explicitly to methods that pass arbitrary and keyword arguments to work as before.

Fix: https://github.com/danger/danger/issues/1282

- - -

I know danger supports ruby 2.4 and above, so I wrote it to work with them, but please let me know if it is incomplete.

See more about keyword arguments behavior: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

