### PR TITLE
Expose `DangerfileGitLabPlugin#mr_closes_issues`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+* Expose `DangerfileGitLabPlugin#mr_closes_issues`. - [@revolter](https://github.com/revolter) [#1321](https://github.com/danger/danger/pull/1321)
 * Test with Ruby 2.7 and 3.0 on CI. - [@mataku](https://github.com/mataku)
 <!-- Your comment above here -->
 

--- a/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_gitlab_plugin.rb
@@ -139,6 +139,14 @@ module Danger
       @gitlab.mr_changes.changes
     end
 
+    # @!group MR Closes issues
+    # The array of issues that this MR closes
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    #
+    def mr_closes_issues
+      @gitlab.mr_closes_issues
+    end
+
     # @!group MR Commit Metadata
     # The branch to which the MR is going to be merged into
     # @deprecated Please use {#branch_for_base} instead

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -130,6 +130,12 @@ module Danger
         end
       end
 
+      def mr_closes_issues
+        @mr_closes_issues ||= begin
+          client.merge_request_closes_issues(ci_source.repo_slug, ci_source.pull_request_id)
+        end
+      end
+
       def setup_danger_branches
         # we can use a GitLab specific feature here:
         base_branch = self.mr_json.source_branch


### PR DESCRIPTION
I didn't test this, because I don't know how, and hoped that it works, being a small change.

I did successfully test part of it using:

```ruby
project_id = gitlab.mr_json['project_id']
mr_iid = gitlab.mr_json['iid']
closing_issues = gitlab.api.merge_request_closes_issues(project_id, mr_iid)

failure('This merge request does not refer to an existing issue') if closing_issues.empty?
```

in my `Dangerfile` though.