### PR TITLE
Suppress new RuboCop offenses #trivial

### DIFF
--- a/lib/danger/ci_source/azure_pipelines.rb
+++ b/lib/danger/ci_source/azure_pipelines.rb
@@ -29,8 +29,6 @@ module Danger
   # which will automatically get your vsts domain and your project name needed for the vsts api.
   #
   class AzurePipelines < CI
-
-
     def self.validates_as_ci?(env)
       has_all_variables = ["AGENT_ID", "BUILD_SOURCEBRANCH", "BUILD_REPOSITORY_URI", "BUILD_REASON", "BUILD_REPOSITORY_NAME"].all? { |x| env[x] && !env[x].empty? }
 

--- a/lib/danger/ci_source/ci_source.rb
+++ b/lib/danger/ci_source/ci_source.rb
@@ -31,7 +31,7 @@ module Danger
     end
 
     def initialize(_env)
-      raise "Subclass and overwrite initialize"
+      raise "Subclass and overwrite initialize" if method(__method__).owner == Danger::CI
     end
   end
 end

--- a/lib/danger/ci_source/custom_ci_with_github.rb
+++ b/lib/danger/ci_source/custom_ci_with_github.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "danger/request_sources/github/github"
 
 module Danger
@@ -31,6 +33,8 @@ module Danger
     end
 
     def initialize(env)
+      super
+
       self.repo_slug = env["GITHUB_REPOSITORY"]
       pull_request_event = JSON.parse(File.read(env["GITHUB_EVENT_PATH"]))
       self.pull_request_id = pull_request_event["number"]

--- a/lib/danger/ci_source/support/pull_request_finder.rb
+++ b/lib/danger/ci_source/support/pull_request_finder.rb
@@ -146,7 +146,7 @@ module Danger
         require "danger/request_sources/bitbucket_server_api"
         project, slug = repo_slug.split("/")
         RequestSources::BitbucketServerAPI.new(project, slug, specific_pull_request_id, env)
-      
+
       when :vsts
         require "danger/request_sources/vsts_api"
         RequestSources::VSTSAPI.new(repo_slug, specific_pull_request_id, env)
@@ -181,7 +181,7 @@ module Danger
       elsif remote_url =~ %r{/pull-requests/}
         :bitbucket_server
       elsif remote_url =~ /\.visualstudio\.com/i || remote_url =~ /dev\.azure\.com/i
-        :vsts 
+        :vsts
       else
         :github
       end

--- a/lib/danger/request_sources/bitbucket_cloud.rb
+++ b/lib/danger/request_sources/bitbucket_cloud.rb
@@ -70,18 +70,14 @@ module Danger
       def update_pull_request!(warnings: [], errors: [], messages: [], markdowns: [], danger_id: "danger", new_comment: false, remove_previous_comments: false)
         delete_old_comments(danger_id: danger_id) if !new_comment || remove_previous_comments
 
-        comment = generate_description(warnings: warnings, errors: errors, template: "bitbucket_server")
-        comment += "\n\n"
-
         warnings = update_inline_comments_for_kind!(:warnings, warnings, danger_id: danger_id)
         errors = update_inline_comments_for_kind!(:errors, errors, danger_id: danger_id)
         messages = update_inline_comments_for_kind!(:messages, messages, danger_id: danger_id)
         markdowns = update_inline_comments_for_kind!(:markdowns, markdowns, danger_id: danger_id)
 
-        has_comments = (warnings.count > 0 || errors.count > 0 || messages.count > 0 || markdowns.count > 0)
+        has_comments = (warnings.count.positive? || errors.count.positive? || messages.count.positive? || markdowns.count.positive?)
         if has_comments
-          comment = generate_description(warnings: warnings,
-                                         errors: errors)
+          comment = generate_description(warnings: warnings, errors: errors, template: "bitbucket_server")
           comment += "\n\n"
           comment += generate_comment(warnings: warnings,
                                       errors: errors,

--- a/spec/lib/danger/ci_sources/custom_ci_with_github_spec.rb
+++ b/spec/lib/danger/ci_sources/custom_ci_with_github_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "danger/ci_source/custom_ci_with_github"
 
 RSpec.describe Danger::CustomCIWithGithub do


### PR DESCRIPTION
This PR suppresses the following new RuboCop offenses:

```console
% bundle exec rubocop
(snip)

Offenses:

lib/danger/ci_source/azure_pipelines.rb:32:1: C: [Correctable] Layout/EmptyLinesAroundClassBody: Extra empty line detected at class body beginning.
lib/danger/ci_source/azure_pipelines.rb:33:1: C: [Correctable] Layout/EmptyLines: Extra blank line detected.
lib/danger/ci_source/custom_ci_with_github.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
require "danger/request_sources/github/github"
^
lib/danger/ci_source/custom_ci_with_github.rb:33:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(env) ...
    ^^^^^^^^^^^^^^^^^^^
lib/danger/ci_source/support/pull_request_finder.rb:149:1: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/danger/ci_source/support/pull_request_finder.rb:184:14: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
        :vsts
             ^
lib/danger/request_sources/bitbucket_cloud.rb:74:9: W: [Correctable] Lint/UselessAssignment: Useless assignment to variable - comment.
        comment += "\n\n"
        ^^^^^^^
lib/danger/request_sources/bitbucket_cloud.rb:81:25: C: [Correctable] Style/NumericPredicate: Use warnings.count.positive? instead of warnings.count > 0.
        has_comments = (warnings.count > 0 || errors.count > 0 || messages.count > 0 || markdowns.count > 0)
                        ^^^^^^^^^^^^^^^^^^
lib/danger/request_sources/bitbucket_cloud.rb:81:47: C: [Correctable] Style/NumericPredicate: Use errors.count.positive? instead of errors.count > 0.
        has_comments = (warnings.count > 0 || errors.count > 0 || messages.count > 0 || markdowns.count > 0)
                                              ^^^^^^^^^^^^^^^^
lib/danger/request_sources/bitbucket_cloud.rb:81:67: C: [Correctable] Style/NumericPredicate: Use messages.count.positive? instead of messages.count > 0.
        has_comments = (warnings.count > 0 || errors.count > 0 || messages.count > 0 || markdowns.count > 0)
                                                                  ^^^^^^^^^^^^^^^^^^
lib/danger/request_sources/bitbucket_cloud.rb:81:89: C: [Correctable] Style/NumericPredicate: Use markdowns.count.positive? instead of markdowns.count > 0.
        has_comments = (warnings.count > 0 || errors.count > 0 || messages.count > 0 || markdowns.count > 0)
                                                                                        ^^^^^^^^^^^^^^^^^^^
spec/lib/danger/ci_sources/custom_ci_with_github_spec.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
require "danger/ci_source/custom_ci_with_github"
^

219 files inspected, 12 offenses detected, 11 offenses autocorrectable
```
