### PR TITLE
Lower the minimum Octokit version required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
-
+* Reduce the minimum required Octokit version
 <!-- Your comment above here -->
 
 ## 9.4.1

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "no_proxy_fix"
-  spec.add_runtime_dependency "octokit", ">= 6.0"
+  spec.add_runtime_dependency "octokit", ">= 4.0"
   spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
 end


### PR DESCRIPTION
I'm working with Danger on an older project that can't upgrade to Octokit v6 or greater yet but is on v4. Since none of Danger's functionality seems to need things from v6 or greater, we can lower the requirements a bit and hopefully soon I can stop vendoring a local version. :smile:
