### PR TITLE
Fix compatibility issue with Octokit >= 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 <!-- Your comment below here -->
 * Add keyword arguments to MessageAggregator.aggregate for Ruby 3.X compatibility - [@dirtyhabits97](https://github.com/dirtyhabits97) [#1466](https://github.com/danger/danger/pull/1466)
 * Fix: remove stale violations when there are no new violations to report - [@iangmaia](https://github.com/iangmaia) [#1477](https://github.com/danger/danger/pull/1477)
+* Fix compatibility issue with Octokit >= 8 - [@manicmaniac](https://github.com/manicmaniac) [#1479](https://github.com/danger/danger/pull/1479)
 <!-- Your comment above here -->
 
 ## 9.4.1

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -349,8 +349,10 @@ module Danger
 
           if matching_comments.empty?
             begin
+              # Since Octokit v8, the signature of create_pull_request_comment has been changed.
+              # See https://github.com/danger/danger/issues/1475 for detailed information.
               client.create_pull_request_comment(ci_source.repo_slug, ci_source.pull_request_id,
-                                                 body, head_ref, m.file, position)
+                                                 body, head_ref, m.file, (Octokit::MAJOR >= 8 ? m.line : position))
             rescue Octokit::UnprocessableEntity => e
               # Show more detail for UnprocessableEntity error
               message = [e, "body: #{body}", "head_ref: #{head_ref}", "filename: #{m.file}", "position: #{position}"].join("\n")


### PR DESCRIPTION
## Overview

Close https://github.com/danger/danger/issues/1475

Currently Danger cannot post an inline comment when it is installed with Octokit >= 8.
It is because that Octokit has changed the method signature of `create_pull_request_comment()` (https://github.com/octokit/octokit.rb/commit/918af86021bbbe2c3883c934ea45c174c51aced5).

This PR fixes this issue by changing arguments depends on Octokit version.

## Test

I added 2 specs to confirm that Danger changes its behavior depends on Octokit version.

And I also confirmed that this PR fixes the issue in other repository.
https://github.com/manicmaniac/danger-issue-1475/pull/6

## Bug / Known issues

The branch name of this PR is wrong. The change of method signature was introduced in Octokit v8, not v7.

<!--
///////////////////⚡///////////////////

# 🚫 AWESOME A PR!

- You can just delete all of this and start your PR text anytime -

Hello there, just a quick pre-warning of some of the Danger rules we run on Danger PRs.

The big one is we request that every code change to Danger include a CHANGELOG entry, 
this is so that:

1. People know what changes are between versions
2. Orta doesn't get all the credit for other people's work

Danger will look for a modification to the `CHANGELOG.md` when there are changes including
`lib/*` - if you're fixing unreleased code, or doing a simple typo change, you can
include `#trivial` in the title or the body of the PR and this is skipped.

We also request that you fill in the body of your PR, a title should be tweet length, but
ideally you can explain the PRs reasoning in the body. We look that it's longer than 5 chars.

Other than that, a lot of the other Danger rules are trickier to trigger so we can address
them as they come up!

❤ THANKS FOR HELPING OUT :D 

///////////////////⚡///////////////////
-->