### PR TITLE
Fix wrong arguments in ArraySubclass#respond_to_missing?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 <!-- Your comment below here -->
 * Fix issue in GitHub `pr_draft?` method which was returning false for draft Pull Requests - [@rogerluan](https://github.com/rogerluan)
+* Fix arguments length of `ArraySubclass#respond_to_missing?` - [@manicmaniac](https://github.com/manicmaniac)
 <!-- Your comment above here -->
 
 ## 8.4.2

--- a/lib/danger/helpers/array_subclass.rb
+++ b/lib/danger/helpers/array_subclass.rb
@@ -19,8 +19,8 @@ module Danger
         respond_to_method(name, *args, &block)
       end
 
-      def respond_to_missing?(name)
-        __array__.respond_to?(name) || super
+      def respond_to_missing?(name, include_all)
+        __array__.respond_to?(name, include_all) || super
       end
 
       def to_a

--- a/spec/lib/danger/helpers/array_subclass_spec.rb
+++ b/spec/lib/danger/helpers/array_subclass_spec.rb
@@ -45,4 +45,20 @@ RSpec.describe Danger::Helpers::ArraySubclass do
       expect(first_list).not_to eq(third_list)
     end
   end
+
+  describe "#respond_to_missing?" do
+    context "with missing method" do
+      it "returns false" do
+        list = List.new([])
+        expect(list.respond_to?(:missing_method)).to be(false)
+      end
+    end
+
+    context "with existing method" do
+      it "returns true" do
+        list = List.new([])
+        expect(list.respond_to?(:to_a)).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`ArraySubclass#respond_to_missing?` has only one argument but `Object#respond_to_missing?` is defined to receive two arguments, according to the official API reference through 2.6.0 to 3.0.0.

So potentially it causes a bug even though I couldn't find it in a practical use case.

https://github.com/danger/danger/blob/43000055d824ca05a8c7ab63366d10e3d5c21529/lib/danger/helpers/array_subclass.rb#L22

https://docs.ruby-lang.org/en/2.6.0/Object.html#method-i-respond_to_missing-3F

> respond_to_missing?(symbol, include_all) → true or falseclick to toggle source
> respond_to_missing?(string, include_all) → true or false

## Solution

- Added a spec to reproduce a bug
- Fixed `ArraySubclass#respond_to_missing?` to receive two arguments

<!--
///////////////////⚡///////////////////

# 🚫 AWESOME A PR!

- You can just delete all of this and start your PR text anytime -

Hello there, just a quick pre-warning of some of the Danger rules we run on Danger PRs.

The big one is we request that every code change to Danger include a CHANGELOG entry, 
this is so that:

1. People know what changes are between versions
2. Orta doesn't get all the credit for other people's work

Danger will look for a modification to the `CHANGELOG.md` when there are changes including
`lib/*` - if you're fixing unreleased code, or doing a simple typo change, you can
include `#trivial` in the title or the body of the PR and this is skipped.

We also request that you fill in the body of your PR, a title should be tweet length, but
ideally you can explain the PRs reasoning in the body. We look that it's longer than 5 chars.

Other than that, a lot of the other Danger rules are trickier to trigger so we can address
them as they come up!

❤ THANKS FOR HELPING OUT :D 

///////////////////⚡///////////////////
-->