### PR TITLE
Fix AzurePipelines giving false positive to AppCenter builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 <!-- Your comment below here -->
 * Test with Ruby 2.7 and 3.0 on CI. - [@mataku](https://github.com/mataku)
+* Fix AppCenter CI source broken due to conflict with AzurePipelines - [@lucasecf](https://github.com/lucasecf)
 <!-- Your comment above here -->
 
 ## 8.3.1

--- a/lib/danger/ci_source/azure_pipelines.rb
+++ b/lib/danger/ci_source/azure_pipelines.rb
@@ -19,7 +19,11 @@ module Danger
   #
   class AzurePipelines < CI
     def self.validates_as_ci?(env)
-      env.key?("AGENT_ID") && env["BUILD_REPOSITORY_PROVIDER"] != "TfsGit"
+      # AGENT_ID is being used by AppCenter as well, so checking here to make sure AppCenter CI doesn't get a false positive for AzurePipelines
+      # Anyone working with AzurePipelines could provide a better/truly unique env key to avoid checking for AppCenter
+      !Danger::Appcenter::validates_as_ci?(env) &&
+      env.key?("AGENT_ID") &&
+      env["BUILD_REPOSITORY_PROVIDER"] != "TfsGit"
     end
 
     def self.validates_as_pr?(env)


### PR DESCRIPTION
Fixes issue https://github.com/danger/danger/issues/1173 

As reported in the issue above, running `danger` on AppCenter builds was broken since release 6.1.0. I had some time now to investigate and found out the problem was introduced by these changes: https://github.com/danger/danger/pull/1145

The root cause here is that `AzurePipelines` implementation is checking an env var with key `AGENT_ID` to be detected as a CI source.
Turns out that, AppCenter, a product also from Microsoft, have this same env var defined, so it was returning a false positive here when `danger` is running on AppCenter CI. You can see the full list of AppCenter's env vars in the linked issue. 

I don't have access to `AzurePipelines` to really know a proper unique env var key to replace `AGENT_ID`, so for now my workaround needed to be a bit 'hacky', but it shouldn't break current usages of Azure. The key used to validate AppCenter, `APPCENTER_BUILD_ID`, should not be present on Azure, given it contains the product name.

I left a comment anyways in hopes that someone with access can improve that in the future.

I tested my fork on our AppCenter CI and it fixed the issue.
