### PR TITLE
Fix `can't modify frozen String (FrozenError)` exception for VSTS / Azure DevOps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 <!-- Your comment below here -->
 <!-- Your comment above here -->
+* VSTS / Azure DevOps: Fix submission of inline comments with recent Ruby versions. - [@yanniks](https://github.com/yanniks)
 
 ## 8.6.1
 

--- a/lib/danger/request_sources/vsts.rb
+++ b/lib/danger/request_sources/vsts.rb
@@ -195,7 +195,7 @@ module Danger
             body = generate_inline_markdown_body(m, danger_id: danger_id, template: "vsts")
           else
             # Hide the inline link behind a span
-            m.message.gsub!("\n", "<br />")
+            m.message = m.message.gsub("\n", "<br />")
             m = process_markdown(m, true)
             body = generate_inline_comment_body(emoji, m, danger_id: danger_id, template: "vsts")
             # A comment might be in previous_violations because only now it's part of the unified diff


### PR DESCRIPTION
On recent Ruby versions, it does not seem to be possible to directly use `gsub!` as Danger did it before in the VSTS / Azure DevOps component:

```
bundle exec danger --dangerfile=../buildtools/Dangerfile
[08:46:08]: ▸ bundler: failed to load command: danger (/Users/ci/.gem/ruby/2.6.0/bin/danger)
[08:46:08]: ▸ /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/request_sources/vsts.rb:198:in `gsub!': can't modify frozen String (FrozenError)
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/request_sources/vsts.rb:198:in `block in submit_inline_comments_for_kind!'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/request_sources/vsts.rb:190:in `reject'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/request_sources/vsts.rb:190:in `submit_inline_comments_for_kind!'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/request_sources/vsts.rb:156:in `submit_inline_comments!'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/request_sources/vsts.rb:97:in `update_pull_request!'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/danger_core/dangerfile.rb:264:in `post_results'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/danger_core/dangerfile.rb:292:in `run'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/danger_core/executor.rb:29:in `run'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/lib/danger/commands/runner.rb:73:in `run'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/claide-1.1.0/lib/claide/command.rb:334:in `run'
[08:46:08]: ▸ from /Users/ci/.gem/ruby/2.6.0/gems/danger-8.6.1/bin/danger:5:in `<top (required)>'
```

We were facing this issue on a Mac Studio with macOS 12.5. This PR fixes the issue.