### PR TITLE
Delete stale violations when there are no new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 <!-- Your comment below here -->
 * Add keyword arguments to MessageAggregator.aggregate for Ruby 3.X compatibility - [@dirtyhabits97](https://github.com/dirtyhabits97) [#1466](https://github.com/danger/danger/pull/1466)
+* Fix: remove stale violations when there are no new violations to report - [@iangmaia](https://github.com/iangmaia) [#1477](https://github.com/danger/danger/pull/1477)
 <!-- Your comment above here -->
 
 ## 9.4.1

--- a/spec/lib/danger/danger_core/executor_spec.rb
+++ b/spec/lib/danger/danger_core/executor_spec.rb
@@ -262,6 +262,7 @@ RSpec.describe Danger::Executor, use: :ci_helper do
           allow(fake_client).to receive(:pull_request) { swiftweekly_pr_89_as_json(head_sha, base_sha) }
           allow(fake_client).to receive(:get) { swiftweekly_issues_89_as_json }
           allow(fake_client).to receive(:issue_comments) { swiftweekly_issue_89_comments_as_json }
+          allow(fake_client).to receive(:pull_request_comments) { swiftweekly_issue_89_comments_as_json }
           allow(fake_client).to receive(:delete_comment) { true }
           allow(fake_client).to receive(:create_status) { true }
 

--- a/spec/lib/danger/request_sources/github_spec.rb
+++ b/spec/lib/danger/request_sources/github_spec.rb
@@ -298,6 +298,8 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "creates a comment if no danger comments exist" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
         comments = []
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
 
@@ -308,6 +310,8 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "updates the issue if no danger comments exist" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
         comments = [{ "body" => '"generated_by_danger"', "id" => "12" }]
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
 
@@ -318,6 +322,8 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "creates a new comment instead of updating the issue if --new-comment is provided" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
         comments = [{ "body" => '"generated_by_danger"', "id" => "12" }]
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
 
@@ -328,6 +334,8 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "updates the issue if no danger comments exist and a custom danger_id is provided" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
         comments = [{ "body" => '"generated_by_another_danger"', "id" => "12" }]
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
 
@@ -338,6 +346,8 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "deletes existing comments if danger doesnt need to say anything" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
         comments = [{ "body" => '"generated_by_danger"', "id" => "12" }]
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
 
@@ -348,6 +358,8 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "deletes existing comments if danger doesnt need to say anything and a custom danger_id is provided" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
         comments = [{ "body" => '"generated_by_another_danger"', "id" => "12" }]
         allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(comments)
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", "12").and_return({})
@@ -402,6 +414,8 @@ RSpec.describe Danger::RequestSources::GitHub, host: :github do
       end
 
       it "deletes all inline comments if there are no violations at all" do
+        allow(@g.client).to receive(:pull_request_comments).with("artsy/eigen", "800").and_return([])
+
         allow(@g.client).to receive(:delete_comment).with("artsy/eigen", main_issue_id)
         allow(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_1)
         allow(@g.client).to receive(:delete_comment).with("artsy/eigen", inline_issue_id_2)


### PR DESCRIPTION
I've stumbled upon this bug that specially showed when using https://github.com/ashfurrow/danger-rubocop.

Very easy to reproduce:
1. Create a PR with RuboCop violations and `danger-rubocop` configured to report violations inline.
2. **Danger runs** -> Violations are added as PR comments
3. Fix some violations in the code
4. **Danger runs** -> Inline PR comments of the removed violations are correctly gone
5. Fix all violations in the code
6. **Danger runs** -> Inline PR comments of the remaining violations aren't deleted 😞 

I went ahead and tried to see if there was something in the code that could point to a misuse on my side, but it didn't look like it.
After some investigation, I saw that the method `submit_inline_comments` was removing the old violations only when there were new violations to be added, exactly like I was experiencing, so I slightly changed the method to do it when there were no violations as well.
It fixed my bug, but I'm not experienced enough in the codebase to foresee eventual side effects or if there was a better solution for this bug -- please let me know of possible alternatives that being the case.