### PR TITLE
Add BitbucketServer to supported Buildkite sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 <!-- Your comment below here -->
 * Add a "`: `" separation between file_name + line_number and message for gitlab inline comments 
 * Add support to pass in `DANGER_BITBUCKETSERVER_VERIFY_SSL` to toggle SSL Verification for Bitbucket Server
+* Add Bitbucket Server support for Buildkite CI. [@pahnev](https://github.com/pahnev)
 <!-- Your comment above here -->
 
 ## 8.4.0

--- a/lib/danger/ci_source/buildkite.rb
+++ b/lib/danger/ci_source/buildkite.rb
@@ -45,7 +45,7 @@ module Danger
     end
 
     def supported_request_sources
-      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab]
+      @supported_request_sources ||= [Danger::RequestSources::GitHub, Danger::RequestSources::GitLab, Danger::RequestSources::BitbucketServer]
     end
   end
 end


### PR DESCRIPTION
I was trying to use Danger with Buidlkite and Bitbucket server, and even though I had exposed all the env variables I was still getting this message:
```
Could not set up API to Code Review site for Danger
For Danger to run on this project, you need to expose a set of following the ENV vars:
 - GitHub: DANGER_GITHUB_API_TOKEN
 - GitLab: DANGER_GITLAB_API_TOKEN
 - BitbucketServer: DANGER_BITBUCKETSERVER_USERNAME, DANGER_BITBUCKETSERVER_PASSWORD, DANGER_BITBUCKETSERVER_HOST
 - BitbucketCloud: DANGER_BITBUCKETCLOUD_USERNAME, DANGER_BITBUCKETCLOUD_UUID, DANGER_BITBUCKETCLOUD_PASSWORD
 - LocalOnly: DANGER_LOCAL_ONLY
 - VSTS: DANGER_VSTS_API_TOKEN, DANGER_VSTS_HOST
 ```
 
 Eventually I found PR #940, and just as with that, simply adding the source, made everything work.