### PR TITLE
Post comment to Bitbucket Server only if there is any content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add a "`: `" separation between file_name + line_number and message for gitlab inline comments 
 * Add support to pass in `DANGER_BITBUCKETSERVER_VERIFY_SSL` to toggle SSL Verification for Bitbucket Server
 * Add Bitbucket Server support for Buildkite CI. [@pahnev](https://github.com/pahnev)
+* Fixes issue where a comment is posted to Bitbucket Server even when everything is green. [@pahnev](https://github.com/pahnev)
 <!-- Your comment above here -->
 
 ## 8.4.0

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -112,17 +112,20 @@ module Danger
           markdowns = main_violations[:markdowns] || []
         end
 
-        comment = generate_description(warnings: warnings,
-                                       errors: errors)
-        comment += "\n\n"
-        comment += generate_comment(warnings: warnings,
-                                    errors: errors,
-                                    messages: messages,
-                                    markdowns: markdowns,
-                                    previous_violations: {},
-                                    danger_id: danger_id,
-                                    template: "bitbucket_server")
-        @api.post_comment(comment)
+        has_comments = (warnings.count > 0 || errors.count > 0 || messages.count > 0 || markdowns.count > 0)
+        if has_comments
+          comment = generate_description(warnings: warnings,
+                                         errors: errors)
+          comment += "\n\n"
+          comment += generate_comment(warnings: warnings,
+                                      errors: errors,
+                                      messages: messages,
+                                      markdowns: markdowns,
+                                      previous_violations: {},
+                                      danger_id: danger_id,
+                                      template: "bitbucket_server")
+          @api.post_comment(comment)
+        end
       end
 
       def delete_old_comments(danger_id: "danger")


### PR DESCRIPTION
This PR adds a simple check to see if a comment should be posted to Bitbucket Server.

The #1299, describes the issue pretty well, but in short, there are some implementation differences between Github and BBS.

Both platforms have the same concepts of comments and build statuses.
On Github there are two actions, [comment posting](https://github.com/danger/danger/blob/master/lib/danger/request_sources/github/github.rb#L198-L203) and [setting build status](https://github.com/danger/danger/blob/master/lib/danger/request_sources/github/github.rb#L208-L212).
On BBS the build status update is not fully implemented, but there are [methods already](https://github.com/danger/danger/blob/master/lib/danger/request_sources/bitbucket_server.rb#L161) so it could be easily finished if needed. Though because BBS requires a build URL, it makes posting one from danger a bit awkward

Now I don't know if there were status badges when the original implementation was done, but now that there is the [Code insights implementation](https://github.com/danger/danger/blob/edaa7ca14fd6d39f18f23842e935bf219afe6279/lib/danger/request_sources/bitbucket_server.rb#L99-L102), which adds its own status badge to the PR page, sending a separate build status update might be unnecessary.