### PR TITLE
Comment on only open gitlab MRs for Gitlab >= 13.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 <!-- Your comment below here -->
 
 * Allow teriminal-table versions through 3.x - [@benasher44](https://github.com/benasher44)
+* Comment on open gitlab MRs only for Gitlab>=13.8.0 - [@asifmohd](https://github.com/asifmohd/)
 
 <!-- Your comment above here -->
 

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -54,6 +54,7 @@ module Danger
         if (client_version >= Gem::Version.new("13.8"))
           # Gitlab 13.8.0 started returning merge requests for merge commits and squashed commits
           # By checking for merge_request.state, we can ensure danger only comments on MRs which are open
+          return 0 if merge_request.nil?
           return 0 unless merge_request.state == "opened"
         end
       else


### PR DESCRIPTION
Update gitlab_ci.rb to add support for changes in the merge_request API since Gitlab 13.8.0 release

i.e. with this release, Gitlab now returns an MR for merged or squashed commits which in case of squashed commits causes danger to error out saying, cannot find this commit, because the commit hash changes for commits when merged.

By filtering out open MRs we can ensure danger comments only on open MRs, and doesn't try to comment on merged or closed MRs where if the MR is squashed, it will not be able to find the commit hash and comment on the MR

[Related MR on gitlab](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/49968/)