### PR TITLE
Do not force verbose in `danger local` and `danger pr`

### DIFF
--- a/lib/danger/commands/local_helpers/local_setup.rb
+++ b/lib/danger/commands/local_helpers/local_setup.rb
@@ -28,10 +28,7 @@ module Danger
         cork.puts "Running your Dangerfile against this PR - https://#{gh.host}/#{source.repo_slug}/pull/#{source.pull_request_id}"
       end
 
-      unless verbose
-        cork.puts "Turning on --verbose"
-        dm.verbose = true
-      end
+      dm.verbose = verbose
 
       cork.puts
 

--- a/spec/lib/danger/commands/local_helpers/local_setup_spec.rb
+++ b/spec/lib/danger/commands/local_helpers/local_setup_spec.rb
@@ -28,7 +28,18 @@ RSpec.describe Danger::LocalSetup do
       expect(ui.string).not_to include("evaluated")
     end
 
-    it "turns on verbose if arguments wasn't passed" do
+    it "turns on verbose if arguments was passed" do
+      github = double(:host => "", :support_tokenless_auth= => nil, :fetch_details => nil)
+      env = FakeEnv.new(ci_source, github)
+      dangerfile = FakeDangerfile.new(env, false)
+      ui = testing_ui
+      subject = described_class.new(dangerfile, ui)
+
+      subject.setup(verbose: true) {}
+      expect(dangerfile.verbose).to be(true)
+    end
+
+    it "turns off verbose if arguments wasn't passed" do
       github = double(:host => "", :support_tokenless_auth= => nil, :fetch_details => nil)
       env = FakeEnv.new(ci_source, github)
       dangerfile = FakeDangerfile.new(env, false)
@@ -36,7 +47,7 @@ RSpec.describe Danger::LocalSetup do
       subject = described_class.new(dangerfile, ui)
 
       subject.setup(verbose: false) {}
-      expect(ui.string).to include("Turning on --verbose")
+      expect(dangerfile.verbose).to be(false)
     end
 
     it "does not evaluate Dangerfile if local repo wasn't found on github" do


### PR DESCRIPTION
Close https://github.com/danger/danger/issues/1405

- Prevent `danger pr` and `danger local` from enforcing verbose flags
- Explicitly passing `--verbose` like `danger pr --verbose` prints verbose output