### PR TITLE
Never save environment as instance variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+* Never save environment as instance variables - [@rymai](https://github.com/rymai) [#1355](https://github.com/danger/danger/pull/1355)
 <!-- Your comment above here -->
 
 ## 8.4.4

--- a/lib/danger/ci_source/codefresh.rb
+++ b/lib/danger/ci_source/codefresh.rb
@@ -31,23 +31,17 @@ module Danger
       @supported_request_sources ||= [Danger::RequestSources::GitHub]
     end
 
-    def repo_slug
-      return "" if @env["CF_REPO_OWNER"].to_s.empty?
-      return "" if @env["CF_REPO_NAME"].to_s.empty?
-      "#{@env['CF_REPO_OWNER']}/#{@env['CF_REPO_NAME']}".downcase!
-    end
+    def self.slug_from(env)
+      return "" if env["CF_REPO_OWNER"].to_s.empty?
+      return "" if env["CF_REPO_NAME"].to_s.empty?
 
-    def repo_url
-      return "" if @env["CF_COMMIT_URL"].to_s.empty?
-      @env["CF_COMMIT_URL"].gsub(/\/commit.+$/, "")
-    end
-
-    def pull_request_id
-      @env["CF_PULL_REQUEST_NUMBER"]
+      "#{env['CF_REPO_OWNER']}/#{env['CF_REPO_NAME']}".downcase!
     end
 
     def initialize(env)
-      @env = env
+      self.repo_url = env["CF_COMMIT_URL"].to_s.gsub(/\/commit.+$/, "")
+      self.repo_slug = self.class.slug_from(env)
+      self.pull_request_id = env["CF_PULL_REQUEST_NUMBER"]
     end
   end
 end

--- a/lib/danger/ci_source/local_only_git_repo.rb
+++ b/lib/danger/ci_source/local_only_git_repo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "git"
 require "danger/request_sources/local_only"
 
@@ -9,8 +11,8 @@ module Danger
   #
   class LocalOnlyGitRepo < CI
     attr_accessor :base_commit, :head_commit
-    HEAD_VAR = "DANGER_LOCAL_HEAD".freeze
-    BASE_VAR = "DANGER_LOCAL_BASE".freeze
+    HEAD_VAR = "DANGER_LOCAL_HEAD"
+    BASE_VAR = "DANGER_LOCAL_BASE"
 
     def self.validates_as_ci?(env)
       env.key? "DANGER_USE_LOCAL_ONLY_GIT"
@@ -33,15 +35,9 @@ module Danger
     end
 
     def initialize(env = {})
-      @env = env
-
       # expects --base/--head specified OR origin/master to be base and HEAD head
       self.base_commit = env[BASE_VAR] || run_git("rev-parse --abbrev-ref origin/master")
       self.head_commit = env[HEAD_VAR] || run_git("rev-parse --abbrev-ref HEAD")
     end
-
-    private
-
-    attr_reader :env
   end
 end

--- a/lib/danger/ci_source/support/pull_request_finder.rb
+++ b/lib/danger/ci_source/support/pull_request_finder.rb
@@ -1,67 +1,65 @@
+# frozen_string_literal: true
+
 require "danger/ci_source/support/local_pull_request"
 require "danger/ci_source/support/remote_pull_request"
 require "danger/ci_source/support/no_pull_request"
 
 module Danger
   class PullRequestFinder
-    def initialize(specific_pull_request_id, repo_slug = nil, remote: false, git_logs: "", remote_url: "", env: nil)
+    def initialize(specific_pull_request_id, repo_slug = nil, remote: false, git_logs: "", remote_url: "")
       @specific_pull_request_id = specific_pull_request_id
       @git_logs = git_logs
       @repo_slug = repo_slug
       @remote = to_boolean(remote)
       @remote_url = remote_url
-      @env = env
     end
 
-    def call
-      check_if_any_pull_request!
-
-      pull_request
+    def call(env: nil)
+      find_pull_request(env).tap do |pull_request|
+        raise_pull_request_not_found!(pull_request) unless pull_request.valid?
+      end
     end
 
     private
 
-    attr_reader :specific_pull_request_id, :git_logs, :repo_slug, :remote, :remote_url, :env
+    attr_reader :specific_pull_request_id, :git_logs, :repo_slug, :remote, :remote_url
 
     def to_boolean(maybe_string)
       ["true", "1", "yes", "y", true].include?(maybe_string)
     end
 
-    def check_if_any_pull_request!
-      unless pull_request.valid?
-        if !specific_pull_request_id.empty?
-          raise "Could not find the Pull Request (#{specific_pull_request_id}) inside the git history for this repo."
-        else
-          raise "No recent Pull Requests found for this repo, danger requires at least one Pull Request for the local mode.".freeze
-        end
+    def raise_pull_request_not_found!(pull_request)
+      if specific_pull_request_id.empty?
+        raise "No recent Pull Requests found for this repo, danger requires at least one Pull Request for the local mode."
+      else
+        raise "Could not find the Pull Request (#{specific_pull_request_id}) inside the git history for this repo."
       end
     end
 
     # @return [String] Log line of most recent merged Pull Request
-    def pull_request
-      @pull_request ||= begin
-        return if pull_request_ref.empty?
+    def find_pull_request(env)
+      return if pull_request_ref.empty?
 
-        if both_present?
-          LocalPullRequest.new(pick_the_most_recent_one_from_two_matches)
-        elsif only_merged_pull_request_present?
-          LocalPullRequest.new(most_recent_merged_pull_request)
-        elsif only_squash_and_merged_pull_request_present?
-          LocalPullRequest.new(most_recent_squash_and_merged_pull_request)
-        elsif remote && remote_pull_request
-          generate_remote_pull_request
-        else
-          NoPullRequest.new
-        end
+      if both_present?
+        LocalPullRequest.new(pick_the_most_recent_one_from_two_matches)
+      elsif only_merged_pull_request_present?
+        LocalPullRequest.new(most_recent_merged_pull_request)
+      elsif only_squash_and_merged_pull_request_present?
+        LocalPullRequest.new(most_recent_squash_and_merged_pull_request)
+      elsif remote
+        remote_pull_request = find_remote_pull_request(env)
+        remote_pull_request ? generate_remote_pull_request(remote_pull_request) : NoPullRequest.new
+      else
+        NoPullRequest.new
       end
     end
 
     # @return [String] "#42"
     def pull_request_ref
-      !specific_pull_request_id.empty? ? "##{specific_pull_request_id}" : "#\\d+".freeze
+      !specific_pull_request_id.empty? ? "##{specific_pull_request_id}" : "#\\d+"
     end
 
-    def generate_remote_pull_request
+    def generate_remote_pull_request(remote_pull_request)
       scm_provider = find_scm_provider(remote_url)
 
       case scm_provider
@@ -88,10 +86,8 @@ module Danger
       end
     end
 
-    def remote_pull_request
-      @_remote_pull_request ||= begin
-        client.pull_request(repo_slug, specific_pull_request_id)
-      end
+    def find_remote_pull_request(env)
+      client(env).pull_request(repo_slug, specific_pull_request_id)
     end
 
     def both_present?
@@ -135,7 +131,7 @@ module Danger
       !most_recent_squash_and_merged_pull_request.nil? && !most_recent_squash_and_merged_pull_request.empty?
     end
 
-    def client
+    def client(env)
       scm_provider = find_scm_provider(remote_url)
 
       case scm_provider
@@ -168,7 +164,7 @@ module Danger
     def api_url
       ENV.fetch("DANGER_GITHUB_API_HOST") do
         ENV.fetch("DANGER_GITHUB_API_BASE_URL") do
-          "https://api.github.com/".freeze
+          "https://api.github.com/"
         end
       end
     end

--- a/lib/danger/request_sources/bitbucket_cloud.rb
+++ b/lib/danger/request_sources/bitbucket_cloud.rb
@@ -24,7 +24,6 @@ module Danger
 
       def initialize(ci_source, environment)
         self.ci_source = ci_source
-        self.environment = environment
 
         @api = BitbucketCloudAPI.new(ci_source.repo_slug, ci_source.pull_request_id, nil, environment)
       end

--- a/lib/danger/request_sources/bitbucket_cloud_api.rb
+++ b/lib/danger/request_sources/bitbucket_cloud_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # coding: utf-8
 
 require "danger/helpers/comments_helper"
@@ -32,9 +33,8 @@ module Danger
       def inspect
         inspected = super
 
-        if @password
-          inspected = inspected.sub! @password, "********".freeze
-        end
+        inspected.gsub!(@password, "********") if @password
+        inspected.gsub!(@access_token, "********") if @access_token
 
         inspected
       end

--- a/lib/danger/request_sources/bitbucket_server.rb
+++ b/lib/danger/request_sources/bitbucket_server.rb
@@ -31,7 +31,6 @@ module Danger
 
       def initialize(ci_source, environment)
         self.ci_source = ci_source
-        self.environment = environment
 
         project, slug = ci_source.repo_slug.split("/")
         @api = BitbucketServerAPI.new(project, slug, ci_source.pull_request_id, environment)

--- a/lib/danger/request_sources/bitbucket_server_api.rb
+++ b/lib/danger/request_sources/bitbucket_server_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # coding: utf-8
 
 require "openssl"
@@ -12,7 +13,7 @@ module Danger
         @username = environment["DANGER_BITBUCKETSERVER_USERNAME"]
         @password = environment["DANGER_BITBUCKETSERVER_PASSWORD"]
         self.host = environment["DANGER_BITBUCKETSERVER_HOST"]
-        self.verify_ssl = environment["DANGER_BITBUCKETSERVER_VERIFY_SSL"] == "false" ? false : true
+        self.verify_ssl = environment["DANGER_BITBUCKETSERVER_VERIFY_SSL"] != "false"
         if self.host && !(self.host.include? "http://") && !(self.host.include? "https://")
           self.host = "https://" + self.host
         end
@@ -24,9 +25,7 @@ module Danger
       def inspect
         inspected = super
 
-        if @password
-          inspected = inspected.sub! @password, "********".freeze
-        end
+        inspected.gsub!(@password, "********") if @password
 
         inspected
       end

--- a/lib/danger/request_sources/code_insights_api.rb
+++ b/lib/danger/request_sources/code_insights_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # coding: utf-8
 
 module Danger
@@ -26,9 +27,7 @@ module Danger
       def inspect
         inspected = super
 
-        if @password
-          inspected = inspected.sub! @password, "********".freeze
-        end
+        inspected.gsub!(@password, "********") if @password
 
         inspected
       end

--- a/lib/danger/request_sources/local_only.rb
+++ b/lib/danger/request_sources/local_only.rb
@@ -13,9 +13,8 @@ module Danger
         ["DANGER_LOCAL_ONLY"]
       end
 
-      def initialize(ci_source, environment)
+      def initialize(ci_source, _environment)
         self.ci_source = ci_source
-        self.environment = environment
       end
 
       def validates_as_ci?

--- a/lib/danger/request_sources/request_source.rb
+++ b/lib/danger/request_sources/request_source.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Danger
   module RequestSources
     class RequestSource
-      DANGER_REPO_NAME = "danger".freeze
+      DANGER_REPO_NAME = "danger"
 
-      attr_accessor :ci_source, :environment, :scm, :host, :ignored_violations
+      attr_accessor :ci_source, :scm, :host, :ignored_violations
 
       def self.env_vars
         raise "Subclass and overwrite self.env_vars"
@@ -23,17 +25,27 @@ module Danger
       end
 
       def self.source_name
-        to_s.sub("Danger::RequestSources::".freeze, "".freeze)
+        to_s.sub("Danger::RequestSources::", "")
       end
 
       def self.available_source_names_and_envs
         available_request_sources.map do |klass|
-          " - #{klass.source_name}: #{klass.env_vars.join(', '.freeze).yellow}"
+          " - #{klass.source_name}: #{klass.env_vars.join(', ').yellow}"
         end
       end
 
       def initialize(_ci_source, _environment)
         raise "Subclass and overwrite initialize"
+      end
+
+      def inspect
+        inspected = super
+
+        inspected.gsub!(@token, "********") if @token
+        inspected.gsub!(@access_token, "********") if @access_token
+        inspected.gsub!(@bearer_token, "********") if @bearer_token
+
+        inspected
       end
 
       # @return [Boolean] whether scm.origins is a valid git repository or not

--- a/lib/danger/request_sources/vsts.rb
+++ b/lib/danger/request_sources/vsts.rb
@@ -24,7 +24,6 @@ module Danger
 
       def initialize(ci_source, environment)
         self.ci_source = ci_source
-        self.environment = environment
 
         @is_vsts_git = environment["BUILD_REPOSITORY_PROVIDER"] == "TfsGit"
 

--- a/lib/danger/request_sources/vsts_api.rb
+++ b/lib/danger/request_sources/vsts_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # coding: utf-8
 
 require "base64"
@@ -35,9 +36,7 @@ module Danger
       def inspect
         inspected = super
 
-        if @token
-          inspected = inspected.sub! @token, "********".freeze
-        end
+        inspected.gsub!(@token, "********") if @token
 
         inspected
       end

--- a/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
@@ -14,6 +14,22 @@ RSpec.describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud
 
       expect(inspected).to include(%(@password="********"))
     end
+
+    context "with access token" do
+      let(:env) do
+        stub_env.merge(
+          "DANGER_BITBUCKETCLOUD_OAUTH_KEY" => "XXX",
+          "DANGER_BITBUCKETCLOUD_OAUTH_SECRET" => "YYY"
+        )
+      end
+      before { stub_access_token }
+
+      it "masks access_token on inspect" do
+        inspected = api.inspect
+
+        expect(inspected).to include(%(@access_token="********"))
+      end
+    end
   end
 
   describe "#project" do

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -6,6 +6,17 @@ require "danger/ci_source/travis"
 require "danger/danger_core/messages/violation"
 
 RSpec.describe Danger::RequestSources::GitHub, host: :github do
+  describe "#inspect" do
+    it "masks access_token and bearer_token on inspect" do
+      gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi", "DANGER_GITHUB_BEARER_TOKEN" => "ho" }
+
+      inspected = Danger::RequestSources::GitHub.new(stub_ci, gh_env).inspect
+
+      expect(inspected).to include(%(@access_token="********"))
+      expect(inspected).to include(%(@bearer_token="********"))
+    end
+  end
+
   describe "the github host" do
     it "sets a default GitHub host" do
       gh_env = { "DANGER_GITHUB_API_TOKEN" => "hi" }

--- a/spec/lib/danger/request_sources/gitlab_spec.rb
+++ b/spec/lib/danger/request_sources/gitlab_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Danger::RequestSources::GitLab, host: :gitlab do
   let(:env) { stub_env.merge("CI_MERGE_REQUEST_IID" => 1) }
   let(:subject) { stub_request_source(env) }
 
+  describe "#inspect" do
+    it "masks token on inspect" do
+      expect(subject.inspect).to include(%(@token="********"))
+    end
+  end
+
   describe "the GitLab host" do
     it "sets the default GitLab host" do
       expect(subject.host).to eq("gitlab.com")


### PR DESCRIPTION
This is similar to https://github.com/danger/danger/pull/1353. I found out that there were other places where environment variables were saved as instance variables, leading to potential leakage in the case of the raising of a `DslError`.

This also redact a few more instance variables through the `#inspect` method.