### PR TITLE
Support terminal-table 4.x versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 <!-- Your comment below here -->
 
-* Allow teriminal-table versions through 4.x - [@murilooon](https://github.com/murilooon)
+* Allow terminal-table versions through 4.x - [@murilooon](https://github.com/murilooon)
 
 <!-- Your comment above here -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ## master
 
 <!-- Your comment below here -->
+
+* Allow teriminal-table versions through 4.x - [@murilooon](https://github.com/murilooon)
+
 <!-- Your comment above here -->
 
 ## 9.5.1

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "octokit", ">= 4.0"
   spec.add_runtime_dependency "pstore", "~> 0.1"
-  spec.add_runtime_dependency "terminal-table", ">= 1", "< 4"
+  spec.add_runtime_dependency "terminal-table", ">= 1", "< 5"
 end


### PR DESCRIPTION
 A v4.0.0 [terminal-table](https://github.com/tj/terminal-table/releases/tag/v4.0.0) was released on Jan 27th, which can't be updated since `danger` blocks it. This PR aims to relax the `terminal-table` rule set 4 years ago by this [PR](https://github.com/danger/danger/pull/1292). I'm actually trying to bump the `unicode-display_width` gem, but only v4.x supports it, so `danger` is the current blocker.