### PR TITLE
Update ruby version in Dockerfile to 3.2 #1472

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/danger
     docker:
-      - image: ruby:2.7
+      - image: ruby:3.2
         environment:
           - RAILS_ENV=test
           - RACK_ENV=test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ inherit_mode:
 # Defaults can be found here: https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   Exclude:
     - 'spec/fixtures/**/*'
     - 'lib/danger/plugin_support/plugin_parser.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
     - bundle
 
 rvm:
-  - 2.7.1
+  - 3.2.2
 
 bundler_args: "--without documentation --path bundle"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ruby:3.2
 
 LABEL "com.github.actions.name"="Danger"
 LABEL "com.github.actions.description"="Runs danger in a docker container such as GitHub Actions"


### PR DESCRIPTION
`docker build` fails with the message "bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225." it seems to be caused by bundler@2.5.1 requires ruby@3.0.0

fix #1472 

Or should I lower the bundler version?