### PR TITLE
Drop no_proxy_fix gem

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "git", "~> 1.13"
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
-  spec.add_runtime_dependency "no_proxy_fix"
   spec.add_runtime_dependency "octokit", ">= 4.0"
   spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
 end

--- a/lib/danger/commands/pr.rb
+++ b/lib/danger/commands/pr.rb
@@ -4,7 +4,6 @@ require "faraday/http_cache"
 require "fileutils"
 require "octokit"
 require "tmpdir"
-require "no_proxy_fix"
 
 module Danger
   class PR < Runner


### PR DESCRIPTION
This gem was only needed to fix [a bug in Ruby 2.4](https://github.com/ruby/ruby/pull/1513), but since the required Ruby version of this gem is 2.7.0 we do not need this patch.
