### PR TITLE
Resolve FIXME comments for `Metrics/BlockLength` in .rubocop.yml #trivial

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -122,11 +122,9 @@ Style/BlockComments:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-# FIXME: 25
 Metrics/BlockLength:
-  Max: 345
   Exclude:
-    - "**/*_spec.rb"
+    - "spec/**/*"
 
 Naming/FileName:
   Enabled: false

--- a/lib/danger/request_sources/github/github.rb
+++ b/lib/danger/request_sources/github/github.rb
@@ -329,7 +329,7 @@ module Danger
         is_markdown_content = kind == :markdown
         emoji = { warning: "warning", error: "no_entry_sign", message: "book" }[kind]
 
-        messages.reject do |m|
+        messages.reject do |m| # rubocop:todo Metrics/BlockLength
           next false unless m.file && m.line
 
           position = find_position_in_diff diff_lines, m, kind

--- a/lib/danger/request_sources/gitlab.rb
+++ b/lib/danger/request_sources/gitlab.rb
@@ -395,7 +395,7 @@ module Danger
         is_markdown_content = kind == :markdown
         emoji = { warning: "warning", error: "no_entry_sign", message: "book" }[kind]
 
-        messages.reject do |m|
+        messages.reject do |m| # rubocop:todo Metrics/BlockLength
           next false unless m.file && m.line
           # Reject if it's out of range and in dismiss mode
           next true if dismiss_out_of_range_messages_for(kind) && is_out_of_range(mr_changes.changes, m)

--- a/lib/danger/request_sources/vsts.rb
+++ b/lib/danger/request_sources/vsts.rb
@@ -185,7 +185,7 @@ module Danger
         is_markdown_content = kind == :markdown
         emoji = { warning: "warning", error: "no_entry_sign", message: "book" }[kind]
 
-        messages.reject do |m|
+        messages.reject do |m| # rubocop:todo Metrics/BlockLength
           next false unless m.file && m.line
 
           # Once we know we're gonna submit it, we format it


### PR DESCRIPTION
Addressed FIXME comments in .rubocop.yml .