### PR TITLE
Post comment to Bitbucket Cloud only if there is any content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Make specs independent from default branch setting in git config [@manicmaniac](https://github.com/manicmaniac) [#1420](https://github.com/danger/danger/pull/1420)
 * Add missing error types to raise_error matcher [@manicmaniac][https://github.com/manicmaniac] [#1421](https://github.com/danger/danger/pull/1421)
 * Add /github/workspace to git safe.directory [@hiro-flank](https://github.com/hiro-flank) [#1427](https://github.com/danger/danger/pull/1427)
+* Fixes issue where a comment is posted to Bitbucket Cloud even when everything is green. [@SalvatoreT](https://github.com/SalvatoreT) [#1299](https://github.com/danger/danger/issues/1299)
 
 <!-- Your comment above here -->
 

--- a/lib/danger/request_sources/bitbucket_cloud.rb
+++ b/lib/danger/request_sources/bitbucket_cloud.rb
@@ -78,15 +78,20 @@ module Danger
         messages = update_inline_comments_for_kind!(:messages, messages, danger_id: danger_id)
         markdowns = update_inline_comments_for_kind!(:markdowns, markdowns, danger_id: danger_id)
 
-        comment += generate_comment(warnings: warnings,
-                                    errors: errors,
-                                    messages: messages,
-                                    markdowns: markdowns,
-                                    previous_violations: {},
-                                    danger_id: danger_id,
-                                    template: "bitbucket_server")
-
-        @api.post_comment(comment)
+        has_comments = (warnings.count > 0 || errors.count > 0 || messages.count > 0 || markdowns.count > 0)
+        if has_comments
+          comment = generate_description(warnings: warnings,
+                                         errors: errors)
+          comment += "\n\n"
+          comment += generate_comment(warnings: warnings,
+                                      errors: errors,
+                                      messages: messages,
+                                      markdowns: markdowns,
+                                      previous_violations: {},
+                                      danger_id: danger_id,
+                                      template: "bitbucket_server")
+          @api.post_comment(comment)
+        end
       end
 
       def update_pr_by_line!(message_groups:,


### PR DESCRIPTION
This feature has already been implemented on Bitbucket Server, but it's missing on Bitbucket Cloud.

Bitbucket Server PR: https://github.com/danger/danger/pull/1331
Original issue: https://github.com/danger/danger/issues/1299