### PR TITLE
Test with Ruby 3.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,11 +5,16 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: [2.7, 3.0]
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
 
     - name: Build and test with Rake
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,13 +15,13 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
 
     - name: Build and test with Rake
       run: |
         git config --global user.email "orta+dangersystems@artsy.net"
         git config --global user.name "Danger.Systems"
 
-        gem install bundler
         bundle install --jobs 4 --retry 3
         bundle exec rake spec
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
 
     - name: Build and test with Rake
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+* Test with Ruby 2.7 and 3.0 on CI. - [@mataku](https://github.com/mataku)
 <!-- Your comment above here -->
 
 ## 8.3.1


### PR DESCRIPTION
Since Danger also supports Ruby 3, add Ruby 3 to CI workflow to make it easier to notice problems. 

In the Ruby setup, actions/setup-ruby was deprecated and replaced with ruby/setup-ruby: https://github.com/actions/setup-ruby#setup-ruby.