### PR TITLE
Allow octokit 8.x

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "no_proxy_fix"
-  spec.add_runtime_dependency "octokit", ">= 6.0", "< 8.0"
+  spec.add_runtime_dependency "octokit", ">= 6.0", "< 9.0"
   spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
 end


### PR DESCRIPTION
Update gemspec to support octokit 8.x.

https://github.com/octokit/octokit.rb/releases/tag/v8.0.0