### PR TITLE
Support batch build in AWS codebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -->
 
 ## master
+* Support batch builds in AWS CodeBuild [@ihatov08](https://github.com/ihatov08)
 <!-- Your comment below here -->
 <!-- Your comment above here -->
 

--- a/lib/danger/ci_source/code_build.rb
+++ b/lib/danger/ci_source/code_build.rb
@@ -4,7 +4,8 @@ require "danger/request_sources/github/github"
 module Danger
   # ### CI Setup
   #
-  # In CodeBuild, make sure to correctly forward CODEBUILD_BUILD_ID, CODEBUILD_WEBHOOK_TRIGGER, CODEBUILD_SOURCE_REPO_URL and DANGER_GITHUB_API_TOKEN.
+  # In CodeBuild, make sure to correctly forward CODEBUILD_BUILD_ID, CODEBUILD_SOURCE_VERSION, CODEBUILD_SOURCE_REPO_URL and DANGER_GITHUB_API_TOKEN.
+  # In CodeBuild with batch builds, make sure to correctly forward CODEBUILD_BUILD_ID, CODEBUILD_WEBHOOK_TRIGGER, CODEBUILD_SOURCE_REPO_URL, CODEBUILD_BATCH_BUILD_IDENTIFIER and DANGER_GITHUB_API_TOKEN.
   #
   # ### Token Setup
   #
@@ -25,7 +26,11 @@ module Danger
 
     def initialize(env)
       self.repo_slug = self.class.extract_repo_slug(env)
-      self.pull_request_id = env["CODEBUILD_WEBHOOK_TRIGGER"].split("/")[1].to_i
+      if env["CODEBUILD_BATCH_BUILD_IDENTIFIER"]
+        self.pull_request_id = env["CODEBUILD_WEBHOOK_TRIGGER"].split("/")[1].to_i
+      else
+        self.pull_request_id = env["CODEBUILD_SOURCE_VERSION"].split("/")[1].to_i
+      end
       self.repo_url = self.class.extract_repo_url(env)
     end
 
@@ -44,12 +49,20 @@ module Danger
     end
 
     def self.extract_pr_url(env)
-      return nil unless env.key? "CODEBUILD_WEBHOOK_TRIGGER"
-      return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
-      return nil unless env["CODEBUILD_WEBHOOK_TRIGGER"].split("/").length == 2
+      if env["CODEBUILD_BATCH_BUILD_IDENTIFIER"]
+        return nil unless env.key? "CODEBUILD_WEBHOOK_TRIGGER"
+        return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
+        return nil unless env["CODEBUILD_WEBHOOK_TRIGGER"].split("/").length == 2
 
-      event_type, pr_number = env["CODEBUILD_WEBHOOK_TRIGGER"].split("/")
-      return nil unless event_type == "pr"
+        event_type, pr_number = env["CODEBUILD_WEBHOOK_TRIGGER"].split("/")
+        return nil unless event_type == "pr"
+      else
+        return nil unless env.key? "CODEBUILD_SOURCE_VERSION"
+        return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
+        return nil unless env["CODEBUILD_SOURCE_VERSION"].split("/").length == 2
+
+        _source_origin, pr_number = env["CODEBUILD_SOURCE_VERSION"].split("/")
+      end
       github_repo_url = env["CODEBUILD_SOURCE_REPO_URL"].gsub(/\.git$/, "")
 
       "#{github_repo_url}/pull/#{pr_number}"

--- a/lib/danger/ci_source/code_build.rb
+++ b/lib/danger/ci_source/code_build.rb
@@ -48,7 +48,8 @@ module Danger
       return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
       return nil unless env["CODEBUILD_WEBHOOK_TRIGGER"].split("/").length == 2
 
-      _source_origin, pr_number = env["CODEBUILD_WEBHOOK_TRIGGER"].split("/")
+      event_type, pr_number = env["CODEBUILD_WEBHOOK_TRIGGER"].split("/")
+      return nil unless event_type == "pr"
       github_repo_url = env["CODEBUILD_SOURCE_REPO_URL"].gsub(/\.git$/, "")
 
       "#{github_repo_url}/pull/#{pr_number}"

--- a/lib/danger/ci_source/code_build.rb
+++ b/lib/danger/ci_source/code_build.rb
@@ -4,7 +4,7 @@ require "danger/request_sources/github/github"
 module Danger
   # ### CI Setup
   #
-  # In CodeBuild, make sure to correctly forward CODEBUILD_BUILD_ID, CODEBUILD_SOURCE_VERSION, CODEBUILD_SOURCE_REPO_URL and DANGER_GITHUB_API_TOKEN.
+  # In CodeBuild, make sure to correctly forward CODEBUILD_BUILD_ID, CODEBUILD_WEBHOOK_TRIGGER, CODEBUILD_SOURCE_REPO_URL and DANGER_GITHUB_API_TOKEN.
   #
   # ### Token Setup
   #
@@ -25,7 +25,7 @@ module Danger
 
     def initialize(env)
       self.repo_slug = self.class.extract_repo_slug(env)
-      self.pull_request_id = env["CODEBUILD_SOURCE_VERSION"].split("/")[1].to_i
+      self.pull_request_id = env["CODEBUILD_WEBHOOK_TRIGGER"].split("/")[1].to_i
       self.repo_url = self.class.extract_repo_url(env)
     end
 
@@ -44,11 +44,11 @@ module Danger
     end
 
     def self.extract_pr_url(env)
-      return nil unless env.key? "CODEBUILD_SOURCE_VERSION"
+      return nil unless env.key? "CODEBUILD_WEBHOOK_TRIGGER"
       return nil unless env.key? "CODEBUILD_SOURCE_REPO_URL"
-      return nil unless env["CODEBUILD_SOURCE_VERSION"].split("/").length == 2
+      return nil unless env["CODEBUILD_WEBHOOK_TRIGGER"].split("/").length == 2
 
-      _source_origin, pr_number = env["CODEBUILD_SOURCE_VERSION"].split("/")
+      _source_origin, pr_number = env["CODEBUILD_WEBHOOK_TRIGGER"].split("/")
       github_repo_url = env["CODEBUILD_SOURCE_REPO_URL"].gsub(/\.git$/, "")
 
       "#{github_repo_url}/pull/#{pr_number}"

--- a/spec/lib/danger/ci_sources/code_build_spec.rb
+++ b/spec/lib/danger/ci_sources/code_build_spec.rb
@@ -47,8 +47,16 @@ RSpec.describe Danger::CodeBuild do
         end
       end
 
-      context "when `CODEBUILD_WEBHOOK_TRIGGER` is commit hash" do
-        let(:env) { valid_env.merge({ "CODEBUILD_WEBHOOK_TRIGGER" => "6548dbc49fe57e1fe7507a7a4b815639a62e9f90" }) }
+      context "when `CODEBUILD_WEBHOOK_TRIGGER` like a 'branch/branch_name'" do
+        let(:env) { valid_env.merge({ "CODEBUILD_WEBHOOK_TRIGGER" => "branch/branch_name" }) }
+
+        it "doesn't validates" do
+          is_expected.to be false
+        end
+      end
+
+      context "when `CODEBUILD_WEBHOOK_TRIGGER` like a 'tag/v1.0.0'" do
+        let(:env) { valid_env.merge({ "CODEBUILD_WEBHOOK_TRIGGER" => "tag/v1.0.0" }) }
 
         it "doesn't validates" do
           is_expected.to be false

--- a/spec/lib/danger/ci_sources/code_build_spec.rb
+++ b/spec/lib/danger/ci_sources/code_build_spec.rb
@@ -1,7 +1,6 @@
 require "danger/ci_source/github_actions"
 
 RSpec.describe Danger::CodeBuild do
-  # CODEBUILD_WEBHOOK_TRIGGER=pr/2512 CODEBUILD_SOURCE_REPO_URL=https://github.o-in.dwango.co.jp/zane/zane-Soroban-web CODEBUILD_BUILD_ID=zane-soroban:cf613895-4a78-4456-8568-a53784fa75c5
   let(:valid_env) do
     {
       "CODEBUILD_BUILD_ID" => "codebuild:cf613895-4a78-4456-8568-a53784fa75c5",

--- a/spec/lib/danger/ci_sources/code_build_spec.rb
+++ b/spec/lib/danger/ci_sources/code_build_spec.rb
@@ -1,11 +1,11 @@
 require "danger/ci_source/github_actions"
 
 RSpec.describe Danger::CodeBuild do
-  # CODEBUILD_SOURCE_VERSION=pr/2512 CODEBUILD_SOURCE_REPO_URL=https://github.o-in.dwango.co.jp/zane/zane-Soroban-web CODEBUILD_BUILD_ID=zane-soroban:cf613895-4a78-4456-8568-a53784fa75c5
+  # CODEBUILD_WEBHOOK_TRIGGER=pr/2512 CODEBUILD_SOURCE_REPO_URL=https://github.o-in.dwango.co.jp/zane/zane-Soroban-web CODEBUILD_BUILD_ID=zane-soroban:cf613895-4a78-4456-8568-a53784fa75c5
   let(:valid_env) do
     {
       "CODEBUILD_BUILD_ID" => "codebuild:cf613895-4a78-4456-8568-a53784fa75c5",
-      "CODEBUILD_SOURCE_VERSION" => "pr/1234",
+      "CODEBUILD_WEBHOOK_TRIGGER" => "pr/1234",
       "CODEBUILD_SOURCE_REPO_URL" => source_repo_url
     }
   end
@@ -39,24 +39,24 @@ RSpec.describe Danger::CodeBuild do
       subject { described_class.validates_as_pr?(env) }
       let(:env) { valid_env }
 
-      context "when `CODEBUILD_SOURCE_VERSION` like a 'pr/1234" do
-        let(:env) { valid_env.merge({ "CODEBUILD_SOURCE_VERSION" => "pr/1234" }) }
+      context "when `CODEBUILD_WEBHOOK_TRIGGER` like a 'pr/1234" do
+        let(:env) { valid_env.merge({ "CODEBUILD_WEBHOOK_TRIGGER" => "pr/1234" }) }
 
         it "validates" do
           is_expected.to be true
         end
       end
 
-      context "when `CODEBUILD_SOURCE_VERSION` is commit hash" do
-        let(:env) { valid_env.merge({ "CODEBUILD_SOURCE_VERSION" => "6548dbc49fe57e1fe7507a7a4b815639a62e9f90" }) }
+      context "when `CODEBUILD_WEBHOOK_TRIGGER` is commit hash" do
+        let(:env) { valid_env.merge({ "CODEBUILD_WEBHOOK_TRIGGER" => "6548dbc49fe57e1fe7507a7a4b815639a62e9f90" }) }
 
         it "doesn't validates" do
           is_expected.to be false
         end
       end
 
-      context "when `CODEBUILD_SOURCE_VERSION` is missing" do
-        let(:env) { valid_env.tap { |e| e.delete("CODEBUILD_SOURCE_VERSION") } }
+      context "when `CODEBUILD_WEBHOOK_TRIGGER` is missing" do
+        let(:env) { valid_env.tap { |e| e.delete("CODEBUILD_WEBHOOK_TRIGGER") } }
 
         it "doesn't validates" do
           is_expected.to be false


### PR DESCRIPTION
`CODEBUILD_SOURCE_VERSION` environment variable returns commit hash(example: `6548dbc49fe57e1fe7507a7a4b815639a62e9f90`) in a batch build when triggered by a pull request.

`CODEBUILD_WEBHOOK_TRIGGER` environment variable rerurns `{event_name}/{event_variable}`(example `pr/123`) in both normal build and batch build.

> CODEBUILD_WEBHOOK_TRIGGER
Shows the webhook event that triggered the build. This variable is available only for builds triggered by a webhook. The value is parsed from the payload sent to CodeBuild by GitHub, GitHub Enterprise Server, or Bitbucket. The value's format depends on what type of event triggered the build.
For builds triggered by a pull request, it is pr/pull-request-number.
For builds triggered by creating a new branch or pushing a commit to a branch, it is branch/branch-name.
For builds triggered by a pushing a tag to a repository, it is tag/tag-name.


https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html

Therefore, use `CODEBUILD_WEBHOOK_TRIGGER` environment variable so that danger works only when event_type is pr.
