### PR TITLE
Fix RuboCop runtime errors #trivial

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,20 +14,16 @@ Style/StringLiterals:
 Style/ClassCheck:
   EnforcedStyle: kind_of?
 
-# It's better to be more explicit about the type
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 # specs sometimes have useless assignments, which is fine
 Lint/UselessAssignment:
   Exclude:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # HoundCI doesn't like this rule
@@ -149,5 +145,5 @@ Security/YAMLLoad:
 Style/RaiseArgs:
   Enabled: false
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false


### PR DESCRIPTION
The following error occurred when currently running the RuboCop, so this PR is fixed this error.

```
bundle exec rubocop
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
.rubocop.yml: Style/FileName has the wrong namespace - should be Naming
/Users/yudai.takada/ydah/danger/.rubocop.yml: Warning: no department given for PercentLiteralDelimiters.
Error: The `Layout/AlignHash` cop has been renamed to `Layout/HashAlignment`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/IndentHash` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/IndentHeredoc` cop has been renamed to `Layout/HeredocIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/BracesAroundHashParameters` cop has been removed.
(obsolete configuration found in .rubocop.yml, please update it)
```