### PR TITLE
Add pr_draft? method to GitHub DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 <!-- Your comment below here -->
 * Handle GitLab URL containing /-/ scope on Jenkins - [@adamprice](https://github.com/adamprice)
+* Add `pr_draft?` method to GitHub DSL. - [@connorshea](https://github.com/connorshea)
 <!-- Your comment above here -->
 
 ## 8.3.0

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -143,6 +143,14 @@ module Danger
       @github.issue_json["labels"].map { |l| l[:name] }
     end
 
+    # @!group PR Metadata
+    # Whether the PR is a Draft.
+    # @return [Boolean]
+    #
+    def pr_draft?
+      pr_json["mergeable_state"] == "draft"
+    end
+
     # @!group PR Commit Metadata
     # The branch to which the PR is going to be merged into.
     # @return [String]

--- a/spec/lib/danger/danger_core/dangerfile_spec.rb
+++ b/spec/lib/danger/danger_core/dangerfile_spec.rb
@@ -145,8 +145,8 @@ RSpec.describe Danger::Dangerfile, host: :github do
         deleted_files deletions diff diff_for_file dismiss_out_of_range_messages
         head_commit html_link import_dangerfile import_plugin info_for_file
         insertions lines_of_code modified_files mr_author mr_body mr_json
-        mr_labels mr_title pr_author pr_body pr_diff pr_json pr_labels
-        pr_title renamed_files review scm_provider tags
+        mr_labels mr_title pr_author pr_body pr_diff pr_draft? pr_json
+        pr_labels pr_title renamed_files review scm_provider tags
       )
     end
 
@@ -219,7 +219,7 @@ RSpec.describe Danger::Dangerfile, host: :github do
           added_files api base_commit branch_for_base branch_for_head commits
           deleted_files deletions diff head_commit insertions lines_of_code
           modified_files mr_author mr_body mr_json mr_labels mr_title
-          pr_author pr_body pr_diff pr_json pr_labels pr_title
+          pr_author pr_body pr_diff pr_draft? pr_json pr_labels pr_title
           renamed_files review scm_provider tags
         )
       end


### PR DESCRIPTION
This checks the mergeable state of the PR JSON to determine whether a PR is a draft. This doesn't add a real proper test for the method because it didn't seem like the other methods (pr_author, pr_labels, etc.) had dedicated tests, so I figured this didn't need one.

I can add a specific test with a fixture if we want that, although I may need a bit of guidance on how to get the fixture to use. :)

Resolves #1150.