### PR TITLE
publish_package.yml: don't use buildx

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -19,8 +19,8 @@ jobs:
       packages: write
 
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -41,6 +41,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
#trivial avoiding a new changelog entry- fixes #1145 (https://github.com/danger/danger/pull/1445#issuecomment-1618410875)

related to https://github.com/danger/danger/issues/1110

#1145 seemed to have a bad time uploading the built image's manifest (https://github.com/danger/danger/actions/runs/5436611587/jobs/9886592800#step:5:686), causing the resulting image to be untagged + lack metadata (https://github.com/danger/danger/pkgs/container/danger/106254064)

I think this is because I'd tried using Docker's buildx to avoid calling `actions/checkout`, but not using buildx allows us to directly pass in the tags + labels as outputs from another runstep.

I've validated these changes in a fork of the repo and it appears to correctly upload (https://github.com/unlobito/danger/pkgs/container/danger/106818152?tag=master / https://github.com/unlobito/danger/actions/runs/5456592469/jobs/9929608665), so this should work on the Danger org (unless there's some permissions flag I'm missing)