### PR TITLE
Improve how violations are handled with inline commenting on Bitbucket Server 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+* Add option to post file specific comments outside of the PR diff to Bitbucket Server, when using Code Insights API. [@pahnev](https://github.com/pahnev)
 <!-- Your comment above here -->
 
 ## 8.5.0

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -177,6 +177,7 @@ module Danger
 
       def find_position_in_diff?(file, line)
         return nil if file.nil? || line.nil?
+        return nil if file.empty?
         added_lines(file).include?(line)
       end
 

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -58,6 +58,10 @@ module Danger
         self.pr_json = @api.fetch_pr_json
       end
 
+      def pr_diff
+        @pr_diff ||= @api.fetch_pr_diff
+      end
+
       def setup_danger_branches
         base_branch = self.pr_json[:toRef][:id].sub("refs/heads/", "")
         base_commit = self.pr_json[:toRef][:latestCommit]

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -9,7 +9,7 @@ module Danger
   module RequestSources
     class BitbucketServer < RequestSource
       include Danger::Helpers::CommentsHelper
-      attr_accessor :pr_json, :include_out_of_range_messages
+      attr_accessor :pr_json, :dismiss_out_of_range_messages
 
       def self.env_vars
         [
@@ -26,13 +26,13 @@ module Danger
           "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION",
           "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL",
           "DANGER_BITBUCKETSERVER_VERIFY_SSL",
-          "DANGER_BITBUCKETSERVER_INCLUDE_OUT_OF_RANGE_MESSAGES"
+          "DANGER_BITBUCKETSERVER_DISMISS_OUT_OF_RANGE_MESSAGES"
         ]
       end
 
       def initialize(ci_source, environment)
         self.ci_source = ci_source
-        self.include_out_of_range_messages = environment["DANGER_BITBUCKETSERVER_INCLUDE_OUT_OF_RANGE_MESSAGES"] == 'true'
+        self.dismiss_out_of_range_messages = environment["DANGER_BITBUCKETSERVER_DISMISS_OUT_OF_RANGE_MESSAGES"] == 'true'
 
         project, slug = ci_source.repo_slug.split("/")
         @api = BitbucketServerAPI.new(project, slug, ci_source.pull_request_id, environment)
@@ -140,20 +140,20 @@ module Danger
       end
 
       def main_violations_group(warnings: [], errors: [], messages: [], markdowns: [])
-        if include_out_of_range_messages
+        if dismiss_out_of_range_messages
+          {
+            warnings: warnings.reject(&:inline?),
+            errors: errors.reject(&:inline?),
+            messages: messages.reject(&:inline?),
+            markdowns: markdowns.reject(&:inline?)
+          }
+        else
           in_diff = proc { |a| find_position_in_diff?(a.file, a.line) }
           {
             warnings: warnings.reject(&in_diff),
             errors: errors.reject(&in_diff),
             messages: messages.reject(&in_diff),
             markdowns: markdowns.reject(&in_diff)
-          }
-         else 
-          {
-            warnings: warnings.reject(&:inline?),
-            errors: errors.reject(&:inline?),
-            messages: messages.reject(&:inline?),
-            markdowns: markdowns.reject(&:inline?)
           }
         end
       end

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -26,13 +26,13 @@ module Danger
           "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_DESCRIPTION",
           "DANGER_BITBUCKETSERVER_CODE_INSIGHTS_REPORT_LOGO_URL",
           "DANGER_BITBUCKETSERVER_VERIFY_SSL",
-          "DANGER_INCLUDE_OUT_OF_RANGE_MESSAGES"
+          "DANGER_BITBUCKETSERVER_INCLUDE_OUT_OF_RANGE_MESSAGES"
         ]
       end
 
       def initialize(ci_source, environment)
         self.ci_source = ci_source
-        self.include_out_of_range_messages = environment["DANGER_INCLUDE_OUT_OF_RANGE_MESSAGES"] == 'true'
+        self.include_out_of_range_messages = environment["DANGER_BITBUCKETSERVER_INCLUDE_OUT_OF_RANGE_MESSAGES"] == 'true'
 
         project, slug = ci_source.repo_slug.split("/")
         @api = BitbucketServerAPI.new(project, slug, ci_source.pull_request_id, environment)

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -43,6 +43,11 @@ module Danger
         fetch_json(uri)
       end
 
+      def fetch_pr_diff
+        uri = URI("#{pr_api_endpoint}/diff?withComments=false")
+        fetch_json(uri)
+      end
+
       def fetch_last_comments
         uri = URI("#{pr_api_endpoint}/activities?limit=1000")
         fetch_json(uri)[:values].select { |v| v[:action] == "COMMENTED" }.map { |v| v[:comment] }

--- a/spec/fixtures/bitbucket_server_api/pr_diff_response.json
+++ b/spec/fixtures/bitbucket_server_api/pr_diff_response.json
@@ -1,0 +1,490 @@
+HTTP/1.1 200 OK
+
+{
+    "fromHash": "e210151df4388c0bde443707930885ada86493df",
+    "toHash": "3fc9bef368821124816aa41df3f328a3b62ff6a4",
+    "contextLines": 10,
+    "whitespace": "SHOW",
+    "diffs": [
+        {
+            "source": {
+                "components": [
+                    "Gemfile"
+                ],
+                "parent": "",
+                "name": "Gemfile",
+                "toString": "Gemfile"
+            },
+            "destination": {
+                "components": [
+                    "Gemfile"
+                ],
+                "parent": "",
+                "name": "Gemfile",
+                "toString": "Gemfile"
+            },
+            "hunks": [
+                {
+                    "sourceLine": 1,
+                    "sourceSpan": 4,
+                    "destinationLine": 1,
+                    "destinationSpan": 5,
+                    "segments": [
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 1,
+                                    "destination": 1,
+                                    "line": "source 'https://rubygems.org'",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 2,
+                                    "destination": 2,
+                                    "line": "",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "ADDED",
+                            "lines": [
+                                {
+                                    "source": 3,
+                                    "destination": 3,
+                                    "line": "",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 3,
+                                    "destination": 4,
+                                    "line": "# Specify your gem's dependencies in batman-rails.gemspec",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 4,
+                                    "destination": 5,
+                                    "line": "gemspec",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        }
+                    ],
+                    "truncated": false
+                }
+            ],
+            "truncated": false
+        },
+        {
+            "source": {
+                "components": [
+                    "lib",
+                    "batman-rails",
+                    "version.rb"
+                ],
+                "parent": "lib/batman-rails",
+                "name": "version.rb",
+                "extension": "rb",
+                "toString": "lib/batman-rails/version.rb"
+            },
+            "destination": {
+                "components": [
+                    "lib",
+                    "batman-rails",
+                    "version.rb"
+                ],
+                "parent": "lib/batman-rails",
+                "name": "version.rb",
+                "extension": "rb",
+                "toString": "lib/batman-rails/version.rb"
+            },
+            "hunks": [
+                {
+                    "sourceLine": 1,
+                    "sourceSpan": 6,
+                    "destinationLine": 1,
+                    "destinationSpan": 7,
+                    "segments": [
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 1,
+                                    "destination": 1,
+                                    "line": "module Batman",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 2,
+                                    "destination": 2,
+                                    "line": "  module Rails",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 3,
+                                    "destination": 3,
+                                    "line": "    VERSION = \"0.16.1\"",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 4,
+                                    "destination": 4,
+                                    "line": "    BATMAN_VERSION = \"0.16.0\"",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "ADDED",
+                            "lines": [
+                                {
+                                    "source": 5,
+                                    "destination": 5,
+                                    "line": "    FOO = \"bar\"",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 5,
+                                    "destination": 6,
+                                    "line": "  end",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 6,
+                                    "destination": 7,
+                                    "line": "end",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        }
+                    ],
+                    "truncated": false
+                }
+            ],
+            "truncated": false
+        },
+        {
+            "source": {
+                "components": [
+                    "lib",
+                    "templates",
+                    "batman",
+                    "html",
+                    "index.html"
+                ],
+                "parent": "lib/templates/batman/html",
+                "name": "index.html",
+                "extension": "html",
+                "toString": "lib/templates/batman/html/index.html"
+            },
+            "destination": {
+                "components": [
+                    "lib",
+                    "templates",
+                    "batman",
+                    "html",
+                    "index.html"
+                ],
+                "parent": "lib/templates/batman/html",
+                "name": "index.html",
+                "extension": "html",
+                "toString": "lib/templates/batman/html/index.html"
+            },
+            "hunks": [
+                {
+                    "sourceLine": 1,
+                    "sourceSpan": 2,
+                    "destinationLine": 1,
+                    "destinationSpan": 3,
+                    "segments": [
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 1,
+                                    "destination": 1,
+                                    "line": "<h1><%= plural_name.camelize %>Controller#index</h1>",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "ADDED",
+                            "lines": [
+                                {
+                                    "source": 2,
+                                    "destination": 2,
+                                    "line": "",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 2,
+                                    "destination": 3,
+                                    "line": "<p>Find me in html/<%= plural_name.underscore %>/index.html</p>",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        }
+                    ],
+                    "truncated": false
+                }
+            ],
+            "truncated": false
+        },
+        {
+            "source": {
+                "components": [
+                    "lib",
+                    "templates",
+                    "batman",
+                    "main_controller.coffee"
+                ],
+                "parent": "lib/templates/batman",
+                "name": "main_controller.coffee",
+                "extension": "coffee",
+                "toString": "lib/templates/batman/main_controller.coffee"
+            },
+            "destination": {
+                "components": [
+                    "lib",
+                    "templates",
+                    "batman",
+                    "main_controller.coffee"
+                ],
+                "parent": "lib/templates/batman",
+                "name": "main_controller.coffee",
+                "extension": "coffee",
+                "toString": "lib/templates/batman/main_controller.coffee"
+            },
+            "hunks": [
+                {
+                    "sourceLine": 1,
+                    "sourceSpan": 9,
+                    "destinationLine": 1,
+                    "destinationSpan": 10,
+                    "segments": [
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 1,
+                                    "destination": 1,
+                                    "line": "class <%= js_application_name %>.MainController extends <%= js_application_name %>.ApplicationController",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 2,
+                                    "destination": 2,
+                                    "line": "  routingKey: 'main'",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 3,
+                                    "destination": 3,
+                                    "line": "",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 4,
+                                    "destination": 4,
+                                    "line": "  index: (params) ->",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 5,
+                                    "destination": 5,
+                                    "line": "    @set 'firstName', 'Bruce'",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 6,
+                                    "destination": 6,
+                                    "line": "    @set 'lastName', 'Wayne'",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "ADDED",
+                            "lines": [
+                                {
+                                    "source": 7,
+                                    "destination": 7,
+                                    "line": "    @set 'nickname', 'Batman'",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 7,
+                                    "destination": 8,
+                                    "line": "",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 8,
+                                    "destination": 9,
+                                    "line": "  @accessor 'fullName', ->",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 9,
+                                    "destination": 10,
+                                    "line": "    \"#{@get('firstName')} #{@get('lastName')}\"",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        }
+                    ],
+                    "truncated": false
+                }
+            ],
+            "truncated": false
+        },
+        {
+            "source": {
+                "components": [
+                    "test",
+                    "fixtures",
+                    "application.js.coffee"
+                ],
+                "parent": "test/fixtures",
+                "name": "application.js.coffee",
+                "extension": "coffee",
+                "toString": "test/fixtures/application.js.coffee"
+            },
+            "destination": {
+                "components": [
+                    "test",
+                    "fixtures",
+                    "application.js.coffee"
+                ],
+                "parent": "test/fixtures",
+                "name": "application.js.coffee",
+                "extension": "coffee",
+                "toString": "test/fixtures/application.js.coffee"
+            },
+            "hunks": [
+                {
+                    "sourceLine": 1,
+                    "sourceSpan": 9,
+                    "destinationLine": 1,
+                    "destinationSpan": 10,
+                    "segments": [
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 1,
+                                    "destination": 1,
+                                    "line": "# This is a manifest file that'll be compiled into including all the files listed below.",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 2,
+                                    "destination": 2,
+                                    "line": "# Add new JavaScript/Coffee code in separate files in this directory and they'll automatically",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 3,
+                                    "destination": 3,
+                                    "line": "# be included in the compiled file accessible from http://example.com/assets/application.js",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 4,
+                                    "destination": 4,
+                                    "line": "# It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 5,
+                                    "destination": 5,
+                                    "line": "# the compiled file.",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 6,
+                                    "destination": 6,
+                                    "line": "#",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "ADDED",
+                            "lines": [
+                                {
+                                    "source": 7,
+                                    "destination": 7,
+                                    "line": "#",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        },
+                        {
+                            "type": "CONTEXT",
+                            "lines": [
+                                {
+                                    "source": 7,
+                                    "destination": 8,
+                                    "line": "#= require jquery",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 8,
+                                    "destination": 9,
+                                    "line": "#= require jquery_ujs",
+                                    "truncated": false
+                                },
+                                {
+                                    "source": 9,
+                                    "destination": 10,
+                                    "line": "#= require_tree .",
+                                    "truncated": false
+                                }
+                            ],
+                            "truncated": false
+                        }
+                    ],
+                    "truncated": false
+                }
+            ],
+            "truncated": false
+        }
+    ]
+}

--- a/spec/lib/danger/request_sources/bitbucket_server_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_server_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server 
 
     it "includes messages outside the PR diff when env variable is set" do
       new_env = stub_env
-      new_env.merge!({ "DANGER_INCLUDE_OUT_OF_RANGE_MESSAGES" => "true" })
+      new_env.merge!({ "DANGER_BITBUCKETSERVER_INCLUDE_OUT_OF_RANGE_MESSAGES" => "true" })
       inspected = Danger::RequestSources::BitbucketServer.new(stub_ci, new_env)
       
       warning_in_diff = Danger::Violation.new("foo", false, "Gemfile", 3, type: :warning)

--- a/spec/lib/danger/request_sources/bitbucket_server_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_server_spec.rb
@@ -60,24 +60,7 @@ RSpec.describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server 
       stub_pull_request_diff
     end
     
-    it "ignores file specific messages outside the PR diff by default" do
-      warnings = [
-        Danger::Violation.new("foo", false, "Gemfile", 3, type: :warning),
-        Danger::Violation.new("bar", false, "file.rb", 1, type: :warning)
-      ]
-      expect(bs.main_violations_group(warnings: warnings)).to eq({
-        warnings: [],
-        errors: [],
-        messages: [],
-        markdowns: []
-        })
-      end
-
-    it "includes messages outside the PR diff when env variable is set" do
-      new_env = stub_env
-      new_env.merge!({ "DANGER_BITBUCKETSERVER_INCLUDE_OUT_OF_RANGE_MESSAGES" => "true" })
-      inspected = Danger::RequestSources::BitbucketServer.new(stub_ci, new_env)
-      
+    it "includes file specific messages outside the PR diff by default" do
       warning_in_diff = Danger::Violation.new("foo", false, "Gemfile", 3, type: :warning)
       warning_outside_of_diff = Danger::Violation.new("bar", false, "file.rb", 1, type: :warning)
       
@@ -85,8 +68,25 @@ RSpec.describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server 
         warning_in_diff,
         warning_outside_of_diff
       ]
-      expect(inspected.main_violations_group(warnings: warnings)).to eq({
+      expect(bs.main_violations_group(warnings: warnings)).to eq({
         warnings: [warning_outside_of_diff],
+        errors: [],
+        messages: [],
+        markdowns: []
+        })
+      end
+
+    it "dismisses messages outside the PR diff when env variable is set" do
+      new_env = stub_env
+      new_env.merge!({ "DANGER_BITBUCKETSERVER_DISMISS_OUT_OF_RANGE_MESSAGES" => "true" })
+      inspected = Danger::RequestSources::BitbucketServer.new(stub_ci, new_env)
+
+      warnings = [
+        Danger::Violation.new("foo", false, "Gemfile", 3, type: :warning),
+        Danger::Violation.new("bar", false, "file.rb", 1, type: :warning)
+      ]
+      expect(inspected.main_violations_group(warnings: warnings)).to eq({
+        warnings: [],
         errors: [],
         messages: [],
         markdowns: []

--- a/spec/lib/danger/request_sources/bitbucket_server_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_server_spec.rb
@@ -46,4 +46,65 @@ RSpec.describe Danger::RequestSources::BitbucketServer, host: :bitbucket_server 
       end
     end
   end
+
+  describe "#pr_diff" do    
+    it "has a non empty pr_diff after fetch" do
+      stub_pull_request_diff
+      bs.pr_diff
+      expect(bs.pr_diff).to be_truthy
+    end
+  end
+
+  describe "#main_violations_group" do
+    before do
+      stub_pull_request_diff
+    end
+    
+    it "ignores file specific messages outside the PR diff by default" do
+      warnings = [
+        Danger::Violation.new("foo", false, "Gemfile", 3, type: :warning),
+        Danger::Violation.new("bar", false, "file.rb", 1, type: :warning)
+      ]
+      expect(bs.main_violations_group(warnings: warnings)).to eq({
+        warnings: [],
+        errors: [],
+        messages: [],
+        markdowns: []
+        })
+      end
+
+    it "includes messages outside the PR diff when env variable is set" do
+      new_env = stub_env
+      new_env.merge!({ "DANGER_INCLUDE_OUT_OF_RANGE_MESSAGES" => "true" })
+      inspected = Danger::RequestSources::BitbucketServer.new(stub_ci, new_env)
+      
+      warning_in_diff = Danger::Violation.new("foo", false, "Gemfile", 3, type: :warning)
+      warning_outside_of_diff = Danger::Violation.new("bar", false, "file.rb", 1, type: :warning)
+      
+      warnings = [
+        warning_in_diff,
+        warning_outside_of_diff
+      ]
+      expect(inspected.main_violations_group(warnings: warnings)).to eq({
+        warnings: [warning_outside_of_diff],
+        errors: [],
+        messages: [],
+        markdowns: []
+        })
+      end 
+    end
+
+    describe "#find_position_in_diff" do
+      before do
+        stub_pull_request_diff
+      end
+      
+      it "returns false when changes are not in the `pr_diff`" do
+        expect(bs.find_position_in_diff?("file.rb", 1)).to be_falsy
+      end
+      
+      it "returns true when changes are in included in the `pr_diff`" do
+        expect(bs.find_position_in_diff?("Gemfile", 3)).to be_truthy
+      end
+    end
 end

--- a/spec/support/bitbucket_server_helper.rb
+++ b/spec/support/bitbucket_server_helper.rb
@@ -25,6 +25,12 @@ module Danger
         url = "https://stash.example.com/rest/api/1.0/projects/ios/repos/fancyapp/pull-requests/2080"
         WebMock.stub_request(:get, url).to_return(raw_file)
       end
+
+      def stub_pull_request_diff
+        raw_file = File.new("spec/fixtures/bitbucket_server_api/pr_diff_response.json")
+        url = "https://stash.example.com/rest/api/1.0/projects/ios/repos/fancyapp/pull-requests/2080/diff?withComments=false"
+        WebMock.stub_request(:get, url).to_return(raw_file)
+      end
     end
   end
 end


### PR DESCRIPTION
As BitBucket Server inline comments are done with the Code Insights annotations, some of the comments may get left out. As per their [API documentation](https://docs.atlassian.com/bitbucket-server/rest/7.18.2/bitbucket-code-insights-rest.html#idp10) only the annotations that are on lines changed in the unified diff will be displayed.

This PR makes a change in how the "rest of the violations" are gathered after the inline comments have been posted.
If environment variable `DANGER_BITBUCKETSERVER_INCLUDE_OUT_OF_RANGE_MESSAGES` is set to true, instead of rejecting all inline comments, it checks for the PR diff and compares the violations against it to determine if the violation should be included in the final comment message.

And thanks to @vassilevsky for doing the ground work for this https://github.com/danger/danger/issues/806#issuecomment-366610399