### PR TITLE
Add gems ejected from future stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 <!-- Your comment below here -->
 * Update ruby version in Dockerfile to 3.2 - [@okatatuki](https://github.com/okatatuki) [#1472](https://github.com/danger/danger/pull/1472) [#1473](https://github.com/danger/danger/pull/1473)
 * Fix: git diff called by methods like `git.modified_files` may fail with error ``[!] Invalid `Dangerfile` file: git ... 'diff' '-p' 'true' '{head}'  2>&1`` - [@nagataaaas](https://github.com/nagataaaas) [#1498](https://github.com/danger/danger/pull/1498)
+* Add gems ejected from future stdlib - [@manicmaniac](https://github.com/manicmaniac) [#1499](https://github.com/danger/danger/pull/1499)
 <!-- Your comment above here -->
 
 ## 9.5.0

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
+  spec.add_runtime_dependency "base64", "~> 0.2"
   spec.add_runtime_dependency "claide", "~> 1.0"
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
   spec.add_runtime_dependency "colored2", "~> 3.1"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "octokit", ">= 4.0"
+  spec.add_runtime_dependency "pstore", "~> 0.1"
   spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
 end


### PR DESCRIPTION
Close #1496

I added `base64` and `pstore` gem to runtime dependencies because they will be removed from future Ruby stdlib.

## Result

### Before this PR

```
$ OCTOKIT_SILENT=1 bundle exec danger --version
/Users/manicmaniac/Projects/danger/danger/lib/danger/commands/local.rb:1: warning: pstore was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add pstore to your Gemfile or gemspec to silence this warning.
/Users/manicmaniac/Projects/danger/danger/lib/danger/request_sources/vsts.rb:2: warning: base64 was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
9.5.0
```

### After this PR

```
$ OCTOKIT_SILENT=1 bundle exec danger --version
9.5.0
```

## Known issues

According to https://github.com/octokit/octokit.rb/issues/1701#issuecomment-2210469054, you need to set `OCTOKIT_SILENT` environment variable or it prints some other warnings.

```
$ bundle exec danger --version
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
To use multipart middleware with Faraday v2.0+, install `faraday-multipart` gem; note: this is used by the ManageGHES client for uploading licenses
9.5.0
```