### PR TITLE
Allow terminal-table versions through 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ## master
 <!-- Your comment below here -->
 
+* Allow teriminal-table versions through 3.x - [@benasher44](https://github.com/benasher44)
+
 <!-- Your comment above here -->
 
 ## 8.2.2

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "octokit", "~> 4.7"
-  spec.add_runtime_dependency "terminal-table", "~> 1"
+  spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "no_proxy_fix"
 end


### PR DESCRIPTION
As of Jekyll 4.2.0, Jekyll requires terminal-table 2.0 (my motivation here is to be able to upgrade my Jekyll version). Looking at their release notes, the breaking change for terminal-table 2 is requiring ruby 2.4+, and it appears danger dropped 2.3 support in #1225.

Side note: I had unfortunately not pinned danger properly when I upgraded to Jekyll 4.2.0, so bundler rolled my danger all the way back to 0.3.0, which is presumably the most recent version of danger that didn't use terminal-table. Anyway, that's a lesson in pinning versions properly for me.