### PR TITLE
Add Ruby 3.2 to the CI matrix #trivial

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,15 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        ruby-version: [2.7, 3.0, 3.1]
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        ruby-version:
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR is add Ruby 3.2 to the CI matrix
Because Ruby 3.2.0 is now in general release, it makes sense to add Ruby 3.2 to the CI matrix.

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/
