### PR TITLE
Fix RuboCop runtime warnings #trivial

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,7 +73,7 @@ Metrics/CyclomaticComplexity:
   Max: 17
 
 # Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 370
 
 # Configuration parameters: CountKeywordArgs.
@@ -121,13 +121,13 @@ Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
 
-Style/FileName:
+Naming/FileName:
   Enabled: false
 
 Style/SpecialGlobalVars:
   Enabled: false
 
-PercentLiteralDelimiters:
+Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     "%":  ()
     "%i": ()

--- a/lib/danger/danger_core/dangerfile.rb
+++ b/lib/danger/danger_core/dangerfile.rb
@@ -308,7 +308,7 @@ module Danger
     private
 
     def eval_file(contents, path)
-      eval(contents, nil, path.to_s) # rubocop:disable Eval
+      eval(contents, nil, path.to_s) # rubocop:disable Security/Eval
     end
 
     def print_list(title, rows)

--- a/spec/lib/danger/helpers/comments_helper_spec.rb
+++ b/spec/lib/danger/helpers/comments_helper_spec.rb
@@ -402,40 +402,40 @@ COMMENT
 
     it "some warnings, no errors" do
       result = dummy.generate_comment(warnings: violations_factory(["my warning", "second warning"]), errors: [], messages: [])
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       expect(result.gsub(/\s+/, "")).to end_with(
         '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr><tr><td>:warning:</td><tddata-sticky="false">secondwarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="https://danger.systems/">Danger</a></p>'
       )
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
     end
 
     it "some warnings with markdown, no errors" do
       warnings = violations_factory(["a markdown [link to danger](https://github.com/danger/danger)", "second **warning**"])
       result = dummy.generate_comment(warnings: warnings, errors: [], messages: [])
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       expect(result.gsub(/\s+/, "")).to end_with(
         '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">2Warnings</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></td></tr><tr><td>:warning:</td><tddata-sticky="false">second<strong>warning</strong></td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="https://danger.systems/">Danger</a></p>'
       )
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
     end
 
     it "a multiline warning with markdown, no errors" do
       warnings = violations_factory(["a markdown [link to danger](https://github.com/danger/danger)\n\n```\nsomething\n```\n\nHello"])
       result = dummy.generate_comment(warnings: warnings, errors: [], messages: [])
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       expect(result.gsub(/\s+/, "")).to end_with(
         '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">amarkdown<ahref="https://github.com/danger/danger">linktodanger</a></p><pre><code>something</code></pre><p>Hello</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="https://danger.systems/">Danger</a></p>'
       )
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
     end
 
     it "some warnings, some errors" do
       result = dummy.generate_comment(warnings: violations_factory(["my warning"]), errors: violations_factory(["some error"]), messages: [])
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       expect(result.gsub(/\s+/, "")).to end_with(
         '<table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Error">1Error</th></tr></thead><tbody><tr><td>:no_entry_sign:</td><tddata-sticky="false">someerror</td></tr></tbody></table><table><thead><tr><thwidth="50"></th><thwidth="100%"data-danger-table="true"data-kind="Warning">1Warning</th></tr></thead><tbody><tr><td>:warning:</td><tddata-sticky="false">mywarning</td></tr></tbody></table><palign="right"data-meta="generated_by_danger">Generatedby:no_entry_sign:<ahref="https://danger.systems/">Danger</a></p>'
       )
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
     end
 
     it "deduplicates previous violations" do


### PR DESCRIPTION
The following warnings occurred when currently running the RuboCop, so this PR is fixed this warnings.

```
/ydah/danger/lib/danger/danger_core/dangerfile.rb: Warning: no department given for Eval. Run `rubocop -a --only Migration/DepartmentName` to fix.
spec/lib/danger/helpers/comments_helper_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
spec/lib/danger/helpers/comments_helper_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
spec/lib/danger/helpers/comments_helper_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
spec/lib/danger/helpers/comments_helper_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
spec/lib/danger/helpers/comments_helper_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
spec/lib/danger/helpers/comments_helper_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
spec/lib/danger/helpers/comments_helper_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
spec/lib/danger/helpers/comments_helper_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
.rubocop.yml: Style/FileName has the wrong namespace - should be Naming
/ydah/danger/.rubocop.yml: Warning: no department given for PercentLiteralDelimiters.
```
