### PR TITLE
fix: always use `LocalOnlyGitRepo` source with `dry_run` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
+* Always use `LocalOnlyGitRepo` source with `dry_run` command - [@imaginaris](https://github.com/imaginaris) [#1452](https://github.com/danger/danger/pull/1452)
 <!-- Your comment above here -->
 
 ## 9.4.3

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -7,6 +7,8 @@ module Danger
 
     # Finds a Danger::CI class based on the ENV
     def self.local_ci_source(env)
+      return Danger::LocalOnlyGitRepo if LocalOnlyGitRepo.validates_as_ci? env
+
       CI.available_ci_sources.find { |ci| ci.validates_as_ci? env }
     end
 

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -115,6 +115,23 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
         expect(Danger::EnvironmentManager.local_ci_source(system_env)).to eq nil
       end
     end
+
+    context "when Local Only Git Repo is valid" do
+      it "loads Local Only Git Repo" do
+        with_localonlygitrepo_setup do |system_env|
+          expect(described_class.local_ci_source(system_env)).to eq Danger::LocalOnlyGitRepo
+        end
+      end
+
+      it "loads Local Only Git Repo ignoring other valid sources" do
+        with_bitrise_setup_and_is_a_pull_request do |system_env_bitrise|
+          with_localonlygitrepo_setup do |system_env_local_only|
+            system_env = system_env_bitrise.merge(system_env_local_only)
+            expect(described_class.local_ci_source(system_env)).to eq Danger::LocalOnlyGitRepo
+          end
+        end
+      end
+    end
   end
 
   describe ".pr?" do

--- a/spec/support/ci_helper.rb
+++ b/spec/support/ci_helper.rb
@@ -145,6 +145,14 @@ module Danger
         yield(system_env)
       end
 
+      def with_localonlygitrepo_setup
+        system_env = {
+          "DANGER_USE_LOCAL_ONLY_GIT" => "true"
+        }
+
+        yield(system_env)
+      end
+
       def with_screwdriver_setup_and_is_a_pull_request
         system_env = {
           "SCREWDRIVER" => "true",


### PR DESCRIPTION
This PR should fix an issue that happens in my project.

We are running `danger dry_run` on master branch (no PR) on Bitrise CI machines.
After upgrading ruby version from 2.7.6 to 3.1.4 we started to get following error:
`/Users/vagrant/.asdf/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/danger-9.3.1/lib/danger/request_sources/bitbucket_cloud_api.rb:125:in `fetch_json': Credentials not available. Provide DANGER_BITBUCKETCLOUD_USERNAME, DANGER_BITBUCKETCLOUD_UUID, and DANGER_BITBUCKETCLOUD_PASSWORD as environment variables. (RuntimeError)`

Even though we use Github.com repos and the same Danger version (9.3.1) as before.

The `CI.available_ci_sources` is a set and `local_ci_source` method in `environment_manager.rb` uses a find function to search for **the first valid source** in that set. A set has undefined order of elements when treated as a list so when there are multiple CI sources valid (in my case Bitrise and LocalOnly), the `local_ci_source` method (theoretically) can return a different value each time.
Returning `Danger::Bitrise` value in my case can't work because there is no PR info in the system env when I'm running `danger dry_run` on no-PR build. (Bitrise class tries to init all RequestSource classes from `supported_request_sources` one by one).

Long story short, when running `danger dry_run` only `LocalOnlyGitRepo` should be used as a CI source.
I did my best in this PR (I'm not a ruby dev 🙂) so any comments are welcome.