### PR TITLE
Handle GitLab URL containing /-/ scope on Jenkins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+* Handle GitLab URL containing /-/ scope on Jenkins - [@adamprice](https://github.com/adamprice)
 <!-- Your comment above here -->
 
 ## 8.3.0

--- a/lib/danger/ci_source/jenkins.rb
+++ b/lib/danger/ci_source/jenkins.rb
@@ -133,7 +133,7 @@ module Danger
           matches = change_url.match(%r{(.+)\/pull\/[0-9]+})
           matches[1] unless matches.nil?
         when %r{\/merge_requests\/} # GitLab
-          matches = change_url.match(%r{(.+)\/merge_requests\/[0-9]+})
+          matches = change_url.match(%r{(.+?)(\/-)?\/merge_requests\/[0-9]+})
           matches[1] unless matches.nil?
         when %r{\/pull-requests\/} # Bitbucket
           matches = change_url.match(%r{(.+)\/pull-requests\/[0-9]+})

--- a/spec/lib/danger/ci_sources/jenkins_spec.rb
+++ b/spec/lib/danger/ci_sources/jenkins_spec.rb
@@ -206,6 +206,11 @@ RSpec.describe Danger::Jenkins do
         expect(described_class.repo_url(valid_env)).to eq("https://gitlab.com/danger/danger")
       end
 
+      it "gets the GitLab url containing /-/ scope" do
+        valid_env["CHANGE_URL"] = "https://gitlab.com/danger/danger/-/merge_requests/1234"
+        expect(described_class.repo_url(valid_env)).to eq("https://gitlab.com/danger/danger")
+      end
+
       it "gets the BitBucket url" do
         valid_env["CHANGE_URL"] = "https://bitbucket.org/danger/danger/pull-requests/1"
         expect(described_class.repo_url(valid_env)).to eq("https://bitbucket.org/danger/danger")


### PR DESCRIPTION
GitLab now uses a `/-/` scope in its URLs as documented [here](https://gitlab.com/gitlab-org/gitlab/-/issues/214217).

The regex in the Jenkins CI class was incorrectly parsing the project URL as `https://<gitlab_host>/<project>/-/` when the URL contained the `/-/` scope, which was resulting in a 404 when trying to access the GitLab project API.

Sorry if I've missed anything, this is my first time contributing 🙂.