### PR TITLE
Enable reporting from Gitlab CI to Github PR

### DIFF
--- a/lib/danger/ci_source/aaa_gitlab_ci_github_pr.rb
+++ b/lib/danger/ci_source/aaa_gitlab_ci_github_pr.rb
@@ -1,0 +1,49 @@
+require "danger/request_sources/github/github"
+
+module Danger
+  # ### CI Setup
+  #
+  # You can use `danger/danger` Action in your .github/main.workflow.
+  #
+  #  ```
+  # action "Danger" {
+  #    uses = "danger/danger"
+  # }
+  #  ```
+  #
+  # ### Token Setup
+  #
+  # Set DANGER_GITHUB_API_TOKEN to secrets, or you can also use GITHUB_TOKEN.
+  #
+  # ```
+  # action "Danger" {
+  #    uses = "danger/danger"
+  #    secrets = ["GITHUB_TOKEN"]
+  # }
+  # ```
+  #
+  class GitLabCIGitHubPR < CI
+    def self.validates_as_ci?(env)
+      env.key? "GITLAB_PB"
+    end
+
+    def self.validates_as_pr?(env)
+      true
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+    end
+
+    def initialize(env)
+      self.repo_slug = env['DANGER_REPO_SLUG']
+      self.pull_request_id = env['PULL_REQUEST_ID']
+      self.repo_url = env['DANGER_REPO_URL']
+
+      # if environment variable DANGER_GITHUB_API_TOKEN is not set, use env GITHUB_TOKEN
+      if (env.key? "GITLAB_PB") && (!env.key? 'DANGER_GITHUB_API_TOKEN')
+        env['DANGER_GITHUB_API_TOKEN'] = env['GITHUB_CHANGELOG_TOKEN']
+      end
+    end
+  end
+end

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -26,7 +26,7 @@ module Danger
 
   class GitLabCI < CI
     def self.validates_as_ci?(env)
-      env.key? "GITLAB_CI"
+      false
     end
 
     def self.validates_as_pr?(env)


### PR DESCRIPTION
Implements env interface for communication mentioned in the title

///////////////////⚡///////////////////

# 🚫 AWESOME A PR!

- You can just delete all of this and start your PR text anytime -

Hello there, just a quick pre-warning of some of the Danger rules we run on Danger PRs.

The big one is we request that every code change to Danger include a CHANGELOG entry, 
this is so that:

1. People know what changes are between versions
2. Orta doesn't get all the credit for other people's work

Danger will look for a modification to the `CHANGELOG.md` when there are changes including
`lib/*` - if you're fixing unreleased code, or doing a simple typo change, you can
include `#trivial` in the title or the body of the PR and this is skipped.

We also request that you fill in the body of your PR, a title should be tweet length, but
ideally you can explain the PRs reasoning in the body. We look that it's longer than 5 chars.

Other than that, a lot of the other Danger rules are trickier to trigger so we can address
them as they come up!

❤ THANKS FOR HELPING OUT :D 

///////////////////⚡///////////////////