### PR TITLE
Add GitLab Merge Request support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
+* Add GitLab Merge Request support with a new `mr` command - [@jtslear](https://github.com/jtslear) [#1516](https://github.com/danger/danger/pull/1516)
 * Support v4 of colored2 gem to make danger work with --enable-frozen-string-literal RUBYOPT of newer Ruby versions - [@eiskrenkov](https://github.com/eiskrenkov) [#1513](https://github.com/danger/danger/pull/1513)
 * Support ruby-git 2.x - [@manicmaniac](https://github.com/manicmaniac) [#1511](https://github.com/danger/danger/pull/1511)
 * Allow terminal-table versions through 4.x - [@murilooon](https://github.com/murilooon)

--- a/lib/danger/ci_source/support/find_repo_info_from_url.rb
+++ b/lib/danger/ci_source/support/find_repo_info_from_url.rb
@@ -31,7 +31,9 @@ module Danger
       else
         matched = url.match(REGEXP)
         if matched
-          RepoInfo.new(matched[:slug], matched[:id])
+          # Clean up the slug to remove any trailing dashes or slashes that might be part of the GitLab URL format
+          clean_slug = matched[:slug].gsub(%r{[-/]+$}, "")
+          RepoInfo.new(clean_slug, matched[:id])
         end
       end
     end

--- a/lib/danger/commands/mr.rb
+++ b/lib/danger/commands/mr.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "danger/commands/local_helpers/http_cache"
+require "danger/commands/local_helpers/pry_setup"
+require "faraday/http_cache"
+require "fileutils"
+require "gitlab"
+require "tmpdir"
+
+module Danger
+  class MR < Runner
+    self.summary = "Run the Dangerfile locally against GitLab Merge Requests. Does not post to the MR. Usage: danger mr <URL>"
+    self.command = "mr"
+
+    def self.options
+      [
+        ["--clear-http-cache", "Clear the local http cache before running Danger locally."],
+        ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."],
+        ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"]
+      ]
+    end
+
+    def initialize(argv)
+      show_help = true if argv.arguments == ["-h"]
+
+      @mr_url = argv.shift_argument
+      @clear_http_cache = argv.flag?("clear-http-cache", false)
+      dangerfile = argv.option("dangerfile", "Dangerfile")
+
+      # Currently CLAide doesn't support short option like -h https://github.com/CocoaPods/CLAide/pull/60
+      # when user pass in -h, mimic the behavior of passing in --help.
+      argv = CLAide::ARGV.new ["--help"] if show_help
+
+      super
+
+      @dangerfile_path = dangerfile if File.exist?(dangerfile)
+
+      if argv.flag?("pry", false)
+        @dangerfile_path = PrySetup.new(cork).setup_pry(@dangerfile_path, MR.command)
+      end
+    end
+
+    def validate!
+      super
+      unless @dangerfile_path
+        help! "Could not find a Dangerfile."
+      end
+      unless @mr_url
+        help! "Could not find a merge-request. Usage: danger mr <URL>"
+      end
+    end
+
+    def run
+      ENV["DANGER_USE_LOCAL_GIT"] = "YES"
+      ENV["LOCAL_GIT_MR_URL"] = @mr_url if @mr_url
+
+      configure_gitlab(ENV["DANGER_TMPDIR"] || Dir.tmpdir)
+
+      env = EnvironmentManager.new(ENV, cork)
+      dm = Dangerfile.new(env, cork)
+
+      LocalSetup.new(dm, cork).setup(verbose: verbose) do
+        dm.run(
+          Danger::EnvironmentManager.danger_base_branch,
+          Danger::EnvironmentManager.danger_head_branch,
+          @dangerfile_path,
+          nil,
+          nil,
+          nil,
+          false
+        )
+      end
+    end
+
+    private
+
+    def configure_gitlab(cache_dir)
+      # setup caching for GitLab calls to avoid hitting the API rate limit too quickly
+      cache_file = File.join(cache_dir, "danger_local_gitlab_cache")
+      HTTPCache.new(cache_file, clear_cache: @clear_http_cache)
+
+      # Configure GitLab client
+      Gitlab.configure do |config|
+        config.endpoint = ENV["DANGER_GITLAB_API_BASE_URL"] || ENV.fetch("CI_API_V4_URL", "https://gitlab.com/api/v4")
+        config.private_token = ENV["DANGER_GITLAB_API_TOKEN"]
+      end
+    end
+  end
+end

--- a/lib/danger/commands/runner.rb
+++ b/lib/danger/commands/runner.rb
@@ -6,6 +6,7 @@ module Danger
     require "danger/commands/staging"
     require "danger/commands/systems"
     require "danger/commands/pr"
+    require "danger/commands/mr"
 
     # manually set claide plugins as a subcommand
     require "claide_plugin"

--- a/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
+++ b/spec/lib/danger/ci_sources/support/find_repo_info_from_url_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe Danger::FindRepoInfoFromURL do
         id: "42"
       )
     end
+
+    it "works with the /-/ pattern" do
+      result = described_class.new("https://gitlab.com/gitlab-org/gitlab-ce/-/merge_requests/42").call
+
+      expect(result).to have_attributes(
+        slug: "gitlab-org/gitlab-ce",
+        id: "42"
+      )
+    end
   end
 
   context "Bitbucket" do

--- a/spec/lib/danger/commands/mr_spec.rb
+++ b/spec/lib/danger/commands/mr_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "danger/commands/mr"
+require "open3"
+
+RSpec.describe Danger::MR do
+  context "prints help" do
+    it "danger mr --help flag prints help" do
+      stdout, = Open3.capture3("danger mr -h")
+      expect(stdout).to include "Usage"
+    end
+  end
+
+  describe ".summary" do
+    it "returns the summary for MR command" do
+      result = described_class.summary
+
+      expect(result).to eq "Run the Dangerfile locally against GitLab Merge Requests. Does not post to the MR. Usage: danger mr <URL>"
+    end
+  end
+
+  context "takes the first argument as MR URL" do
+    it "works" do
+      argv = CLAide::ARGV.new(["https://gitlab.com/gitlab-org/gitlab-ce/-/merge_requests/42"])
+
+      result = described_class.new(argv)
+
+      expect(result).to have_instance_variables(
+        "@mr_url" => "https://gitlab.com/gitlab-org/gitlab-ce/-/merge_requests/42"
+      )
+    end
+  end
+
+  describe ".options" do
+    it "contains extra options for MR command" do
+      result = described_class.options
+
+      expect(result).to include ["--clear-http-cache", "Clear the local http cache before running Danger locally."]
+      expect(result).to include ["--pry", "Drop into a Pry shell after evaluating the Dangerfile."]
+      expect(result).to include ["--dangerfile=<path/to/dangerfile>", "The location of your Dangerfile"]
+    end
+
+    it "dangerfile can be set" do
+      argv = CLAide::ARGV.new(["--dangerfile=/Users/Orta/Dangerfile"])
+      allow(File).to receive(:exist?) { true }
+
+      result = described_class.new(argv)
+
+      expect(result).to have_instance_variables(
+        "@dangerfile_path" => "/Users/Orta/Dangerfile"
+      )
+    end
+  end
+
+  context "default options" do
+    it "mr url is nil and clear_http_cache defaults to false" do
+      argv = CLAide::ARGV.new([])
+
+      result = described_class.new(argv)
+
+      expect(result).to have_instance_variables(
+        "@mr_url" => nil,
+        "@clear_http_cache" => false
+      )
+    end
+  end
+
+  context "#run" do
+    let(:env_double) { instance_double("Danger::EnvironmentManager") }
+    let(:request_source_double) { instance_double("Danger::RequestSources::RequestSource") }
+
+    it "does not post to the mr" do
+      allow(Danger::EnvironmentManager).to receive(:new).and_return(env_double)
+      allow(env_double).to receive(:request_source).and_return(request_source_double)
+      allow(request_source_double).to receive(:update_pull_request!)
+
+      argv = CLAide::ARGV.new(["https://gitlab.com/gitlab-org/gitlab-ce/-/merge_requests/42"])
+
+      result = described_class.new(argv)
+      expect(request_source_double).not_to have_received(:update_pull_request!)
+    end
+  end
+end


### PR DESCRIPTION
- Add GitLab Merge Request support with a new 'mr' command
- Improve URL parsing for GitLab URLs with the '-/' pattern, example:
  - https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/42 versus
  - https://gitlab.com/gitlab-org/gitlab-foss/merge_requests/42
- Add tests for the new functionality
- I opted to not rewrite some functionality for language due to the reuse of various parts of bitbucket using similar method names

I did have goofy issues with testing and the client, so I have what I thought would be unnecessary changes, I'm looking for feedback on this, I wasn't entirely sure how to approach those.  And later rubocop finally came around and told me I made things too complex.  Which was true, so I did a hint of refactoring, but only relied on rspec to tell me things were fine.