### PR TITLE
Fix dependency constraint on ruby-git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ## master
 
 * Update Octokit dependency to version 6.0 - [@spencertransier](https://github.com/spencertransier) [#1437](https://github.com/danger/danger/pull/1437)
+<!-- Your comment above here -->
+* Fixes dependency constraint issue on `ruby-git` - [@ainame](https://github.com/ainame) [#1436](https://github.com/danger/danger/pull/1436)
 
 ## 9.3.0
 

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "faraday", ">= 0.9.0", "< 3.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
-  spec.add_runtime_dependency "git", "~> 1.13.0"
+  spec.add_runtime_dependency "git", "~> 1.13"
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "no_proxy_fix"

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -179,8 +179,8 @@ module Danger
     end
 
     # Compare given paths as realpath. Return true if both are same.
-    # In rspec, given path can be a temporary directory's path and in macOS `/var` directory is
-    # a symbolic link to `/private/var`.
+    # `git rev-parse --show-toplevel` returns a path resolving symlink. In rspec, given path can
+    # be a temporary directory's path created under a symlinked directory `/var`.
     def compare_path(path1, path2)
       Pathname.new(path1).realdirpath == Pathname.new(path2).realdirpath
     end

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe Danger::GitRepo, host: :github do
     it "looks up the top level git folder when requested" do
       with_git_repo do |dir|
         @dm = testing_dangerfile
-        @dm.env.scm.diff_for_folder(dir + "/subdir", lookup_top_level: true)
+        expect do
+          @dm.env.scm.diff_for_folder(dir + "/subdir", lookup_top_level: true)
+        end.not_to raise_error
       end
     end
   end

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Danger::GitRepo, host: :github do
         @dm = testing_dangerfile
         expect do
           @dm.env.scm.diff_for_folder(dir + "/subdir")
-        end.to raise_error(ArgumentError, /path does not exist/)
+        end.to raise_error(ArgumentError, /is not the top level git directory/)
       end
     end
 


### PR DESCRIPTION
In this PR https://github.com/danger/danger/pull/1419, the gemspec for runtime dependency on `git` was bumped to `~> 1.13.0`. 

When updating Danger to 9.3.0 today, I noticed the dependency-resolving issue. In my project, bundler has already fixed `git` at version `1.18.0`, so installing danger v9.3.0 means we need to downgrade `git`. Bundler didn't allows me to do that by default. (I needed to delete Gemfile.lock and re-run bundle install) 

<details>

This is what we got when updating `danger` via Renovate.

```
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies............

Bundler could not find compatible versions for gem "git":
  In snapshot (Gemfile.lock):
    git (>= 1.17.2)

  In Gemfile:
    danger (= 9.3.0) was resolved to 9.3.0, which depends on
      git (~> 1.13.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.

Bundler could not find compatible versions for gem "highline":
  In snapshot (Gemfile.lock):
    highline (>= 2.0.3)

  In Gemfile:
    fastlane (= 2.212.2) was resolved to 2.212.2, which depends on
      highline (~> 2.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.

Bundler could not find compatible versions for gem "multipart-post":
  In snapshot (Gemfile.lock):
    multipart-post (>= 2.0.0)

  In Gemfile:
    fastlane (= 2.212.2) was resolved to 2.212.2, which depends on
      faraday (~> 1.0) was resolved to 1.10.3, which depends on
        faraday-multipart (~> 1.0) was resolved to 1.0.4, which depends on
          multipart-post (~> 2)

    fastlane (= 2.212.2) was resolved to 2.212.2, which depends on
      multipart-post (~> 2.0.0)

    xcov (= 1.8.1) was resolved to 1.8.1, which depends on
      multipart-post

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.

```

</details>

The previous constraint of being flexible on the minor versions is easier for anyone who has been using Danger.

According to the PR author, there was no reason to limit the version constraint to the patch version.
https://github.com/danger/danger/pull/1419#issuecomment-1519406302


cc: @manicmaniac 