### PR TITLE
Fix a test case for Ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
-
+* Fix a test for Ruby 3.0 keyword arguments. - [@mataku](https://github.com/mataku)
 <!-- Your comment above here -->
 
 ## 8.2.2

--- a/spec/lib/danger/danger_core/message_group_spec.rb
+++ b/spec/lib/danger/danger_core/message_group_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Danger::MessageGroup do
         end
       end
       context "with other messages" do
-        let(:messages) { [Danger::Violation.new("warning!",type: :warning), Danger::Violation.new("error!", type: :error)] }
+        let(:messages) { [Danger::Violation.new("warning!", false, type: :warning), Danger::Violation.new("error!", false, type: :error)] }
 
         it "still only has both markdowns" do
           expect(Set.new(subject)).to eq Set.new(markdowns)


### PR DESCRIPTION
Fixed a test case that was not following https://github.com/danger/danger/pull/1286, which keyword arguments are treated explicitly on Ruby 3.

Sorry for the oversight!

```ruby
# With ruby 3
Failures:

  1) Danger::MessageGroup#markdowns with 2 markdowns with other messages still only has both markdowns
     Failure/Error:
           def initialize(message, sticky, file = nil, line = nil, type: :warning)
             raise ArgumentError unless VALID_TYPES.include?(type)

             super(type: type, message: message, file: file, line: line)
             self.sticky = sticky
           end

     ArgumentError:
       wrong number of arguments (given 1, expected 2..4)
     # ./lib/danger/danger_core/messages/violation.rb:10:in `initialize'
     # ./spec/lib/danger/danger_core/message_group_spec.rb:238:in `new'
     # ./spec/lib/danger/danger_core/message_group_spec.rb:238:in `block (5 levels) in <top (required)>'
     # ./spec/lib/danger/danger_core/message_group_spec.rb:217:in `block (3 levels) in <top (required)>'

Finished in 38.97 seconds (files took 2.02 seconds to load)
1158 examples, 1 failure, 2 pending

Failed examples:

rspec ./spec/lib/danger/danger_core/message_group_spec.rb:240 # Danger::MessageGroup#markdowns with 2 markdowns with other messages still only has both markdowns
```