### PR TITLE
No need to install gitlab for less than Ruby 2.5.0 #trivial

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,3 @@ gem "simplecov", "~> 0.18"
 gem "test-queue"
 gem "webmock", "~> 3.16.2"
 gem "yard", "~> 0.9.11"
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.5.0")
-  gem "gitlab", "< 4.14.1"
-end


### PR DESCRIPTION
The current required_ruby_version is specified as ">= 2.7.0", so there is no need to consider Ruby version "< 2.7.0".

It seems that the minimum Ruby version was changed to 2.5 in gitlab gem 4.14.1, so special handling was required.