### PR TITLE
Update Octokit gem dependency to version 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+* Update Octokit dependency to version 5.0. - [@mathroule](https://github.com/mathroule) [#1377](https://github.com/danger/danger/pull/1377)
 <!-- Your comment above here -->
 
 ## 8.6.1

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
-  spec.add_runtime_dependency "octokit", "~> 4.7"
+  spec.add_runtime_dependency "octokit", "~> 5.0"
   spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "no_proxy_fix"


### PR DESCRIPTION
Danger relies on Octokit gem dependency version `~> 4.7`, which makes it impossible to use Octokit version 5.0 and above when dependencies are resolved with Bundler.