### PR TITLE
Namespace the Commits class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 <!-- Your comment below here -->
 
 * Allow teriminal-table versions through 3.x - [@benasher44](https://github.com/benasher44)
+* Namespace the `Commits` class properly under `Danger`. [@rymai](https://github.com/rymai) [#1294](https://github.com/danger/danger/pull/1294)
 
 <!-- Your comment above here -->
 

--- a/lib/danger/ci_source/support/commits.rb
+++ b/lib/danger/ci_source/support/commits.rb
@@ -1,17 +1,19 @@
-class Commits
-  def initialize(base_head)
-    @base_head = base_head.strip.split(" ".freeze)
+module Danger
+  class Commits
+    def initialize(base_head)
+      @base_head = base_head.strip.split(" ".freeze)
+    end
+
+    def base
+      base_head.first
+    end
+
+    def head
+      base_head.last
+    end
+
+    private
+
+    attr_reader :base_head
   end
-
-  def base
-    base_head.first
-  end
-
-  def head
-    base_head.last
-  end
-
-  private
-
-  attr_reader :base_head
 end


### PR DESCRIPTION
We have a class name clash in GitLab where we also have a non-namespaced `Commits` class.

Namespacing the `Commits` class here seems like the right change, given that gems should always namespace their classes and that other classes in the same folder are already namespaced.