### PR TITLE
Replaces the deprecated `MAINTAINER` for Dockerfile #trivial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM ruby:2.7
 
-MAINTAINER Orta Therox
-
-LABEL "com.github.actions.name"="Danger" 
+LABEL "com.github.actions.name"="Danger"
 LABEL "com.github.actions.description"="Runs danger in a docker container such as GitHub Actions"
 LABEL "com.github.actions.icon"="mic"
 LABEL "com.github.actions.color"="purple"
 LABEL "repository"="https://github.com/danger/danger"
 LABEL "homepage"="https://github.com/danger/danger"
 LABEL "maintainer"="Rishabh Tayal <rtayal11@gmail.com>"
+LABEL "maintainer"="Orta Therox"
 
 RUN apt-get update -qq && apt-get install -y build-essential p7zip unzip
 


### PR DESCRIPTION
According to DockerFile reference `MAINTAINER` is now deprecated. 
- https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

We would therefore replace it with `LABEL`.

Ref: https://togithub.com/WerWolv/ImHex/pull/767