### PR TITLE
Use test-queue for parallel testing #trivial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ junit-results.xml
 # RSpec
 /spec/examples.txt
 
+# test-queue
+.test_queue_stats
+
 # Byebug
 /.byebug_history
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "rspec", "~> 3.9"
 gem "rspec_junit_formatter", "~> 0.4"
 gem "rubocop"
 gem "simplecov", "~> 0.18"
+gem "test-queue"
 gem "webmock", "~> 3.16.2"
 gem "yard", "~> 0.9.11"
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,12 @@ task default: %w(rubocop spec)
 
 desc "Danger's tests"
 task :spec do
-  Rake::Task["specs"].invoke
+  if Process.respond_to?(:fork)
+    sh("rspec-queue")
+  else
+    sh("rspec")
+  end
+
   Rake::Task["spec_docs"].invoke
 end
 


### PR DESCRIPTION
This PR makes developer tests parallel using test-queue: https://github.com/tmm1/test-queue

## Before (serial testing)

Around 20 seconds:

```console
$ bundle exec rake spec
(snip)

Finished in 19.61 seconds (files took 0.8812 seconds to load)
1006 examples, 0 failures, 2 pending
```

## After (parallel testing / e.g. 8 CPUs with hyper threading)

Around 6 seconds:

```console
Starting test-queue master (/tmp/test_queue_92019_4740.sock)

==> Summary (16 workers in 5.9512s)

    [ 1]                                     128 examples, 0 failures        15 suites in 1.6613s      (pid 92022 exit 0 )
    [ 2]                                      74 examples, 0 failures         5 suites in 3.8227s      (pid 92023 exit 0 )
    [ 3]                                      33 examples, 0 failures         2 suites in 3.8232s      (pid 92024 exit 0 )
    [ 4]                                     113 examples, 0 failures         6 suites in 3.8233s      (pid 92025 exit 0 )
    [ 5]                                      87 examples, 0 failures         4 suites in 3.8237s      (pid 92026 exit 0 )
    [ 6]                                      51 examples, 0 failures         7 suites in 3.8364s      (pid 92027 exit 0 )
    [ 7]                                      63 examples, 0 failures         5 suites in 5.9421s      (pid 92028 exit 0 )
    [ 8]                          124 examples, 0 failures, 2 pending         8 suites in 5.9423s      (pid 92029 exit 0 )
    [ 9]                                      56 examples, 0 failures        12 suites in 5.9423s      (pid 92030 exit 0 )
    [10]                                     125 examples, 0 failures         5 suites in 5.9422s      (pid 92031 exit 0 )
    [11]                                      17 examples, 0 failures         1 suites in 5.9421s      (pid 92032 exit 0 )
    [12]                                     145 examples, 0 failures         7 suites in 5.9418s      (pid 92033 exit 0 )
    [13]                                      76 examples, 0 failures         2 suites in 5.9416s      (pid 92034 exit 0 )
    [14]                                      45 examples, 0 failures         5 suites in 5.9414s      (pid 92035 exit 0 )
    [15]                                      60 examples, 0 failures         4 suites in 5.9411s      (pid 92036 exit 0 )
    [16]                                      43 examples, 0 failures         3 suites in 5.9389s      (pid 92037 exit 0 )
```

It can be up to 3x faster depending on the environment.
