### PR TITLE
Fix `diff_for_file` on deleted files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 <!-- Your comment below here -->
 <!-- Your comment above here -->
 
+* Fix `diff_for_file` for deleted files - [@alexevanczuk](https://github.com/alexevanczuk) [#1357](https://github.com/danger/danger/pull/1357)
+
 ## 8.5.0
 
 * New feature on VSTS/Azure DevOps: inline comment - [@damien-danglard](https://github.com/damien-danglard) [#1356](https://github.com/danger/danger/pull/1356)

--- a/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb
@@ -128,7 +128,7 @@ module Danger
     # @return [Git::Diff::DiffFile] from the gem `git`
     #
     def diff_for_file(file)
-      (added_files + modified_files).include?(file) ? @git.diff[file] : nil
+      (added_files + modified_files + deleted_files).include?(file) ? @git.diff[file] : nil
     end
 
     # @!group Git Metadata

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -107,6 +107,26 @@ RSpec.describe Danger::DangerfileGitPlugin, host: :github do
           expect(@dsl.diff_for_file("file2")).to_not be_nil
         end
       end
+
+      it "returns a diff when it is deleted" do
+        run_in_repo_with_diff do |git|
+          diff = git.diff("master")
+          allow(@repo).to receive(:diff).and_return(diff)
+          diff_for_file = @dsl.diff_for_file("file1")
+          expect(diff_for_file).to_not be_nil
+          expected_patch = <<~PATCH
+            diff --git a/file1 b/file1
+            deleted file mode 100644
+            index 2cec6e8..0000000
+            --- a/file1
+            +++ /dev/null
+            @@ -1 +0,0 @@
+            -More buritto please.
+            \\ No newline at end of file
+          PATCH
+          expect(diff_for_file.patch).to eq expected_patch.chomp
+        end
+      end
     end
 
     describe "getting info for a specific file" do


### PR DESCRIPTION
Similar to https://github.com/danger/danger/pull/788, we want to be able to get a diff for a file when it is deleted.
