### PR TITLE
Remove `< 2.0` Faraday version restriction

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "cork", "~> 0.1"
-  spec.add_runtime_dependency "faraday", ">= 0.9.0", "< 2.0"
+  spec.add_runtime_dependency "faraday", "~> 2.0.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
   spec.add_runtime_dependency "git", "~> 1.7"
   spec.add_runtime_dependency "kramdown", "~> 2.3"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "cork", "~> 0.1"
-  spec.add_runtime_dependency "faraday", ">= 0.9.0", "~> 2.0.0"
+  spec.add_runtime_dependency "faraday", ">= 0.9.0", "< 3.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
   spec.add_runtime_dependency "git", "~> 1.7"
   spec.add_runtime_dependency "kramdown", "~> 2.3"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "cork", "~> 0.1"
-  spec.add_runtime_dependency "faraday", ">= 2.0", "~> 2.0"
+  spec.add_runtime_dependency "faraday", "< 2.0", "~> 2.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
   spec.add_runtime_dependency "git", "~> 1.7"
   spec.add_runtime_dependency "kramdown", "~> 2.3"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "cork", "~> 0.1"
-  spec.add_runtime_dependency "faraday", ">= 0.9.0", "~> 2.0"
+  spec.add_runtime_dependency "faraday", ">= 0.9.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
   spec.add_runtime_dependency "git", "~> 1.7"
   spec.add_runtime_dependency "kramdown", "~> 2.3"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "cork", "~> 0.1"
-  spec.add_runtime_dependency "faraday", ">= 0.9.0"
+  spec.add_runtime_dependency "faraday", ">= 0.9.0", "~> 2.0.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
   spec.add_runtime_dependency "git", "~> 1.7"
   spec.add_runtime_dependency "kramdown", "~> 2.3"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "cork", "~> 0.1"
-  spec.add_runtime_dependency "faraday", "~> 2.0.0"
+  spec.add_runtime_dependency "faraday", ">= 2.0", "~> 2.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
   spec.add_runtime_dependency "git", "~> 1.7"
   spec.add_runtime_dependency "kramdown", "~> 2.3"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
   spec.add_runtime_dependency "colored2", "~> 3.1"
   spec.add_runtime_dependency "cork", "~> 0.1"
-  spec.add_runtime_dependency "faraday", "< 2.0", "~> 2.0"
+  spec.add_runtime_dependency "faraday", ">= 0.9.0", "~> 2.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
   spec.add_runtime_dependency "git", "~> 1.7"
   spec.add_runtime_dependency "kramdown", "~> 2.3"


### PR DESCRIPTION
Updating to allow Faraday 2.0.0. 

Locking between versions of ">= 0.9.0", "< 2.0" was causing new projects to have dependency conflicts.

Related: https://github.com/danger/danger/issues/1349