### PR TITLE
Expose DangerfileGitLabPlugin#mr_changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 <!-- Your comment below here -->
 * Handle GitLab URL containing /-/ scope on Jenkins - [@adamprice](https://github.com/adamprice)
 * Add `pr_draft?` method to GitHub DSL. - [@connorshea](https://github.com/connorshea)
+* Expose `DangerfileGitLabPlugin#mr_changes`. - [@rymai](https://github.com/rymai) [#1309](https://github.com/danger/danger/pull/1309)
 <!-- Your comment above here -->
 
 ## 8.3.0

--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -131,6 +131,14 @@ module Danger
       @gitlab.mr_diff
     end
 
+    # @!group MR Changes
+    # The array of changes
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    #
+    def mr_changes
+      @gitlab.mr_changes.changes
+    end
+
     # @!group MR Commit Metadata
     # The branch to which the MR is going to be merged into
     # @deprecated Please use {#branch_for_base} instead

--- a/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin_spec.rb
@@ -49,6 +49,24 @@ RSpec.describe Danger::DangerfileGitLabPlugin, host: :gitlab do
     end
   end
 
+  describe "#mr_changes" do
+    before do
+      stub_merge_request_changes(
+        "merge_request_1_changes_response",
+        "k0nserv\%2Fdanger-test",
+        1
+      )
+    end
+
+    it "sets the mr_changes" do
+      with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do
+        expect(plugin.mr_changes[0].to_h).to match(hash_including("old_path"=>"Dangerfile", "new_path"=>"Dangerfile", "a_mode"=>"100644", "b_mode"=>"100644", "new_file"=>false, "renamed_file"=>false, "deleted_file"=>false, "diff"=>an_instance_of(String)))
+        expect(plugin.mr_changes[1].to_h).to match(hash_including("old_path"=>"a", "new_path"=>"a", "a_mode"=>"0", "b_mode"=>"100644", "new_file"=>true, "renamed_file"=>false, "deleted_file"=>false, "diff"=>"--- /dev/null\n+++ b/a\n@@ -0,0 +1 @@\n+Danger rocks!\n"))
+        expect(plugin.mr_changes[2].to_h).to match(hash_including("old_path"=>"b", "new_path"=>"b", "a_mode"=>"0", "b_mode"=>"100644", "new_file"=>true, "renamed_file"=>false, "deleted_file"=>false, "diff"=>"--- /dev/null\n+++ b/b\n@@ -0,0 +1 @@\n+Test message please ignore\n"))
+      end
+    end
+  end
+
   describe "#mr_json" do
     it "is set" do
       with_git_repo(origin: "git@gitlab.com:k0nserv/danger-test.git") do


### PR DESCRIPTION
I wrongly assumed it was exposed already here: https://gitlab.com/gitlab-org/gitlab-dangerfiles/-/blob/8802a22a5e18cc13abe5e2ee39377a1eb0f1597f/lib/danger/plugins/helper.rb#L419 but it's not.