### PR TITLE
Fix GitHub inline commens cleanup logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Fix GitHub inline commens cleanup logic - [@kemchenj](https://kemchen.github.io/)
+
 <!-- Your comment above here -->
 
 ## 9.1.0

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -253,9 +253,6 @@ module Danger
       end
 
       def submit_inline_comments!(warnings: [], errors: [], messages: [], markdowns: [], previous_violations: [], danger_id: "danger")
-        # Avoid doing any fetchs if there's no inline comments
-        return {} if (warnings + errors + messages + markdowns).select(&:inline?).empty?
-
         diff_lines = self.pr_diff.lines
         pr_comments = client.pull_request_comments(ci_source.repo_slug, ci_source.pull_request_id)
         danger_comments = pr_comments.select { |comment| Comment.from_github(comment).generated_by_danger?(danger_id) }


### PR DESCRIPTION
Currently, danger cleans up all the outdated inline comments after submitting inline comments. 

But there is an early return when there are no inline comments needed to submit before all, and it breaks the cleanup logic. So we might want to remove it.