### PR TITLE
Remove upper bound constraint on the git gem

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cork", "~> 0.1"
   spec.add_runtime_dependency "faraday", ">= 0.9.0", "< 3.0"
   spec.add_runtime_dependency "faraday-http-cache", "~> 2.0"
-  spec.add_runtime_dependency "git", ">= 1.13", "< 3.0"
+  spec.add_runtime_dependency "git", ">= 1.13"
   spec.add_runtime_dependency "kramdown", ">= 2.5.1", "< 3.0"
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_runtime_dependency "octokit", ">= 4.0"


### PR DESCRIPTION
This removes the upper bound constraint for using the git gem. Right now git is on 4.0.5 https://github.com/ruby-git/ruby-git/releases which makes danger 2 major versions behind. It leaves us unable to update git-ruby.  

Most of the breaking changes in the git gem are around which version of ruby the gem supports.