### PR TITLE
Add keyword arguments in MessageAggregator.aggregate for Ruby 3.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
+* Add keyword arguments to MessageAggregator.aggregate for Ruby 3.X compatibility - [@dirtyhabits97](https://github.com/dirtyhabits97) [#1466](https://github.com/danger/danger/pull/1466)
 <!-- Your comment above here -->
 
 ## 9.4.1

--- a/lib/danger/danger_core/message_aggregator.rb
+++ b/lib/danger/danger_core/message_aggregator.rb
@@ -5,8 +5,8 @@ require "danger/helpers/message_groups_array_helper"
 
 module Danger
   class MessageAggregator
-    def self.aggregate(*args)
-      new(*args).aggregate
+    def self.aggregate(*args, **kwargs)
+      new(*args, **kwargs).aggregate
     end
 
     def initialize(warnings: [],


### PR DESCRIPTION
This fixes #1465

Context: [Changes to the splat operator's behavior were introduced in Ruby 3](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

It passes the dummy "Replicate Crash" test case mentioned in the issue (not sure if I should add it in this PR as well):
<img width="1071" alt="Screenshot 2023-10-27 at 00 26 25" src="https://github.com/danger/danger/assets/25568998/4af62620-0f1b-4418-9ecf-a541fc8ed543">
