### PR TITLE
Security update: ruby-git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 
-* Update ruby-git gem [@manicmaniac](https://github.com/manicmaniac) [#1419](https://github.com/danger/danger/pull/1419)
+* Update ruby-git gem [@manicmaniac](https://github.com/manicmaniac) - [#1419](https://github.com/danger/danger/pull/1419)
 * Make specs independent from default branch setting in git config [@manicmaniac](https://github.com/manicmaniac) [#1420](https://github.com/danger/danger/pull/1420)
 * Add missing error types to raise_error matcher [@manicmaniac][https://github.com/manicmaniac] [#1421](https://github.com/danger/danger/pull/1421)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 
-
+* Update ruby-git gem [@manicmaniac](https://github.com/manicmaniac) [#1419](https://github.com/danger/danger/pull/1419)
 <!-- Your comment above here -->
 
 ## 9.2.0

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "faraday", ">= 0.9.0", "< 3.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
-  spec.add_runtime_dependency "git", "~> 1.7"
+  spec.add_runtime_dependency "git", "~> 1.13.0"
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "no_proxy_fix"


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2022-47318

> ruby-git versions prior to v1.13.0 allows a remote authenticated attacker to execute an arbitrary ruby code by having a user to load a repository containing a specially crafted filename to the product. This vulnerability is different from CVE-2022-46648.

I think this issue doesn't affect on users in a regular use case.
But for someone who uses Danger and exposes internet-facing API that uses ruby-git, this PR could be helpful.