### PR TITLE
Run GitHub Actions workflow on macOS, Ubuntu and Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,11 +4,11 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
         ruby-version: [2.7, '3.0', 3.1]
-
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -21,8 +22,10 @@ jobs:
         run: |
           git config --global user.email "orta+dangersystems@artsy.net"
           git config --global user.name "Danger.Systems"
+
       - name: Running Tests
         run: bundle exec rake spec
+
       - name: Running the Dangerfile for this repo
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,21 +10,21 @@ jobs:
         ruby-version: [2.7, '3.0', 3.1]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
+      - uses: actions/checkout@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
 
-    - name: Configure Git email/username
-      run: |
-        git config --global user.email "orta+dangersystems@artsy.net"
-        git config --global user.name "Danger.Systems"
-    - name: Running Tests
-      run: bundle exec rake spec
-    - name: Running the Dangerfile for this repo
-      run: |
-        TOKEN='7469b4e94ce21b43e3ab7a'
-        TOKEN+='79960c12a1e067f2ec'
-        DANGER_GITHUB_API_TOKEN=$TOKEN RUNNING_IN_ACTIONS=true echo 'bundle exec danger --verbose'
+      - name: Configure Git email/username
+        run: |
+          git config --global user.email "orta+dangersystems@artsy.net"
+          git config --global user.name "Danger.Systems"
+      - name: Running Tests
+        run: bundle exec rake spec
+      - name: Running the Dangerfile for this repo
+        run: |
+          TOKEN='7469b4e94ce21b43e3ab7a'
+          TOKEN+='79960c12a1e067f2ec'
+          DANGER_GITHUB_API_TOKEN=$TOKEN RUNNING_IN_ACTIONS=true echo 'bundle exec danger --verbose'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        ruby-version: [2.7, '3.0', 3.1]
+        ruby-version: [2.7, 3.0, 3.1]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -24,6 +24,7 @@ jobs:
       - name: Running Tests
         run: bundle exec rake spec
       - name: Running the Dangerfile for this repo
+        if: runner.os != 'Windows'
         run: |
           TOKEN='7469b4e94ce21b43e3ab7a'
           TOKEN+='79960c12a1e067f2ec'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 <!-- Your comment below here -->
+* Check pull request to Danger repo on macOS, Ubuntu and Windows - [@mathroule](https://github.com/mathroule) [#1365](https://github.com/danger/danger/pull/1381)
 <!-- Your comment above here -->
 
 ## 8.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 ## 8.4.4
 
-* Don't post Dangefile errors as comment on PR when the `DANGER_DO_NOT_POST_INVALID_DANGERFILE_ERROR` env var is set - [@rymai](https://github.com/rymai) [#1354](https://github.com/danger/danger/pull/1354)
+* Don't post Dangerfile errors as comment on PR when the `DANGER_DO_NOT_POST_INVALID_DANGERFILE_ERROR` env var is set - [@rymai](https://github.com/rymai) [#1354](https://github.com/danger/danger/pull/1354)
 
 ## 8.4.3
 


### PR DESCRIPTION
# Description
Use GitHub Actions matrix to run checks on macOS, Ubuntu and Windows.

# Changes
- Use GitHub Actions matrix with OS
- Cancel concurrent GitHub Actions workflow run
- Check only pull requests to `master` branch
- Reformat code