### PR TITLE
Fix `Danger::GitRepo::find_merge_base_with_incremental_fetch` return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 <!-- Your comment below here -->
 * Update ruby version in Dockerfile to 3.2 - [@okatatuki](https://github.com/okatatuki) [#1472](https://github.com/danger/danger/pull/1472) [#1473](https://github.com/danger/danger/pull/1473)
+* Fix: git diff called by methods like `git.modified_files` may fail with error ``[!] Invalid `Dangerfile` file: git ... 'diff' '-p' 'true' '{head}'  2>&1`` - [@nagataaaas](https://github.com/nagataaaas) [#1472](https://github.com/danger/danger/pull/1472)
 <!-- Your comment above here -->
 
 ## 9.5.0

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -144,12 +144,13 @@ module Danger
       return unless from_is_ref || to_is_ref
 
       depth = 0
-      (3..6).any? do |factor|
+      (3..6).each do |factor|
         depth += Math.exp(factor).to_i
 
         git_fetch_branch_to_depth(from, depth) if from_is_ref
         git_fetch_branch_to_depth(to, depth) if to_is_ref
-        possible_merge_base(repo, from, to)
+        merge_base = possible_merge_base(repo, from, to)
+        return merge_base if merge_base
       end
     end
 


### PR DESCRIPTION
Looks like there's a bug.
In the method `Danger::GitRepo::find_merge_base_with_incremental_fetch` which supposed to return string(possible_merge_base), we return boolean(possible_merge_base is found).

This causes an error that passes string `true` or `false` as a branch to git.

```
$ bundle exec danger --verbose --base={base} --head={head} --fail-on-errors=true
  
bundler: failed to load command: danger (repo/vendor/bundle/ruby/3.2.0/bin/danger)
repo/vendor/bundle/ruby/3.2.0/gems/git-1.19.1/lib/git/lib.rb:[12]({job_id}?pr={pr_number}):in `command':  (Danger::DSLError)
[!] Invalid `Dangerfile` file: git '--git-dir=repo/.git' '--work-tree=repo' '-c' 'core.quotePath=true' '-c' 'color.ui=false' 'diff' '-p' 'true' '{head}'  2>&1
status: pid 383 exit 128
output: "fatal: ambiguous argument 'true': unknown revision or path not in the working tree.\nUse '--' to separate paths from revisions, like this:\n'git <command> [<revision>...] -- [<file>...]'\n"
 #  from Dangerfile:[13]
 #  -------------------------------------------
 #  
 >  active_files = (git.modified_files + git.added_files).uniq
 #  
 #  -------------------------------------------

	from repo/vendor/bundle/ruby/3.2.0/gems/git-1.19.1/lib/git/lib.rb:492:in `diff_full'
	from repo/vendor/bundle/ruby/3.2.0/gems/git-1.19.1/lib/git/diff.rb:104:in `cache_full'
	from repo/vendor/bundle/ruby/3.2.0/gems/git-1.19.1/lib/git/diff.rb:109:in `process_full'
	from repo/vendor/bundle/ruby/3.2.0/gems/git-1.19.1/lib/git/diff.rb:68:in `each'
	from repo/vendor/bundle/ruby/3.2.0/gems/danger-9.5.0/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb:75:in `select'
	from repo/vendor/bundle/ruby/3.2.0/gems/danger-9.5.0/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb:75:in `modified_files'
	from Dangerfile:n:in `eval_file'
```