### PR TITLE
Update SCM module to handle invalid UTF-8 characters from git output

### DIFF
--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -53,7 +53,7 @@ module Danger
       Dir.chdir(self.folder || ".") do
         git_command = string.split(" ").dup.unshift("git")
         Open3.popen2(default_env, *git_command) do |_stdin, stdout, _wait_thr|
-          stdout.read.rstrip
+          stdout.read.scrub.rstrip
         end
       end
     end


### PR DESCRIPTION
In some cases, it seems that Danger will fail if the output contains a single character out of place, failing with "invalid byte sequence in UTF-8 (Encoding::CompatibilityError)" when running rstrip.