### PR TITLE
Add Ruby 3.2 to test matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add missing error types to raise_error matcher [@manicmaniac][https://github.com/manicmaniac] [#1421](https://github.com/danger/danger/pull/1421)
 * Add /github/workspace to git safe.directory [@hiro-flank](https://github.com/hiro-flank) [#1427](https://github.com/danger/danger/pull/1427)
 * Fixes issue where a comment is posted to Bitbucket Cloud even when everything is green. [@SalvatoreT](https://github.com/SalvatoreT) [#1299](https://github.com/danger/danger/issues/1299)
+* Add Ruby 3.2 to test matrix [@mataku](https://github.com/mataku) [#1434](https://github.com/danger/danger/pull/1434)
 
 <!-- Your comment above here -->
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "rspec", "~> 3.9"
 gem "rspec_junit_formatter", "~> 0.4"
 gem "rubocop"
 gem "simplecov", "~> 0.18"
-gem "webmock", "~> 2.1"
+gem "webmock", "~> 3.16.2"
 gem "yard", "~> 0.9.11"
 
 if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.5.0")


### PR DESCRIPTION
## Description

add Ruby 3.2 to GitHub Actions test matrix and fix failed specs to ensure that Danger works with Ruby 3.2 on CI

it seems https://github.com/danger/danger/pull/1411 has been reverted, this is a restore of it

## Changes

On Ruby 3.2, some tests using WebMock fail like the one below.

<details>
<summary> Result of a test case using WebMock </summary>

```ruby
$ bundle rspec spec/lib/danger/request_sources/gitlab_spec.rb:147
Run options: include {:locations=>{"./spec/lib/danger/request_sources/gitlab_spec.rb"=>[147]}}

Randomized with seed 60974

Danger::RequestSources::GitLab
  valid server response
    set its mr_json (FAILED - 1)

Failures:

  1) Danger::RequestSources::GitLab valid server response set its mr_json
     Failure/Error: WebMock.stub_request(:get, url).with(headers: expected_headers).to_return(raw_file)

     TypeError:
       no implicit conversion from nil to integer
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.5.0/lib/webmock/response.rb:124:in `read_raw_response'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.5.0/lib/webmock/response.rb:18:in `initialize'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.5.0/lib/webmock/response.rb:10:in `new'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.5.0/lib/webmock/response.rb:10:in `response_for'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.5.0/lib/webmock/request_stub.rb:21:in `block in to_return'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.5.0/lib/webmock/request_stub.rb:21:in `map'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.5.0/lib/webmock/request_stub.rb:21:in `to_return'
     # ./spec/support/gitlab_helper.rb:50:in `stub_merge_request'
     # ./spec/lib/danger/request_sources/gitlab_spec.rb:109:in `block (3 levels) in <top (required)>'

Finished in 0.01012 seconds (files took 0.32573 seconds to load)
1 example, 1 failure
```

</details>

it seems net-protocol (v0.2.1) bundled gem in Ruby 3.2 and the version of WebMock currently used in Danger seem to be incompatible. Ruby 3.1.1 uses net-protocol 0.1.2, so you will see that tests pass if fix net-protocol to v1.0.0. 

However, changing the version of the bundled gem is a bit hard to manage, so update WebMock so that the test passes