### PR TITLE
Allow import_dangerfile to accept full path

### DIFF
--- a/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
+++ b/lib/danger/danger_core/plugins/dangerfile_danger_plugin.rb
@@ -132,7 +132,7 @@ module Danger
     #
     def import_dangerfile_from_path(path)
       raise "`import_dangerfile_from_path` requires a string" unless path.kind_of?(String)
-      local_path = File.join(path, "Dangerfile")
+      local_path = File.file?(path) ? path : File.join(path, "Dangerfile")
       @dangerfile.parse(Pathname.new(local_path))
     end
 

--- a/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_danger_plugin_spec.rb
@@ -129,6 +129,17 @@ RSpec.describe Danger::Dangerfile::DSL, host: :github do
       expect(dm.status_report[:messages]).to eq(["OK"])
     end
 
+    it "path: 'full_path'" do
+      outer_dangerfile = "danger.import_dangerfile(path: 'foo/bar/baz.rb')"
+      inner_dangerfile = "message('OK')"
+
+      expected_path = "foo/bar/baz.rb"
+      expect(File).to receive(:file?).with(expected_path).and_return(true)
+      expect(File).to receive(:open).with(Pathname.new(expected_path), "r:utf-8").and_return(inner_dangerfile)
+      dm.parse(Pathname.new("."), outer_dangerfile)
+      expect(dm.status_report[:messages]).to eq(["OK"])
+    end
+
     it "gem: 'name'" do
       outer_dangerfile = "danger.import_dangerfile(gem: 'example')"
       inner_dangerfile = "message('OK')"


### PR DESCRIPTION
Currently `import_dangerfile(path: '...')` assumes the user provides the path to the directory containing a Dangerfile.
This is not the case when we are splitting large Dangerfiles into smaller ones. We have to place each Dangerfile in separate directories. 
In this PR I modified the `import_dangerfile_from_path` method to check if the provided path is a file, if yes, then use that path to import. Otherwise, append `Dangerfile` to the path and import it.

Fixes #1379