### PR TITLE
Remove unintended overrides of self.summary to fix help comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## master
 
+* Fixed incorrect help messages for `danger plugins lint` and `danger plugins readme`. [@manicmaniac](https://github.com/manicmaniac) [#1397](https://github.com/danger/danger/issues/1397)
 <!-- Your comment above here -->
 
 ## 9.1.0

--- a/lib/danger/commands/plugins/plugin_json.rb
+++ b/lib/danger/commands/plugins/plugin_json.rb
@@ -3,7 +3,7 @@ require "danger/plugin_support/plugin_file_resolver"
 
 module Danger
   class PluginJSON < CLAide::Command::Plugins
-    self.summary = "Prints the JSON documentation representing a plugin"
+    self.summary = "Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success."
     self.command = "json"
 
     attr_accessor :cork
@@ -14,8 +14,6 @@ module Danger
                               verbose: argv.option("verbose", false))
       super
     end
-
-    self.summary = "Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success."
 
     self.description = <<-DESC
       Converts a collection of file paths of Danger plugins into a JSON format.

--- a/lib/danger/commands/plugins/plugin_lint.rb
+++ b/lib/danger/commands/plugins/plugin_lint.rb
@@ -17,8 +17,6 @@ module Danger
       super
     end
 
-    self.summary = "Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success."
-
     self.description = <<-DESC
       Converts a collection of file paths of Danger plugins into a JSON format.
       Note: Before 1.0, it will also parse the represented JSON to validate whether https://danger.systems would

--- a/lib/danger/commands/plugins/plugin_readme.rb
+++ b/lib/danger/commands/plugins/plugin_readme.rb
@@ -17,8 +17,6 @@ module Danger
       super
     end
 
-    self.summary = "Lint plugins from files, gems or the current folder. Outputs JSON array representation of Plugins on success."
-
     self.description = <<-DESC
       Converts a collection of file paths of Danger plugins into a format usable in a README.
       This is useful for Danger itself, but also for any plugins wanting to showcase their API.


### PR DESCRIPTION
Close https://github.com/danger/danger/issues/1397

## Cause

All of `Danger::PluginJSON`, `Danger::PluginLint` and `Danger::PluginReadme` classes have 2 `self.summary` assignments.
Only the latter is effective but it is not suitable message for `Danger::PluginLint` and `Danger::PluginReadme`.

In `Danger::PluginJSON`
- https://github.com/danger/danger/blob/99bc6c7a50628fc0a8b70854b9faed08050f57ed/lib/danger/commands/plugins/plugin_json.rb#L6
- https://github.com/danger/danger/blob/99bc6c7a50628fc0a8b70854b9faed08050f57ed/lib/danger/commands/plugins/plugin_json.rb#L18

In `Danger::PluginLint`
- https://github.com/danger/danger/blob/99bc6c7a50628fc0a8b70854b9faed08050f57ed/lib/danger/commands/plugins/plugin_lint.rb#L7
- https://github.com/danger/danger/blob/99bc6c7a50628fc0a8b70854b9faed08050f57ed/lib/danger/commands/plugins/plugin_lint.rb#L20

In `Danger::PluginReadme`
- https://github.com/danger/danger/blob/99bc6c7a50628fc0a8b70854b9faed08050f57ed/lib/danger/commands/plugins/plugin_readme.rb#L8
- https://github.com/danger/danger/blob/99bc6c7a50628fc0a8b70854b9faed08050f57ed/lib/danger/commands/plugins/plugin_readme.rb#L20

## Solution

I removed the one of the assignments in each class with leaving the correct-ish message.