### PR TITLE
Update `octokit` to `6.0`

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "no_proxy_fix"
-  spec.add_runtime_dependency "octokit", "~> 5.0"
+  spec.add_runtime_dependency "octokit", "~> 6.0"
   spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
 end

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "no_proxy_fix"
-  spec.add_runtime_dependency "octokit", "~> 6.0"
+  spec.add_runtime_dependency "octokit", "~> 5.0"
   spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
 end


### PR DESCRIPTION
This PR updates the `octokit` dependency from `~> 5.0` to `~> 6.0`. The latest version of `octokit` is [`6.1.1`](https://github.com/octokit/octokit.rb/releases/tag/v6.1.1). This change allows projects that use `danger` to keep up-to-date with the latest `octokit` changes. 

This is technically a breaking change because it's jumping from `5.x` to `6.x`. The `octokit` `6.0.0` release states: 

> We're releasing v6.0.0 because https://github.com/octokit/octokit.rb/pull/1494 and https://github.com/octokit/octokit.rb/pull/1495 are technically breaking changes although the APIs that underlie this functionalilty have been not operational for some time.

I ran the `danger` tests locally after upgrading to `6.1.1` and they all passed successfully. 

I also searched the `danger` codebase for any uses of the `Octokit::Client::Authorizations` or `Octokit::Client::Hooks#available_hooks` modules that were removed in `6.0.0` and verified that they aren't being used anywhere. 



