### PR TITLE
Remove redundant github `danger/` prefix

### DIFF
--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -219,7 +219,7 @@ module Danger
         begin
           client.create_status(ci_source.repo_slug, latest_pr_commit_ref, status, {
             description: message,
-            context: "danger/#{danger_id}",
+            context: danger_id,
             target_url: details_url
           })
         rescue StandardError

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "uses danger_id as context of status" do
-        options = hash_including(context: "danger/special_context")
+        options = hash_including(context: "special_context")
         expect(@g.client).to receive(:create_status).with(any_args, options).and_return({})
 
         @g.pr_json = { "head" => { "sha" => "pr_commit_ref" } }


### PR DESCRIPTION
Close: #1431

Technically all CI checks on GH from Danger having prefix `danger/` what actually very inflexible if we can have an option to use `danger_id` CLI argument

---
By default check result is `danger/danger` what actually looks pretty strange. Probably just a `danger`  will be enough as a default configuration.

---
Without prefix CI check will be more flexible for some specific cases:
For example we having a monorepo with PlatformA and PlatformB. Both of them is independent and we having **required** checks:
PlatformA/check1
PlatformA/check2
PlatformA/danger

PlatformB/check1
PlatformB/check2
PlatformB/danger

Then we can create a some short circuiting bases on platform name kind of "If directory with PlarformA have no changes then set all checks PlatformA/* as Skipped"`

---

Or even if it required it can be declared `--danger_id="danger/danger"`


---

However those changes will break backward compatibility if previous danger check are required. And project maintainers should update required check name in this case.

What will be the best option in this case? IMO having 2 variables for declaring prefix and postfix is redundant and having only one looks straight forward for me
