### PR TITLE
Fix `pr_draft?` GitHub Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+* Fix issue in GitHub `pr_draft?` method which was returning false for draft Pull Requests - [@rogerluan](https://github.com/rogerluan)
 <!-- Your comment above here -->
 
 ## 8.4.2

--- a/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_github_plugin.rb
@@ -148,7 +148,7 @@ module Danger
     # @return [Boolean]
     #
     def pr_draft?
-      pr_json["mergeable_state"] == "draft"
+      pr_json["draft"] == true
     end
 
     # @!group PR Commit Metadata


### PR DESCRIPTION
## Description

This PR resolves #1338

My best guess is that there was a change in GitHub's API functionality and the mergeable state now doesn't return "draft" when the PR is a PR. In fact, now there's this dedicated API, so we should just be using it anyway 😊 

## Tests

Dangerfile:

```ruby
if defined?(github) and github.pr_draft?
  message("Test: skipping early")
  return
else
if defined?(github)
  is_github_defined = true
else
  is_github_defined = false
end
if is_github_defined
  is_draft_pr = github.pr_draft?
  if github.pr_json['draft']
      message("github.pr_json['draft'] = true")
  end
end
message("Test: not skipping. is_github_defined  = #{is_github_defined}, is_draft_pr = #{is_draft_pr}")
message("#{github.pr_json['draft']}")
message("#{github.pr_json.inspect}")
```

#### Before

<img width="504" alt="image" src="https://user-images.githubusercontent.com/8419048/146532012-e0754c84-05b1-481a-939b-fef9dfb6c8a6.png">

#### After

<img width="240" alt="image" src="https://user-images.githubusercontent.com/8419048/146534193-0de8065c-0291-4cd9-b519-48894a54a77e.png">


