### PR TITLE
Use PROJECT_ID instead of PROJECT_PATH in Gitlab urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
+* Use PROJECT_ID instead of PROJECT_PATH in Gitlab urls. This fixes a bug where Danger would not work with Gitlab self-hosted instances. - [@simonfelding](https://github.com/simonfelding) [#x](https://github.com/danger/danger/pull/x)
 <!-- Your comment above here -->
 
 ## 9.4.1

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -31,7 +31,7 @@ module Danger
 
     def self.validates_as_pr?(env)
       exists = [
-        "GITLAB_CI", "CI_PROJECT_PATH"
+        "GITLAB_CI", "CI_PROJECT_ID"
       ].all? { |x| env[x] }
 
       exists && determine_pull_or_merge_request_id(env).to_i > 0
@@ -42,7 +42,7 @@ module Danger
       return env["CI_EXTERNAL_PULL_REQUEST_IID"] if env["CI_EXTERNAL_PULL_REQUEST_IID"]
       return 0 unless env["CI_COMMIT_SHA"]
 
-      project_path = env["CI_MERGE_REQUEST_PROJECT_PATH"] || env["CI_PROJECT_PATH"]
+      project_path = env["CI_MERGE_REQUEST_PROJECT_ID"] || env["CI_PROJECT_ID"]
       base_commit = env["CI_COMMIT_SHA"]
       client = RequestSources::GitLab.new(nil, env).client
 
@@ -70,7 +70,7 @@ module Danger
       if env["DANGER_PROJECT_REPO_URL"]
         env["DANGER_PROJECT_REPO_URL"].split("/").last(2).join("/")
       else
-        env["CI_MERGE_REQUEST_PROJECT_PATH"] || env["CI_PROJECT_PATH"]
+        env["CI_MERGE_REQUEST_PROJECT_ID"] || env["CI_PROJECT_ID"]
       end
     end
 


### PR DESCRIPTION
This PR fixes a bug where danger would not work with (some?) self-hosted instances.


Before this patch, I got a 404 from our self-hosted Gitlab CE API. Now it works as expected.

It also fixes issues like https://github.com/danger/danger/issues/968 because the problem is deriving a valid URL for the project. Since PROJECT_ID is unique on a gitlab instance, you can always just use that instead of the PROJECT_PATH.

I tested this and it works. I'm not sure how to run tests in ruby locally, so CI will probably fail.

