### PR TITLE
Support bearer_token for GitHub integrations

### DIFF
--- a/lib/danger/ci_source/support/pull_request_finder.rb
+++ b/lib/danger/ci_source/support/pull_request_finder.rb
@@ -155,7 +155,7 @@ module Danger
         bearer_token = ENV["DANGER_GITHUB_BEARER_TOKEN"]
         if bearer_token && !bearer_token.empty?
           Octokit::Client.new(bearer_token: bearer_token, api_endpoint: api_url)
-        elsif access_token && !access_token&.empty?
+        elsif access_token && !access_token.empty?
           Octokit::Client.new(access_token: access_token, api_endpoint: api_url)
         else
           raise "No API token given, please provide one using `DANGER_GITHUB_API_TOKEN` or `DANGER_GITHUB_BEARER_TOKEN`"

--- a/lib/danger/ci_source/support/pull_request_finder.rb
+++ b/lib/danger/ci_source/support/pull_request_finder.rb
@@ -153,9 +153,9 @@ module Danger
         require "octokit"
         access_token = ENV["DANGER_GITHUB_API_TOKEN"]
         bearer_token = ENV["DANGER_GITHUB_BEARER_TOKEN"]
-        if !bearer_token&.empty?
+        if bearer_token && !bearer_token.empty?
           Octokit::Client.new(bearer_token: bearer_token, api_endpoint: api_url)
-        elsif !access_token&.empty?
+        elsif access_token && !access_token&.empty?
           Octokit::Client.new(access_token: access_token, api_endpoint: api_url)
         else
           raise "No API token given, please provide one using `DANGER_GITHUB_API_TOKEN` or `DANGER_GITHUB_BEARER_TOKEN`"

--- a/lib/danger/ci_source/support/pull_request_finder.rb
+++ b/lib/danger/ci_source/support/pull_request_finder.rb
@@ -137,7 +137,7 @@ module Danger
 
     def client
       scm_provider = find_scm_provider(remote_url)
-    
+
       case scm_provider
       when :bitbucket_cloud
         require "danger/request_sources/bitbucket_cloud_api"
@@ -151,8 +151,15 @@ module Danger
 
       when :github
         require "octokit"
-        Octokit::Client.new(access_token: ENV["DANGER_GITHUB_API_TOKEN"], api_endpoint: api_url)
-
+        access_token = ENV["DANGER_GITHUB_API_TOKEN"]
+        bearer_token = ENV["DANGER_GITHUB_BEARER_TOKEN"]
+        if !bearer_token&.empty?
+          Octokit::Client.new(bearer_token: bearer_token, api_endpoint: api_url)
+        elsif !access_token&.empty?
+          Octokit::Client.new(access_token: access_token, api_endpoint: api_url)
+        else
+          raise "No API token given, please provide one using `DANGER_GITHUB_API_TOKEN` or `DANGER_GITHUB_BEARER_TOKEN`"
+        end
       else
         raise "SCM provider not supported: #{scm_provider}"
       end

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -239,6 +239,7 @@ RSpec.describe Danger::LocalGitRepo do
     end
 
     context "forked PR" do
+      before { ENV['DANGER_GITHUB_API_TOKEN'] = 'hi' }
       it "works" do
         spec_root = Dir.pwd
         client = double("Octokit::Client")
@@ -249,7 +250,6 @@ RSpec.describe Danger::LocalGitRepo do
             object_class: OpenStruct
           )
         end
-        ENV['DANGER_GITHUB_API_TOKEN'] = 'hi'
 
         run_in_repo do
           fork_pr_env = { "LOCAL_GIT_PR_URL" => "https://github.com/orta/danger/pull/42" }
@@ -263,6 +263,7 @@ RSpec.describe Danger::LocalGitRepo do
           )
         end
       end
+      after { ENV['DANGER_GITHUB_API_TOKEN'] = nil }
     end
   end
 end

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -249,6 +249,7 @@ RSpec.describe Danger::LocalGitRepo do
             object_class: OpenStruct
           )
         end
+        ENV['DANGER_GITHUB_API_TOKEN'] = 'hi'
 
         run_in_repo do
           fork_pr_env = { "LOCAL_GIT_PR_URL" => "https://github.com/orta/danger/pull/42" }

--- a/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
@@ -107,11 +107,9 @@ RSpec.describe Danger::PullRequestFinder do
     end
 
     context "specify api endpoint of octokit client" do
-      before do
-        ENV["DANGER_GITHUB_API_TOKEN"] = 'hi'
-        ENV["DANGER_GITHUB_API_HOST"] = "https://enterprise.artsy.net"
-      end
+      before { ENV["DANGER_GITHUB_API_TOKEN"] = 'hi' }
       it "By DANGER_GITHUB_API_HOST" do
+        ENV["DANGER_GITHUB_API_HOST"] = "https://enterprise.artsy.net"
         allow(Octokit::Client).to receive(:new).with(
           access_token: ENV["DANGER_GITHUB_API_TOKEN"],
           api_endpoint: "https://enterprise.artsy.net"
@@ -146,6 +144,7 @@ RSpec.describe Danger::PullRequestFinder do
 
     after do
       ENV['DANGER_GITHUB_API_TOKEN'] = nil
+      ENV['DANGER_GITHUB_BEARER_TOKEN'] = nil
       ENV['DANGER_GITHUB_API_HOST'] = nil
       ENV["DANGER_GITHUB_API_BASE_URL"] = nil
     end

--- a/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe Danger::PullRequestFinder do
     end
 
     context "with open Pull Request" do
+      before { ENV["DANGER_GITHUB_API_TOKEN"] = 'hi' }
       it "returns the opened Pull Request info" do
         client = double("Octokit::Client")
         allow(Octokit::Client).to receive(:new) { client }
@@ -106,6 +107,7 @@ RSpec.describe Danger::PullRequestFinder do
     end
 
     context "specify api endpoint of octokit client" do
+      before { ENV["DANGER_GITHUB_API_TOKEN"] = 'hi' }
       it "By DANGER_GITHUB_API_HOST" do
         ENV["DANGER_GITHUB_API_HOST"] = "https://enterprise.artsy.net"
 

--- a/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
@@ -104,13 +104,15 @@ RSpec.describe Danger::PullRequestFinder do
         expect(result.head).to eq "pr 518 head commit sha1"
         expect(result.base).to eq "pr 518 base commit sha1"
       end
+      after { ENV['DANGER_GITHUB_API_TOKEN'] = nil }
     end
 
     context "specify api endpoint of octokit client" do
-      before { ENV["DANGER_GITHUB_API_TOKEN"] = 'hi' }
-      it "By DANGER_GITHUB_API_HOST" do
+      before do
+        ENV["DANGER_GITHUB_API_TOKEN"] = 'hi'
         ENV["DANGER_GITHUB_API_HOST"] = "https://enterprise.artsy.net"
-
+      end
+      it "By DANGER_GITHUB_API_HOST" do
         allow(Octokit::Client).to receive(:new).with(
           access_token: ENV["DANGER_GITHUB_API_TOKEN"],
           api_endpoint: "https://enterprise.artsy.net"
@@ -129,20 +131,24 @@ RSpec.describe Danger::PullRequestFinder do
 
         finder(pull_request_id: "42", remote: true, logs: "not important").call
       end
+      after do
+        ENV['DANGER_GITHUB_API_TOKEN'] = nil
+        ENV['DANGER_GITHUB_API_HOST'] = nil
+        ENV["DANGER_GITHUB_API_BASE_URL"] = nil
+      end
     end
 
     context "with bearer_token" do
       before { ENV["DANGER_GITHUB_BEARER_TOKEN"] = 'hi' }
       it "creates clients with bearer_token" do
-        ENV["DANGER_GITHUB_API_HOST"] = "https://enterprise.artsy.net"
-
         allow(Octokit::Client).to receive(:new).with(
           bearer_token: ENV["DANGER_GITHUB_BEARER_TOKEN"],
-          api_endpoint: "https://enterprise.artsy.net"
+          api_endpoint: be_a(String)
         ) { spy("Octokit::Client") }
 
         finder(pull_request_id: "42", remote: true, logs: "not important").call
       end
+      after { ENV['DANGER_GITHUB_BEARER_TOKEN'] = nil }
     end
   end
 

--- a/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
@@ -130,6 +130,20 @@ RSpec.describe Danger::PullRequestFinder do
         finder(pull_request_id: "42", remote: true, logs: "not important").call
       end
     end
+
+    context "with bearer_token" do
+      before { ENV["DANGER_GITHUB_BEARER_TOKEN"] = 'hi' }
+      it "creates clients with bearer_token" do
+        ENV["DANGER_GITHUB_API_HOST"] = "https://enterprise.artsy.net"
+
+        allow(Octokit::Client).to receive(:new).with(
+          bearer_token: ENV["DANGER_GITHUB_BEARER_TOKEN"],
+          api_endpoint: "https://enterprise.artsy.net"
+        ) { spy("Octokit::Client") }
+
+        finder(pull_request_id: "42", remote: true, logs: "not important").call
+      end
+    end
   end
 
   describe "#find_scm_provider" do

--- a/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
+++ b/spec/lib/danger/ci_sources/support/pull_request_finder_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe Danger::PullRequestFinder do
         expect(result.head).to eq "pr 518 head commit sha1"
         expect(result.base).to eq "pr 518 base commit sha1"
       end
-      after { ENV['DANGER_GITHUB_API_TOKEN'] = nil }
     end
 
     context "specify api endpoint of octokit client" do
@@ -131,11 +130,6 @@ RSpec.describe Danger::PullRequestFinder do
 
         finder(pull_request_id: "42", remote: true, logs: "not important").call
       end
-      after do
-        ENV['DANGER_GITHUB_API_TOKEN'] = nil
-        ENV['DANGER_GITHUB_API_HOST'] = nil
-        ENV["DANGER_GITHUB_API_BASE_URL"] = nil
-      end
     end
 
     context "with bearer_token" do
@@ -148,7 +142,12 @@ RSpec.describe Danger::PullRequestFinder do
 
         finder(pull_request_id: "42", remote: true, logs: "not important").call
       end
-      after { ENV['DANGER_GITHUB_BEARER_TOKEN'] = nil }
+    end
+
+    after do
+      ENV['DANGER_GITHUB_API_TOKEN'] = nil
+      ENV['DANGER_GITHUB_API_HOST'] = nil
+      ENV["DANGER_GITHUB_API_BASE_URL"] = nil
     end
   end
 

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
     end
   end
 
+  describe "bearer token" do
+    context "with DANGER_GITHUB_BEARER_TOKEN" do
+      let(:client) { double('client') }
+      it 'creates Octokit client with bearer token' do
+        allow(Octokit::Client).to receive(:new).and_return(client)
+        gh_env = { "DANGER_GITHUB_BEARER_TOKEN" => "hi" }
+
+        expect(Octokit::Client).to receive(:new).with(hash_including(:bearer_token))
+        Danger::RequestSources::GitHub.new(stub_ci, gh_env).client
+      end
+    end
+  end
+
   describe "ssl verification" do
     it "sets ssl verification environment variable to false" do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_HOST" => "git.club-mateusa.com", "DANGER_OCTOKIT_VERIFY_SSL" => "false" }


### PR DESCRIPTION
## Motivation

I'd like to use danger with the GitHub App.
https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps

However, currently, danger only supports Personal Access Token. 

This PR makes an internal GitHub client to enable using `bearer_token` to authenticate.

## Description

Introduce a new environment variable `DANGER_GITHUB_BEARER_TOKEN`.
when it is set, danger makes GitHub clients use this value.

Of course, you can still use an access token via `DANGER_GITHUB_API_TOKEN`.

Thanks to this patch, we can use danger with GitHub App.

<img width="961" alt="Screen Shot 2021-11-10 at 19 20 17" src="https://user-images.githubusercontent.com/147051/141095498-b895b457-5971-45b7-b6e4-390c73590c67.png">

## Points of reviews

- I concern about the naming of the environment variable.
- how to update documentation?
