### PR TITLE
Explicitly specify initial branch to avoid being affected by global git config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 
-
+* Make specs independent from default branch setting in git config [@manicmaniac](https://github.com/manicmaniac) [#1420](https://github.com/danger/danger/pull/1420)
 <!-- Your comment above here -->
 
 ## 9.2.0

--- a/spec/lib/danger/ci_sources/local_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_git_repo_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Danger::LocalGitRepo do
   def run_in_repo(merge_pr: true, squash_and_merge_pr: false)
     Dir.mktmpdir do |dir|
       Dir.chdir dir do
-        `git init`
+        `git init -b master`
         `git remote add origin https://github.com/danger/danger.git`
         File.open(dir + "/file1", "w") {}
         `git add .`

--- a/spec/lib/danger/ci_sources/local_only_git_repo_spec.rb
+++ b/spec/lib/danger/ci_sources/local_only_git_repo_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Danger::LocalOnlyGitRepo do
   def run_in_repo
     Dir.mktmpdir do |dir|
       Dir.chdir dir do
-        `git init`
+        `git init -b master`
         `git remote add origin .`
         File.open(dir + "/file1", "w") {}
         `git add .`

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
   def git_repo_with_danger_branches_setup
     Dir.mktmpdir do |dir|
       Dir.chdir dir do
-        `git init`
+        `git init -b master`
         `git remote add origin git@github.com:devdanger/devdanger.git`
         `touch README.md`
         `git add .`

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Danger::Executor, use: :ci_helper do
         `echo "# SwiftWeekly" >> README.md`
         `mkdir _drafts _posts`
         FileUtils.cp "#{project_root}/spec/fixtures/github/Dangerfile", dir
-        `git init`
+        `git init -b master`
         `git add .`
         `git commit -m "first commit"`
         `git remote add origin git@github.com:SwiftWeekly/swiftweekly.github.io.git`

--- a/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
+++ b/spec/lib/danger/danger_core/plugins/dangerfile_git_plugin_spec.rb
@@ -3,7 +3,7 @@ require "ostruct"
 def run_in_repo_with_diff
   Dir.mktmpdir do |dir|
     Dir.chdir dir do
-      `git init`
+      `git init -b master`
       File.open(dir + "/file1", "w") { |f| f.write "More buritto please." }
       File.open(dir + "/file2", "w") { |f| f.write "Shorts.\nShoes." }
       `git add .`

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Danger::GitRepo, host: :github do
     it "handles file deletions as expected" do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
-          `git init`
+          `git init -b master`
           `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`
@@ -118,7 +118,7 @@ RSpec.describe Danger::GitRepo, host: :github do
     it "handles modified as expected" do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
-          `git init`
+          `git init -b master`
           `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`
@@ -142,7 +142,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         Dir.chdir dir do
           subfolder = "subfolder"
 
-          `git init`
+          `git init -b master`
           `git config diff.renames true`
           `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
@@ -168,7 +168,7 @@ RSpec.describe Danger::GitRepo, host: :github do
     it "handles code insertions as expected" do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
-          `git init`
+          `git init -b master`
           `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("hi\n\nfb\nasdasd") }
           `git add .`
@@ -190,7 +190,7 @@ RSpec.describe Danger::GitRepo, host: :github do
     it "handles code deletions as expected" do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
-          `git init`
+          `git init -b master`
           `git remote add origin git@github.com:danger/danger.git`
           File.open(dir + "/file", "w") { |file| file.write("1\n2\n3\n4\n5\n") }
           `git add .`
@@ -226,7 +226,7 @@ RSpec.describe Danger::GitRepo, host: :github do
     it "returns array of hashes with names before and after" do
       Dir.mktmpdir do |dir|
         Dir.chdir dir do
-          `git init`
+          `git init -b master`
           `git remote add origin git@github.com:danger/danger.git`
 
           Dir.mkdir(File.join(dir, "first"))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,7 +111,7 @@ end
 def with_git_repo(origin: "git@github.com:artsy/eigen")
   Dir.mktmpdir do |dir|
     Dir.chdir dir do
-      `git init`
+      `git init -b master`
       File.open(dir + "/file1", "w") {}
       `git add .`
       `git commit -m "ok"`


### PR DESCRIPTION
## Problem

Some specs always fail if `init.defaultBranch` is not `master` in `~/.gitconfig`.

## Cause

Those spec call `git init` and it determines the initial branch name by global git config since [git 2.28](https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch).

## Solution

I replaced every `git init` with `git init -b master` to set the initial branch.


<!--
///////////////////⚡///////////////////

# 🚫 AWESOME A PR!

- You can just delete all of this and start your PR text anytime -

Hello there, just a quick pre-warning of some of the Danger rules we run on Danger PRs.

The big one is we request that every code change to Danger include a CHANGELOG entry, 
this is so that:

1. People know what changes are between versions
2. Orta doesn't get all the credit for other people's work

Danger will look for a modification to the `CHANGELOG.md` when there are changes including
`lib/*` - if you're fixing unreleased code, or doing a simple typo change, you can
include `#trivial` in the title or the body of the PR and this is skipped.

We also request that you fill in the body of your PR, a title should be tweet length, but
ideally you can explain the PRs reasoning in the body. We look that it's longer than 5 chars.

Other than that, a lot of the other Danger rules are trickier to trigger so we can address
them as they come up!

❤ THANKS FOR HELPING OUT :D 

///////////////////⚡///////////////////
-->