### PR TITLE
Custom success message support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## master
 <!-- Your comment below here -->
 * Test with Ruby 2.7 and 3.0 on CI. - [@mataku](https://github.com/mataku)
-* Added support for custom success message - [@omarzl](https://github.com/omarzl)
+* Added support for custom success message using the env var `DANGER_SUCCESS_MESSAGE` - [@omarzl](https://github.com/omarzl)
 <!-- Your comment above here -->
 
 ## 8.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 <!-- Your comment below here -->
 * Test with Ruby 2.7 and 3.0 on CI. - [@mataku](https://github.com/mataku)
+* Added support for custom success message - [@omarzl](https://github.com/omarzl)
 <!-- Your comment above here -->
 
 ## 8.3.1

--- a/lib/danger/helpers/comments_helper.rb
+++ b/lib/danger/helpers/comments_helper.rb
@@ -148,7 +148,7 @@ module Danger
       def generate_description(warnings: nil, errors: nil, template: "github")
         emoji_mapper = EmojiMapper.new(template)
         if errors.empty? && warnings.empty?
-          return "All green. #{random_compliment}"
+          return ENV['DANGER_SUCCESS_MESSAGE'] || "All green. #{random_compliment}"
         else
           message = "#{emoji_mapper.map('warning')} "
           message += "#{'Error'.danger_pluralize(errors.count)}. " unless errors.empty?


### PR DESCRIPTION
Hello! This pr adds support for a custom success message via the env var `DANGER_SUCCESS_MESSAGE`
I think it is better to handle it via an env var that adding a flag only for this