### PR TITLE
Release to GitHub Container Registry

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -1,0 +1,46 @@
+name: Release Danger package
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
+* Release to GitHub Container Registry - [@unlobito](https://github.com/unlobito) [#1445](https://github.com/danger/danger/pull/1445)
 * Update README badges - [@manicmaniac](https://github.com/manicmaniac) [#1442](https://github.com/danger/danger/pull/1442)
 
 <!-- Your comment above here -->


### PR DESCRIPTION
[[dangergem.slack.com context](https://dangergem.slack.com/archives/C0BHS23PG/p1688132250783649)]

Fixes https://github.com/danger/danger/issues/1110

This PR adds a workflow similar to [danger/swift](https://github.com/danger/swift/blob/master/.github/workflows/publish_package.yml), [danger/kotlin](https://github.com/danger/kotlin/blob/master/.github/workflows/publish_package.yml), and [danger/danger-js](https://github.com/danger/danger-js/blob/main/.github/workflows/publish_package.yml), but has been updated to make use of new `github` context variables for easier setup (see https://github.com/docker/build-push-action#usage + https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages). If this PR is accepted, I'd be happy to port these changes to the aforementioned repos.

It will publish an image on `ghcr.io/danger/danger` on each new tag (e.g., `ghcr.io/danger/danger:v9.3.1` for latest) and on new pushes to the default branch (at `ghcr.io/danger/danger:master`).