### PR TITLE
Update README badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
+* Update README badges - [@manicmaniac](https://github.com/manicmaniac) [#1442](https://github.com/danger/danger/pull/1442)
 
 <!-- Your comment above here -->
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![License](http://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/orta/danger/blob/master/LICENSE)
 [![Gem](https://img.shields.io/gem/v/danger.svg?style=flat)](http://rubygems.org/gems/danger)
 [![CI](https://github.com/danger/danger/actions/workflows/CI.yml/badge.svg)](https://github.com/danger/danger/actions/workflows/CI.yml)
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/danger)
 
 Formalize your Pull Request etiquette.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](http://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/orta/danger/blob/master/LICENSE)
 [![Gem](https://img.shields.io/gem/v/danger.svg?style=flat)](http://rubygems.org/gems/danger)
-[![Travis CI](https://img.shields.io/travis/danger/danger.svg?style=flat)](https://travis-ci.org/danger/danger)
+[![CI](https://github.com/danger/danger/actions/workflows/CI.yml/badge.svg)](https://github.com/danger/danger/actions/workflows/CI.yml)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/danger)
 
 Formalize your Pull Request etiquette.


### PR DESCRIPTION
- I substituted GitHub Actions badge for Travis CI, which is no longer used
- I removed link to Spectrum chat because it returns 404