### PR TITLE
Make danger work with pull_request_target in GH Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
+* Make danger work with pull_request_target in GH Actions - [@tomhughes](https://github.com/tomhughes) [#1501](https://github.com/danger/danger/pull/1501)
 <!-- Your comment above here -->
 
 ## 9.5.1

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -115,18 +115,20 @@ module Danger
 
       def setup_danger_branches
         # we can use a github specific feature here:
+        base_repo = self.pr_json["base"]["repo"]["clone_url"]
         base_branch = self.pr_json["base"]["ref"]
         base_commit = self.pr_json["base"]["sha"]
+        head_repo = self.pr_json["head"]["repo"]["clone_url"]
         head_branch = self.pr_json["head"]["ref"]
         head_commit = self.pr_json["head"]["sha"]
 
         # Next, we want to ensure that we have a version of the current branch at a known location
-        scm.ensure_commitish_exists_on_branch! base_branch, base_commit
+        scm.ensure_commitish_exists_on_branch! base_branch, base_commit, remote: base_repo
         self.scm.exec "branch #{EnvironmentManager.danger_base_branch} #{base_commit}"
 
         # OK, so we want to ensure that we have a known head branch, this will always represent
         # the head of the PR ( e.g. the most recent commit that will be merged. )
-        scm.ensure_commitish_exists_on_branch! head_branch, head_commit
+        scm.ensure_commitish_exists_on_branch! head_branch, head_commit, remote: head_repo
         self.scm.exec "branch #{EnvironmentManager.danger_head_branch} #{head_commit}"
       end
 


### PR DESCRIPTION
When trying to fetch base and head for a GitHub pull request make sure to do so from the correct remote instead of assuming that they are both present in the origin remote.

To explain more, when we are running as `pull_request_target` the checked out repository is the target repository and while it contains the proposed change it is as `refs/pull/N/head` and not as `refs/heads/BRANCH` so trying to fetch using the branch name will not work.

This change ensures that we fetch both base and head from the remote that matches the ref as given in the pull request data returned from the API.

I haven't checked but I think the opposite problem may be possible for `pull_request` if the source and target somehow had base branches that diverged as it will have the source repository as `origin` but will be looking for a target repository reference. That is probably a lot less likely but this ensures that we fetch both from the correct place anyway.

This should fix #1103.