### PR TITLE
#1546 Reduce Docker Image Size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+spec
+docs
+Guardfile
+appveyor.yml
+build.sh
+CHANGELOG.md
+VISION.md
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Remove upper bound constraint on the git gem - [@andrewmarkle](https://github.com/andrewmarkle) [#1526](https://github.com/danger/danger/pull/1526)
 * Add "Add GitLab Merge Request support" again with fix - [@manicmaniac](https://github.com/manicmaniac) [#1522](https://github.com/danger/danger/pull/1522)
 * **Breaking** - Prevent danger pr and danger local from enforcing verbose flags - [@manicmaniac](https://github.com/manicmaniac) [#1424](https://github.com/danger/danger/pull/1424)
+* Reduce size of docker image by utilizing alpine image - [@beninabox](https://github.com/beninabox) [#1547](https://github.com/danger/danger/pull/1547)
 <!-- Your comment above here -->
 
 ## 9.5.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
-FROM ruby:3.2
+FROM ruby:3.2 AS builder
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /myapp
+COPY . /myapp
+
+ENV BUNDLE_WITHOUT="development:test"
+RUN gem install bundler && bundle install
+
+FROM ruby:3.2-slim
 
 LABEL "com.github.actions.name"="Danger"
 LABEL "com.github.actions.description"="Runs danger in a docker container such as GitHub Actions"
@@ -9,17 +21,17 @@ LABEL "homepage"="https://github.com/danger/danger"
 LABEL "maintainer"="Rishabh Tayal <rtayal11@gmail.com>"
 LABEL "maintainer"="Orta Therox"
 
-RUN apt-get update -qq && apt-get install -y build-essential p7zip unzip
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends git p7zip-full unzip && \
+    rm -rf /var/lib/apt/lists/*
 
 # See https://github.com/actions/runner/issues/2033
 RUN git config --system --add safe.directory /github/workspace
 
-RUN mkdir /myapp
 WORKDIR /myapp
-COPY . /myapp
-
-RUN gem install bundler
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+COPY --from=builder /myapp /myapp
 
 ENV BUNDLE_GEMFILE=/myapp/Gemfile
-RUN bundle install
+ENV BUNDLE_WITHOUT="development:test"
 ENTRYPOINT ["bundle", "exec", "danger"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM ruby:3.2 AS builder
+FROM ruby:3.2-alpine AS builder
 
-RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends build-essential && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache build-base
 
 WORKDIR /myapp
 COPY . /myapp
@@ -10,7 +8,7 @@ COPY . /myapp
 ENV BUNDLE_WITHOUT="development:test"
 RUN gem install bundler && bundle install
 
-FROM ruby:3.2-slim
+FROM ruby:3.2-alpine
 
 LABEL "com.github.actions.name"="Danger"
 LABEL "com.github.actions.description"="Runs danger in a docker container such as GitHub Actions"
@@ -21,9 +19,7 @@ LABEL "homepage"="https://github.com/danger/danger"
 LABEL "maintainer"="Rishabh Tayal <rtayal11@gmail.com>"
 LABEL "maintainer"="Orta Therox"
 
-RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends git p7zip-full unzip && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache git p7zip
 
 # See https://github.com/actions/runner/issues/2033
 RUN git config --system --add safe.directory /github/workspace


### PR DESCRIPTION
This change improves the size of the Docker image by utilising multi stage builds and the alpine image so that we can reduce the attack surface area and the overall size of the image. 