### PR TITLE
Add git 5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## master
 
 <!-- Your comment below here -->
+* Support git gem 5.0 - [#1549](https://github.com/danger/danger/issues/1549)
 <!-- Your comment above here -->
 
 ## 9.6.0

--- a/lib/danger/scm_source/git_repo.rb
+++ b/lib/danger/scm_source/git_repo.rb
@@ -192,12 +192,22 @@ module Danger
   end
 end
 
-module Git
-  class Base
-    # Use git-merge-base https://git-scm.com/docs/git-merge-base to
-    # find as good common ancestors as possible for a merge
-    def merge_base(commit1, commit2, *other_commits)
-      Open3.popen2("git", "merge-base", commit1, commit2, *other_commits) { |_stdin, stdout, _wait_thr| stdout.read.rstrip }
+module Danger
+  class GitRepo
+    module MergeBase
+      # Use git-merge-base https://git-scm.com/docs/git-merge-base to
+      # find as good common ancestors as possible for a merge
+      def merge_base(commit1, commit2, *other_commits)
+        Open3.popen2("git", "merge-base", commit1, commit2, *other_commits) { |_stdin, stdout, _wait_thr| stdout.read.rstrip }
+      end
     end
   end
+end
+
+# Git::Base became a compatibility module included in Git::Repository in git 5.0.
+# Prepend Danger's extension to the concrete repository class in either version.
+if Git::Base.kind_of?(Class)
+  Git::Base.prepend(Danger::GitRepo::MergeBase)
+else
+  Git::Repository.prepend(Danger::GitRepo::MergeBase)
 end

--- a/spec/lib/danger/scm_source/git_repo_spec.rb
+++ b/spec/lib/danger/scm_source/git_repo_spec.rb
@@ -31,13 +31,20 @@ RSpec.describe Danger::GitRepo, host: :github do
     it "passes commits count in branch to git log" do
       with_git_repo do |dir|
         @dm = testing_dangerfile
+        repository = Git.open(dir)
+        allow(Git).to receive(:open).with(dir).and_return(repository)
 
-        expect_any_instance_of(Git::Base).to(
-          receive(:log).with(1).and_call_original
-        )
+        expect(repository).to receive(:log).with(1).and_call_original
 
         @dm.env.scm.diff_for_folder(dir)
       end
+    end
+
+    it "extends the repository class used by the installed git gem" do
+      repository_class = Git::Base.kind_of?(Class) ? Git::Base : Git::Repository
+
+      expect(repository_class.ancestors).to include(Danger::GitRepo::MergeBase)
+      expect(repository_class.instance_method(:merge_base).owner).to eq(Danger::GitRepo::MergeBase)
     end
 
     it "assumes the requested folder is the top level git folder by default" do


### PR DESCRIPTION
## Summary

- move Danger's merge-base override into a Danger-owned extension module
- prepend the extension to `Git::Base` on git 4.x and `Git::Repository` on git 5.x
- update repository specs to work when `Git::Base` is a module
- add regression coverage and a changelog entry

Closes #1549.

## Testing

- `bundle exec rspec spec/lib/danger/scm_source/git_repo_spec.rb` with git 4.0.5 (17 examples, 0 failures)
- focused compatibility regression with git 5.0.0
- `bundle exec rubocop --config .rubocop.yml lib/danger/scm_source/git_repo.rb spec/lib/danger/scm_source/git_repo_spec.rb`
- `git diff --check`