### PR TITLE
Adds support for Xcode Cloud as CI environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 <!-- Your comment below here -->
 * Test with Ruby 2.7 and 3.0 on CI. - [@mataku](https://github.com/mataku)
+* Adds Xcode Cloud CI source support - [@rpassis]((https://github.com/rpassis)
 <!-- Your comment above here -->
 
 ## 8.3.1

--- a/lib/danger/ci_source/xcode_cloud.rb
+++ b/lib/danger/ci_source/xcode_cloud.rb
@@ -1,5 +1,3 @@
-require "danger/request_sources/github/github"
-
 module Danger
   # ### CI Setup
   #

--- a/lib/danger/ci_source/xcode_cloud.rb
+++ b/lib/danger/ci_source/xcode_cloud.rb
@@ -1,0 +1,23 @@
+require "danger/request_sources/github/github"
+
+module Danger
+  class XcodeCloud < CI
+    def self.validates_as_ci?(env)
+      env.key? "CI_XCODEBUILD_ACTION"
+    end
+
+    def self.validates_as_pr?(env)
+      env.key? "CI_PULL_REQUEST_NUMBER"
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+    end
+
+    def initialize(env)
+      self.repo_slug = env["CI_PULL_REQUEST_SOURCE_REPO"]
+      self.pull_request_id = env["CI_PULL_REQUEST_NUMBER"]
+      self.repo_url = env["CI_PULL_REQUEST_HTML_URL"]
+    end
+  end
+end

--- a/lib/danger/ci_source/xcode_cloud.rb
+++ b/lib/danger/ci_source/xcode_cloud.rb
@@ -1,6 +1,18 @@
 require "danger/request_sources/github/github"
 
 module Danger
+  # ### CI Setup
+  #
+  # In order to work with Xcode Cloud and Danger, you will need to add `bundle exec danger` to 
+  # the `ci_scripts/ci_post_xcodebuild.sh` (Xcode Cloud's expected filename for a post-action build script).
+  # More details and documentation on Xcode Cloud configuration can be found [here](https://developer.apple.com/documentation/xcode/writing-custom-build-scripts).
+  # 
+  # ### Token Setup
+  #
+  # You will need to add the `DANGER_GITHUB_API_TOKEN` to your build environment. 
+  # If running on GitHub Enterprise, make sure you also set the expected values for 
+  # both `DANGER_GITHUB_API_HOST` and `DANGER_GITHUB_HOST`.
+  #  
   class XcodeCloud < CI
     def self.validates_as_ci?(env)
       env.key? "CI_XCODEBUILD_ACTION"

--- a/lib/danger/ci_source/xcode_cloud.rb
+++ b/lib/danger/ci_source/xcode_cloud.rb
@@ -11,7 +11,12 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+      @supported_request_sources ||= [
+        Danger::RequestSources::GitHub,
+        Danger::RequestSources::GitLab, 
+        Danger::RequestSources::BitbucketCloud, 
+        Danger::RequestSources::BitbucketServer
+      ]
     end
 
     def initialize(env)

--- a/spec/lib/danger/ci_sources/ci_source_spec.rb
+++ b/spec/lib/danger/ci_sources/ci_source_spec.rb
@@ -5,9 +5,8 @@ RSpec.describe Danger::CI do
     it "returns list of CI subclasses" do
       expect(described_class.available_ci_sources.map(&:to_s)).to match_array(
         [
-          "Danger::LocalGitRepo",
-          "Danger::LocalOnlyGitRepo",
           "Danger::Appcenter",
+          "Danger::AppVeyor",
           "Danger::AzurePipelines",
           "Danger::Bamboo",
           "Danger::BitbucketPipelines",
@@ -15,6 +14,7 @@ RSpec.describe Danger::CI do
           "Danger::Buddybuild",
           "Danger::Buildkite",
           "Danger::CircleCI",
+          "Danger::Cirrus",
           "Danger::CodeBuild",
           "Danger::Codefresh",
           "Danger::Codemagic",
@@ -22,18 +22,19 @@ RSpec.describe Danger::CI do
           "Danger::Concourse",
           "Danger::DotCi",
           "Danger::Drone",
+          "Danger::GitHubActions",
           "Danger::GitLabCI",
           "Danger::Jenkins",
+          "Danger::LocalGitRepo",
+          "Danger::LocalOnlyGitRepo",
           "Danger::Screwdriver",
           "Danger::Semaphore",
           "Danger::Surf",
           "Danger::TeamCity",
           "Danger::Travis",
           "Danger::VSTS",
-          "Danger::XcodeServer",
-          "Danger::AppVeyor",
-          "Danger::GitHubActions",
-          "Danger::Cirrus"
+          "Danger::XcodeCloud",
+          "Danger::XcodeServer"
         ]
       )
     end

--- a/spec/lib/danger/ci_sources/xcode_cloud_spec.rb
+++ b/spec/lib/danger/ci_sources/xcode_cloud_spec.rb
@@ -1,0 +1,74 @@
+require "danger/ci_source/xcode_cloud"
+
+RSpec.describe Danger::XcodeCloud do
+  let(:valid_env) do
+    {
+      "CI_XCODEBUILD_ACTION" => "Any build action",
+      "CI_PULL_REQUEST_NUMBER" => "999",
+      "CI_PULL_REQUEST_SOURCE_REPO" => "danger/danger",
+      "CI_PULL_REQUEST_HTML_URL" => "https://danger.systems"
+    }
+  end
+
+  let(:invalid_env) do
+    {
+        "XCS_BOT_NAME" => "BuildaBot [danger/danger] PR #99"
+    }
+  end
+
+  let(:source) { described_class.new(valid_env) }
+
+  describe ".validates_as_pr?" do
+    it "validates when the required env variables are set" do
+      expect(described_class.validates_as_pr?(valid_env)).to be true
+    end    
+
+    it "does not validate when the required env variables are not set" do
+      expect(described_class.validates_as_pr?(invalid_env)).to be false
+    end
+  end
+
+  describe ".validates_as_ci?" do
+    it "validates when the required env variables are set" do
+      expect(described_class.validates_as_ci?(valid_env)).to be true
+    end
+
+    it "does not validate when the required env variables are not set" do
+      expect(described_class.validates_as_ci?(invalid_env)).to be false
+    end
+  end
+
+  describe "#new" do
+    it "sets the repo_slug" do
+      expect(source.repo_slug).to eq("danger/danger")
+    end
+
+    it "sets the pull_request_id" do
+      expect(source.pull_request_id).to eq("999")
+    end
+
+    it "sets the repo_url", host: :github do
+      with_git_repo(origin: "https://danger.systems") do
+        expect(source.repo_url).to eq("https://danger.systems")
+      end
+    end
+  end
+
+  describe "supported_request_sources" do
+    it "supports GitHub" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::GitHub)
+    end
+
+    it "supports GitLab" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::GitLab)
+    end
+
+    it "supports BitbucketServer" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::BitbucketServer)
+    end
+
+    it "supports BitbucketCloud" do
+      expect(source.supported_request_sources).to include(Danger::RequestSources::BitbucketCloud)
+    end
+  end
+end


### PR DESCRIPTION
///////////////////⚡///////////////////

This PR adds basic Xcode Cloud CI source support to `danger`

For reference, the documentation for all available environment variables defined by a build running on Xcode Cloud can be found [here](https://developer.apple.com/documentation/xcode/environment-variable-reference)

///////////////////⚡///////////////////