### PR TITLE
Don't report to provider on danger pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+* Fix for `danger pr` posting results to provider. - [@bobbymcwho](https://github.com/bobbymcwho) [#1365](https://github.com/danger/danger/pull/1365)
 <!-- Your comment above here -->
 
 ## 8.6.0

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -67,7 +67,8 @@ module Danger
           @dangerfile_path,
           nil,
           nil,
-          nil
+          nil,
+          false
         )
       end
     end

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -274,7 +274,7 @@ module Danger
       env.scm.diff_for_folder(".".freeze, from: base_branch, to: head_branch, lookup_top_level: true)
     end
 
-    def run(base_branch, head_branch, dangerfile_path, danger_id, new_comment, remove_previous_comments)
+    def run(base_branch, head_branch, dangerfile_path, danger_id, new_comment, remove_previous_comments, report_results = true)
       # Setup internal state
       init_plugins
       env.fill_environment_vars
@@ -289,7 +289,7 @@ module Danger
         # Push results to the API
         # Pass along the details of the run to the request source
         # to send back to the code review site.
-        post_results(danger_id, new_comment, remove_previous_comments)
+        post_results(danger_id, new_comment, remove_previous_comments) if report_results
 
         # Print results in the terminal
         print_results

--- a/spec/lib/danger/commands/pr_spec.rb
+++ b/spec/lib/danger/commands/pr_spec.rb
@@ -69,4 +69,20 @@ RSpec.describe Danger::PR do
       )
     end
   end
+
+  context "#run" do
+    let(:env_double) { instance_double('Danger::EnvironmentManager') }
+    let(:request_source_double) { instance_double('Danger::RequestSources::RequestSource') }
+
+    it "does not post to the pr" do
+      allow(Danger::EnvironmentManager).to receive(:new).and_return(env_double)
+      allow(env_double).to receive(:request_source).and_return(request_source_double)
+      allow(request_source_double).to receive(:update_pull_request!)
+
+      argv = CLAide::ARGV.new(["https://github.com/danger/danger/pull/1366"])
+
+      result = described_class.new(argv)
+      expect(request_source_double).not_to have_received(:update_pull_request!)
+    end
+  end
 end


### PR DESCRIPTION
Resolves #1364 

Action:
Run `danger pr` locally w/ a DANGER_GITHUB_API_TOKEN and a remote PR url. 
Desired:
Danger runs locally against your PR, and does not post to the PR. 
Actual Behavior:
Danger posts to the PR as your token user. 

![image](https://user-images.githubusercontent.com/6934825/164755634-32bb37f0-dc93-41c4-b7dc-44c499880568.png)
