### PR TITLE
Add missing error types to raise_error matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## master
 
-
+* Add missing error types to raise_error matcher [@manicmaniac][https://github.com/manicmaniac] [#1421](https://github.com/danger/danger/pull/1421)
 <!-- Your comment above here -->
 
 ## 9.2.0

--- a/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
+++ b/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb
@@ -101,17 +101,17 @@ RSpec.describe Danger::RequestSources::BitbucketCloudAPI, host: :bitbucket_cloud
   describe "#credentials_given" do
     it "#fetch_json raise error when missing credentials" do
       empty_env = {}
-      expect { api.pull_request }.to raise_error
+      expect { api.pull_request }.to raise_error WebMock::NetConnectNotAllowedError
     end
 
     it "#post raise error when missing credentials" do
       empty_env = {}
-      expect { api.post("http://post-url.org", {}) }.to raise_error
+      expect { api.post("http://post-url.org", {}) }.to raise_error NoMethodError
     end
 
     it "#delete raise error when missing credentials" do
       empty_env = {}
-      expect { api.delete("http://delete-url.org") }.to raise_error
+      expect { api.delete("http://delete-url.org") }.to raise_error NoMethodError
     end
   end
 


### PR DESCRIPTION
Resolve the following warning on `bundle exec rspec spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb`.


```
WARNING: Using the `raise_error` matcher without providing a specific error or
message risks false positives, since `raise_error` will match when Ruby raises a
`NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the
expectation to pass without even executing the method you are intending to call.
Actual error raised was #<WebMock::NetConnectNotAllowedError: Real HTTP
connections are disabled. Unregistered request: GET h... => 200, :body => "",
:headers => {})

============================================================>. Instead consider
providing a specific error class or message. This message can be suppressed by
setting: `RSpec::Expectations.configuration.on_potential_false_positives =
:nothing`. Called from
/Users/rito/Projects/danger/danger/spec/lib/danger/request_sources/bitbucket_cloud_api_spec.rb:104:in
`block (3 levels) in <top (required)>'.
```