### PR TITLE
Support v4 of `colored2` gem to make danger compatible with --enable-frozen-string-literal RUBYOPT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
+* Bump colored2 to v4 to make danger work with --enable-frozen-string-literal RUBYOPT - [@eiskrenkov](https://github.com/eiskrenkov) [#1513](https://github.com/danger/danger/pull/1513)
 * Support ruby-git 2.x - [@manicmaniac](https://github.com/manicmaniac) [#1511](https://github.com/danger/danger/pull/1511)
 * Allow terminal-table versions through 4.x - [@murilooon](https://github.com/murilooon)
 <!-- Your comment above here -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
-* Bump colored2 to v4 to make danger work with --enable-frozen-string-literal RUBYOPT - [@eiskrenkov](https://github.com/eiskrenkov) [#1513](https://github.com/danger/danger/pull/1513)
+* Support v4 of colored2 gem to make danger work with --enable-frozen-string-literal RUBYOPT of newer Ruby versions - [@eiskrenkov](https://github.com/eiskrenkov) [#1513](https://github.com/danger/danger/pull/1513)
 * Support ruby-git 2.x - [@manicmaniac](https://github.com/manicmaniac) [#1511](https://github.com/danger/danger/pull/1511)
 * Allow terminal-table versions through 4.x - [@murilooon](https://github.com/murilooon)
 <!-- Your comment above here -->

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "base64", "~> 0.2"
   spec.add_runtime_dependency "claide", "~> 1.0"
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
-  spec.add_runtime_dependency "colored2", "~> 4.0"
+  spec.add_runtime_dependency "colored2", ">= 3.1", "< 5"
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "faraday", ">= 0.9.0", "< 3.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"

--- a/danger.gemspec
+++ b/danger.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "base64", "~> 0.2"
   spec.add_runtime_dependency "claide", "~> 1.0"
   spec.add_runtime_dependency "claide-plugins", ">= 0.9.2"
-  spec.add_runtime_dependency "colored2", "~> 3.1"
+  spec.add_runtime_dependency "colored2", "~> 4.0"
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "faraday", ">= 0.9.0", "< 3.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"


### PR DESCRIPTION
Hey all, first of all thank you for an amazing gem, love it!

In my team we just tried running Rails app using `RUBYOPT=--enable-frozen-string-literal` and got a green CI, except danger failed at the very end:

```
Results:
bundler: failed to load command: danger (/usr/local/bundle/bin/danger)
/usr/local/bundle/gems/colored2-3.1.2/lib/colored2/ascii_decorator.rb:67:in 'Colored2::AsciiDecorator#decorate': can't modify frozen String: "" (FrozenError)
	from /usr/local/bundle/gems/colored2-3.1.2/lib/colored2.rb:26:in 'String#surround_with_color'
	from /usr/local/bundle/gems/colored2-3.1.2/lib/colored2.rb:51:in 'block (3 levels) in String#included'
	from /usr/local/bundle/gems/danger-9.4.3/lib/danger/danger_core/dangerfile.rb:223:in 'block (2 levels) in Danger::Dangerfile#print_results'
	from /usr/local/bundle/gems/danger-9.4.3/lib/danger/danger_core/dangerfile.rb:219:in 'Array#each'
	from /usr/local/bundle/gems/danger-9.4.3/lib/danger/danger_core/dangerfile.rb:219:in 'block in Danger::Dangerfile#print_results'
	from /usr/local/bundle/gems/cork-0.3.0/lib/cork/board.rb:184:in 'Cork::Board#section'
	from /usr/local/bundle/gems/danger-9.4.3/lib/danger/danger_core/dangerfile.rb:218:in 'Danger::Dangerfile#print_results'
	from /usr/local/bundle/gems/danger-9.4.3/lib/danger/danger_core/dangerfile.rb:295:in 'Danger::Dangerfile#run'
	from /usr/local/bundle/gems/danger-9.4.3/lib/danger/danger_core/executor.rb:28:in 'Danger::Executor#run'
	from /usr/local/bundle/gems/danger-9.4.3/lib/danger/commands/runner.rb:73:in 'Danger::Runner#run'
	from /usr/local/bundle/gems/claide-1.1.0/lib/claide/command.rb:334:in 'CLAide::Command.run'
	from /usr/local/bundle/gems/danger-9.4.3/bin/danger:5:in '<top (required)>'
	from /usr/local/bundle/bin/danger:25:in 'Kernel#load'
	from /usr/local/bundle/bin/danger:25:in '<top (required)>'
	from /usr/local/lib/ruby/3.4.0/bundler/cli/exec.rb:59:in 'Kernel.load'
	from /usr/local/lib/ruby/3.4.0/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
	from /usr/local/lib/ruby/3.4.0/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
	from /usr/local/lib/ruby/3.4.0/bundler/cli.rb:452:in 'Bundler::CLI#exec'
	from /usr/local/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
	from /usr/local/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
	from /usr/local/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
	from /usr/local/lib/ruby/3.4.0/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
	from /usr/local/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
	from /usr/local/lib/ruby/3.4.0/bundler/cli.rb:29:in 'Bundler::CLI.start'
	from /usr/local/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/exe/bundle:28:in 'block in <top (required)>'
	from /usr/local/lib/ruby/3.4.0/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
	from /usr/local/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/exe/bundle:20:in '<top (required)>'
	from /usr/local/bin/bundle:25:in 'Kernel#load'
	from /usr/local/bin/bundle:25:in '<main>'
```

This was "fixed" by adding `# frozen_string_literal: false` in `colored2` [here](https://github.com/kigster/colored2/pull/7/files#diff-1ecdb5867180adf396d5b7d1c587aa516d27a323703311c93f047db238ee9c85R1), in version 4.0