### PR TITLE
Drop support for Ruby 2.4, support Ruby 2.7+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/danger
     docker:
-      - image: ruby:2.4
+      - image: ruby:2.7
         environment:
         - RAILS_ENV=test
         - RACK_ENV=test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - checkout
       - run: gem update --system 2.5.0
-      - run: gem install bundler -v '2.0.1'
+      - run: gem install bundler -v '2.3.20'
       - restore_cache:
           key: gem-cache-{{ .Branch }}-{{ checksum "Gemfile" }}
       - run: bundle install --path vendor/bundle

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # Defaults can be found here: https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
   Exclude:
     - 'spec/fixtures/**/*'
     - 'lib/danger/plugin_support/plugin_parser.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ bundler_args: "--without documentation --path bundle"
 
 before_install:
   - git fetch --depth=1000000
-  - gem install bundler -v '2.0.1'
+  - gem install bundler -v '2.3.20'
 
 after_install:
   - rake install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ cache:
 
 rvm:
   - 2.7.1
-  - 2.6.0
-  - 2.5.3
-  - 2.4.5
 
 bundler_args: "--without documentation --path bundle"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
-**Breaking** - Drop support for Ruby 2.6, support Ruby 2.7+ [@mathroule](https://github.com/mathroule) [#1378](https://github.com/danger/danger/pull/1378)
+**Breaking** - Drop support for Ruby 2.4, support Ruby 2.7+ [@mathroule](https://github.com/mathroule) [#1378](https://github.com/danger/danger/pull/1378)
 <!-- Your comment above here -->
 
 ## 8.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
-**Breaking** - Drop support for Ruby 2.4, support Ruby 2.7+ [@mathroule](https://github.com/mathroule) [#1378](https://github.com/danger/danger/pull/1378)
+**Breaking** - Drop support for Ruby 2.4, support Ruby 2.7+ [@mathroule](https://github.com/mathroule) [#1378](https://github.com/danger/danger/pull/1378) 
 <!-- Your comment above here -->
 
 ## 8.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+**Breaking** - Drop support for Ruby 2.6, support Ruby 2.7+ [@mathroule](https://github.com/mathroule) [#1378](https://github.com/danger/danger/pull/1378)
 <!-- Your comment above here -->
 
 ## 8.6.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - set PATH=C:\Ruby24\bin;%PATH%
+  - set PATH=C:\Ruby27\bin;%PATH%
   - gem uninstall bundler --executables
   - gem install bundler -v '2.0.1'
   - bundle install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 install:
   - set PATH=C:\Ruby27\bin;%PATH%
   - gem uninstall bundler --executables
-  - gem install bundler -v '2.0.1'
+  - gem install bundler -v '2.3.20'
   - bundle install
 
 build: off

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.add_runtime_dependency "claide", "~> 1.0"
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"


### PR DESCRIPTION
Require Ruby version 2.7+. Ruby 2.6 has reached end of life: https://www.ruby-lang.org/en/downloads/branches. This change is a prerequisite to https://github.com/danger/danger/pull/1377.

Changes:
- Use Ruby 2.7
- Use bundler 2.3.20

AppVeyor project configuration needs to be changed to use Visual Studio 2022 (or at least 2019) to support Ruby 2.7 (https://www.appveyor.com/docs/windows-images-software/#ruby).
<img width="983" alt="Screen Shot 2022-08-22 at 19 19 47" src="https://user-images.githubusercontent.com/4117425/185981334-5d9e6f15-10ff-423f-8e61-31eb5d7b94cf.png">