### PR TITLE
Fix Remote Code Execution vulnerability

### DIFF
--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -55,7 +55,8 @@ module Danger
     def exec(string)
       require "open3"
       Dir.chdir(self.folder || ".") do
-        Open3.popen2(default_env, "git #{string}") do |_stdin, stdout, _wait_thr|
+        git_command = string.split(" ").dup.unshift("git")
+        Open3.popen2(default_env, *git_command) do |_stdin, stdout, _wait_thr|
           stdout.read.rstrip
         end
       end

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -4,12 +4,10 @@ RSpec.describe Danger::GitRepo, host: :github do
   describe "#exec" do
     it "run command with our env set" do
       git_repo = described_class.new
-      allow(git_repo).to receive(:default_env) { Hash("LANG" => "zh_TW.UTF-8") }
-      command = Gem.win_platform? ? "status && set LANG" : "status && echo $LANG"
+      allow(git_repo).to receive(:default_env) { Hash("GIT_EXEC_PATH" => "git-command-path") }
+      result = git_repo.exec("--exec-path")
 
-      result = git_repo.exec(command)
-
-      expect(result).to match(/zh_TW.UTF-8/)
+      expect(result).to match(/git-command-path/)
     end
   end
 


### PR DESCRIPTION
Fixes #1359

My idea is `Danger::GitRepo#exec` (`Danger::LocalGitRepo#run_git`, `Danger::LocalOnlyGitRepo#run_git`) executes `Open3.popen2` with expanding Array parameter.