### PR TITLE
Don't pin octokit dependency

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "no_proxy_fix"
-  spec.add_runtime_dependency "octokit", ">= 6.0", "< 8.0"
+  spec.add_runtime_dependency "octokit", ">= 6.0"
   spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
 end


### PR DESCRIPTION
We've [agreed](https://github.com/danger/danger/pull/1469#issuecomment-1834074314) that we don't need to pin the upper version limit for octokit.