### PR TITLE
change book emoji with blue_book

### DIFF
--- a/lib/danger/helpers/emoji_mapper.rb
+++ b/lib/danger/helpers/emoji_mapper.rb
@@ -10,7 +10,7 @@ module Danger
       "bitbucket_server" => {
         "no_entry_sign"    => ":no_entry_sign:",
         "warning"          => ":warning:",
-        "book"             => ":book:",
+        "book"             => ":blue_book:",
         "white_check_mark" => ":white_check_mark:"
       }
     }.freeze

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -540,7 +540,7 @@ COMMENT
 
             :warning: World!
 
-            :book: HOW R
+            :blue_book: HOW R
 
 
             U DOING?

--- a/spec/lib/danger/helpers/emoji_mapper_spec.rb
+++ b/spec/lib/danger/helpers/emoji_mapper_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Danger::EmojiMapper do
       context "when emoji is book" do
         let(:emoji) { "book" }
 
-        it { is_expected.to eq ":book:" }
+        it { is_expected.to eq ":blue_book:" }
       end
 
       context "when emoji is white_check_mark" do
@@ -113,7 +113,7 @@ RSpec.describe Danger::EmojiMapper do
       context "when type is message" do
         let(:type) { :message }
 
-        it { is_expected.to eq ":book:" }
+        it { is_expected.to eq ":blue_book:" }
       end
     end
   end


### PR DESCRIPTION
Bitbucket Server doesn't display :book: emoji
I tried on v7.6.
Here is what we have related to book

<img width="237" alt="emoji list" src="https://user-images.githubusercontent.com/17482092/135855277-124038fd-833a-4348-b898-d1acee92a5ae.png">

So I picked 📘 from available options
