### PR TITLE
Revert "Do not force verbose in `danger local` and `danger pr`"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 * Add `--no-gpg-sign` flag to test specs to prevent GPG signing prompts - [@numbata](https://github.com/numbata) [#1535](https://github.com/danger/danger/pull/1535)
 * Remove upper bound constraint on the git gem - [@andrewmarkle](https://github.com/andrewmarkle) [#1526](https://github.com/danger/danger/pull/1526)
 * Add "Add GitLab Merge Request support" again with fix - [@manicmaniac](https://github.com/manicmaniac) [#1522](https://github.com/danger/danger/pull/1522)
-* **Breaking** - Prevent danger pr and danger local from enforcing verbose flags - [@manicmaniac](https://github.com/manicmaniac) [#1424](https://github.com/danger/danger/pull/1424)
 <!-- Your comment above here -->
 
 ## 9.5.3

--- a/lib/danger/commands/local_helpers/local_setup.rb
+++ b/lib/danger/commands/local_helpers/local_setup.rb
@@ -30,7 +30,10 @@ module Danger
         cork.puts "Running your Dangerfile against this PR - https://#{gh.host}/#{source.repo_slug}/pull/#{source.pull_request_id}"
       end
 
-      dm.verbose = verbose
+      unless verbose
+        cork.puts "Turning on --verbose"
+        dm.verbose = true
+      end
 
       cork.puts
 

--- a/spec/lib/danger/commands/local_helpers/local_setup_spec.rb
+++ b/spec/lib/danger/commands/local_helpers/local_setup_spec.rb
@@ -30,18 +30,7 @@ RSpec.describe Danger::LocalSetup do
       expect(ui.string).not_to include("evaluated")
     end
 
-    it "turns on verbose if arguments was passed" do
-      github = double(:host => "", :support_tokenless_auth= => nil, :fetch_details => nil)
-      env = FakeEnv.new(ci_source, github)
-      dangerfile = FakeDangerfile.new(env, false)
-      ui = testing_ui
-      subject = described_class.new(dangerfile, ui)
-
-      subject.setup(verbose: true) {}
-      expect(dangerfile.verbose).to be(true)
-    end
-
-    it "turns off verbose if arguments wasn't passed" do
+    it "turns on verbose if arguments wasn't passed" do
       github = double(:host => "", :support_tokenless_auth= => nil, :fetch_details => nil)
       env = FakeEnv.new(ci_source, github)
       dangerfile = FakeDangerfile.new(env, false)
@@ -49,7 +38,7 @@ RSpec.describe Danger::LocalSetup do
       subject = described_class.new(dangerfile, ui)
 
       subject.setup(verbose: false) {}
-      expect(dangerfile.verbose).to be(false)
+      expect(ui.string).to include("Turning on --verbose")
     end
 
     it "does not evaluate Dangerfile if local repo wasn't found on github" do


### PR DESCRIPTION
///////////////////⚡///////////////////

# 🚫 AWESOME A PR!

- You can just delete all of this and start your PR text anytime -

Hello there, just a quick pre-warning of some of the Danger rules we run on Danger PRs.

The big one is we request that every code change to Danger include a CHANGELOG entry, 
this is so that:

1. People know what changes are between versions
2. Orta doesn't get all the credit for other people's work

Danger will look for a modification to the `CHANGELOG.md` when there are changes including
`lib/*` - if you're fixing unreleased code, or doing a simple typo change, you can
include `#trivial` in the title or the body of the PR and this is skipped.

We also request that you fill in the body of your PR, a title should be tweet length, but
ideally you can explain the PRs reasoning in the body. We look that it's longer than 5 chars.

Other than that, a lot of the other Danger rules are trickier to trigger so we can address
them as they come up!

❤ THANKS FOR HELPING OUT :D 

///////////////////⚡///////////////////