### PR TITLE
Use an Octokit client without tokens when support_tokenless_auth is true

### DIFF
--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -73,6 +73,8 @@ module Danger
             Octokit::Client.new(bearer_token: @bearer_token, auto_paginate: true, api_endpoint: api_url)
           elsif valid_access_token?
             Octokit::Client.new(access_token: @access_token, auto_paginate: true, api_endpoint: api_url)
+          elsif support_tokenless_auth
+            Octokit::Client.new(auto_paginate: true, api_endpoint: api_url)
           end
         end
       end


### PR DESCRIPTION
Currently, if support_tokenless_auth is true (mainly, invoked with `danger local`), the client method returns nil and results in NoMethodError.

```
% bundle exec danger local
Running your Dangerfile against this PR - https://github.com/danger/danger/pull/1384
Turning on --verbose

bundler: failed to load command: danger (/Users/makimoto/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/bin/danger)
NoMethodError: undefined method `pull_request' for nil:NilClass
  /Users/makimoto/.ghq/github.com/danger/danger/lib/danger/request_sources/github/github.rb:117:in `fetch_details'
  /Users/makimoto/.ghq/github.com/danger/danger/lib/danger/commands/local_helpers/local_setup.rb:37:in `setup'
  /Users/makimoto/.ghq/github.com/danger/danger/lib/danger/commands/local.rb:55:in `run'
  /Users/makimoto/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/claide-1.1.0/lib/claide/command.rb:334:in `run'
  /Users/makimoto/.ghq/github.com/danger/danger/bin/danger:5:in `<top (required)>'
  /Users/makimoto/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/bin/danger:23:in `load'
  /Users/makimoto/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/bin/danger:23:in `<top (required)>'
```

Therefore, in this case, the client method should return a client without tokens to access resources of public repositories.

Definitely, the patch should include a test for the case, but I couldn't see where I should add it. Could you please advise me about it?
Thank you.